### PR TITLE
Remove net461 target

### DIFF
--- a/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
+++ b/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>


### PR DESCRIPTION
> The .NET Standard is a formal specification of .NET APIs that are intended to be available on all .NET implementations. https://docs.microsoft.com/en-us/dotnet/standard/net-standard

To my knowledge there is no reason to target the framework, when standard is targeted.

@danwalmsley This would resolve the build warnings I get on OSX: https://github.com/zkSNACKs/WalletWasabi/issues/452 

And I think this would also resolve the build errors our users get on mono-less Linux/OSX: https://github.com/zkSNACKs/WalletWasabi/issues/418, https://github.com/zkSNACKs/WalletWasabi/issues/461