### PR TITLE
Call OnSelected() everytime the activedockable is changed

### DIFF
--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Avalonia;
@@ -136,6 +137,7 @@ namespace Dock.Model
                 if (value != null)
                 {
                     Factory?.UpdateDockable(value, this);
+                    value.OnSelected();
                 }
                 Factory?.SetFocusedDockable(this, value);
                 SetAndRaise(CanGoBackProperty, ref _canGoBack, _navigateAdapter?.CanGoBack ?? false);

--- a/src/Dock.Model.INPC/Core/DockBase.cs
+++ b/src/Dock.Model.INPC/Core/DockBase.cs
@@ -66,6 +66,7 @@ namespace Dock.Model
                 if (value != null)
                 {
                     _factory?.UpdateDockable(value, this);
+                    value.OnSelected();
                 }
                 _factory?.SetFocusedDockable(this, value);
                 this.RaisePropertyChanged(nameof(CanGoBack));

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -67,6 +67,7 @@ namespace Dock.Model
                 if (value != null)
                 {
                     _factory?.UpdateDockable(value, this);
+                    value.OnSelected();
                 }
                 _factory?.SetFocusedDockable(this, value);
                 this.RaisePropertyChanged(nameof(CanGoBack));

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -217,7 +217,6 @@ namespace Dock.Model
             if (dockable.Owner is IDock dock)
             {
                 dock.ActiveDockable = dockable;
-                dockable.OnSelected();
             }
         }
 


### PR DESCRIPTION
## Current behaviour
OnSelected() get's only called if SetActiveDockable in FactoryBase is called.
This does not happen automaticly

## Expected behaviour
OnSelected() get's called everytime the dockable is selected.

## How?
Using the setter for ActiveDockable to call OnSelected()

I am not sure if I should test if the value actually changed before calling OnSelected(). 