### PR TITLE
Enable nullable reference types

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -12,7 +12,7 @@
     <PackageTags>dock;docking;layout;avalonia</PackageTags>
   </PropertyGroup>
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>

--- a/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+++ b/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+++ b/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+++ b/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishTrimmed>True</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />
@@ -31,12 +31,6 @@
   </ItemGroup>
 
   <Import Project="..\..\build\EmbedXaml.props" />
-
-  <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Metro\Dock.Avalonia.Themes.Metro.csproj" />

--- a/samples/AvaloniaDemo.Experimental/ViewLocator.cs
+++ b/samples/AvaloniaDemo.Experimental/ViewLocator.cs
@@ -12,12 +12,23 @@ namespace AvaloniaDemo
 
         public IControl Build(object data)
         {
-            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            var name = data.GetType()?.FullName?.Replace("ViewModel", "View");
+            if (name == null)
+            {
+                return new TextBlock { Text = "Invalid Data Type" };
+            }
             var type = Type.GetType(name);
-
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type);
+                var instance = Activator.CreateInstance(type);
+                if (instance != null)
+                {
+                    return (Control)instance;
+                }
+                else
+                {
+                    return new TextBlock { Text = "Create Instance Failed: " + type.FullName };
+                }
             }
             else
             {

--- a/samples/AvaloniaDemo.Experimental/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo.Experimental/ViewModels/MainWindowViewModel.cs
@@ -15,36 +15,36 @@ namespace AvaloniaDemo.ViewModels
 {
     public class MainWindowViewModel : StyledElement
     {
-        public static readonly DirectProperty<MainWindowViewModel, DockControl> DockControlProperty =
-            AvaloniaProperty.RegisterDirect<MainWindowViewModel, DockControl>(nameof(DockControl), o => o.DockControl, (o, v) => o.DockControl = v);
+        public static readonly DirectProperty<MainWindowViewModel, DockControl?> DockControlProperty =
+            AvaloniaProperty.RegisterDirect<MainWindowViewModel, DockControl?>(nameof(DockControl), o => o.DockControl, (o, v) => o.DockControl = v);
 
-        public static readonly DirectProperty<MainWindowViewModel, IFactory> FactoryProperty =
-            AvaloniaProperty.RegisterDirect<MainWindowViewModel, IFactory>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
+        public static readonly DirectProperty<MainWindowViewModel, IFactory?> FactoryProperty =
+            AvaloniaProperty.RegisterDirect<MainWindowViewModel, IFactory?>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
 
-        public static readonly DirectProperty<MainWindowViewModel, IDockSerializer> SerializerProperty =
-            AvaloniaProperty.RegisterDirect<MainWindowViewModel, IDockSerializer>(nameof(Serializer), o => o.Serializer, (o, v) => o.Serializer = v);
+        public static readonly DirectProperty<MainWindowViewModel, IDockSerializer?> SerializerProperty =
+            AvaloniaProperty.RegisterDirect<MainWindowViewModel, IDockSerializer?>(nameof(Serializer), o => o.Serializer, (o, v) => o.Serializer = v);
 
         public static readonly DirectProperty<MainWindowViewModel, string> PathProperty =
             AvaloniaProperty.RegisterDirect<MainWindowViewModel, string>(nameof(Path), o => o.Path, (o, v) => o.Path = v);
 
-        private DockControl _dockControl;
-        private IFactory _factory;
-        private IDockSerializer _serializer;
-        private string _path;
+        private DockControl? _dockControl;
+        private IFactory? _factory;
+        private IDockSerializer? _serializer;
+        private string _path = string.Empty;
 
-        public DockControl DockControl
+        public DockControl? DockControl
         {
             get => _dockControl;
             set => SetAndRaise(DockControlProperty, ref _dockControl, value);
         }
 
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => SetAndRaise(FactoryProperty, ref _factory, value);
         }
 
-        public IDockSerializer Serializer
+        public IDockSerializer? Serializer
         {
             get => _serializer;
             set => SetAndRaise(SerializerProperty, ref _serializer, value);
@@ -72,7 +72,7 @@ namespace AvaloniaDemo.ViewModels
 
                 if (File.Exists(Path))
                 {
-                    var layout = Serializer.Load<RootDock>(Path);
+                    var layout = Serializer?.Load<RootDock>(Path);
                     if (layout != null)
                     {
                         DockControl.Layout = layout;
@@ -93,7 +93,7 @@ namespace AvaloniaDemo.ViewModels
                 if (DockControl.Layout != null)
                 {
                     DockControl.Layout.Close();
-                    Serializer.Save(Path, DockControl.Layout);
+                    Serializer?.Save(Path, DockControl.Layout);
                 }
 
                 DockControl = null;
@@ -109,8 +109,12 @@ namespace AvaloniaDemo.ViewModels
                     root.Close();
                 }
                 Factory = new DemoFactory(new DemoData());
-                DockControl.Layout = Factory?.CreateLayout();
-                Factory?.InitLayout(DockControl.Layout);
+                var layout = Factory?.CreateLayout();
+                if (layout != null)
+                {
+                    DockControl.Layout = layout;
+                    Factory?.InitLayout(DockControl.Layout);
+                }
             }
         }
 
@@ -124,13 +128,16 @@ namespace AvaloniaDemo.ViewModels
                 var result = await dlg.ShowAsync(GetWindow());
                 if (result != null)
                 {
-                    IDock layout = Serializer?.Load<RootDock>(result.FirstOrDefault());
-                    if (DockControl.Layout is IDock root)
+                    IDock? layout = Serializer?.Load<RootDock>(result.FirstOrDefault());
+                    if (layout != null)
                     {
-                        root.Close();
+                        if (DockControl.Layout is IDock root)
+                        {
+                            root.Close();
+                        }
+                        DockControl.Layout = layout;
+                        Factory?.InitLayout(DockControl.Layout);
                     }
-                    DockControl.Layout = layout;
-                    Factory?.InitLayout(DockControl.Layout);
                 }
             }
         }
@@ -147,12 +154,12 @@ namespace AvaloniaDemo.ViewModels
                 var result = await dlg.ShowAsync(GetWindow());
                 if (result != null)
                 {
-                    Serializer.Save(result, DockControl.Layout);
+                    Serializer?.Save(result, DockControl.Layout);
                 }
             }
         }
 
-        private Window GetWindow()
+        private Window? GetWindow()
         {
             if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {

--- a/samples/AvaloniaDemo.Experimental/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo.Experimental/ViewModels/MainWindowViewModel.cs
@@ -81,7 +81,7 @@ namespace AvaloniaDemo.ViewModels
 
                 if (DockControl.Layout != null)
                 {
-                    Factory.InitLayout(DockControl.Layout);
+                    Factory?.InitLayout(DockControl.Layout);
                 }
             }
         }
@@ -109,8 +109,8 @@ namespace AvaloniaDemo.ViewModels
                     root.Close();
                 }
                 Factory = new DemoFactory(new DemoData());
-                DockControl.Layout = Factory.CreateLayout();
-                Factory.InitLayout(DockControl.Layout);
+                DockControl.Layout = Factory?.CreateLayout();
+                Factory?.InitLayout(DockControl.Layout);
             }
         }
 
@@ -130,7 +130,7 @@ namespace AvaloniaDemo.ViewModels
                         root.Close();
                     }
                     DockControl.Layout = layout;
-                    Factory.InitLayout(DockControl.Layout);
+                    Factory?.InitLayout(DockControl.Layout);
                 }
             }
         }

--- a/samples/AvaloniaDemo.Experimental/ViewModels/Views/DashboardViewModel.cs
+++ b/samples/AvaloniaDemo.Experimental/ViewModels/Views/DashboardViewModel.cs
@@ -6,7 +6,7 @@ namespace AvaloniaDemo.ViewModels.Views
 {
     public class DashboardViewModel : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             var dashboardViewModel = new DashboardViewModel();
 

--- a/samples/AvaloniaDemo.Experimental/ViewModels/Views/HomeViewModel.cs
+++ b/samples/AvaloniaDemo.Experimental/ViewModels/Views/HomeViewModel.cs
@@ -6,7 +6,7 @@ namespace AvaloniaDemo.ViewModels.Views
 {
     public class HomeViewModel : RootDock
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             var homeViewModel = new HomeViewModel();
 

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishTrimmed>True</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />
@@ -31,12 +31,6 @@
   </ItemGroup>
 
   <Import Project="..\..\build\EmbedXaml.props" />
-
-  <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Metro\Dock.Avalonia.Themes.Metro.csproj" />

--- a/samples/AvaloniaDemo.Perspectives/ViewLocator.cs
+++ b/samples/AvaloniaDemo.Perspectives/ViewLocator.cs
@@ -12,12 +12,23 @@ namespace AvaloniaDemo
 
         public IControl Build(object data)
         {
-            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            var name = data.GetType()?.FullName?.Replace("ViewModel", "View");
+            if (name == null)
+            {
+                return new TextBlock { Text = "Invalid Data Type" };
+            }
             var type = Type.GetType(name);
-
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type);
+                var instance = Activator.CreateInstance(type);
+                if (instance != null)
+                {
+                    return (Control)instance;
+                }
+                else
+                {
+                    return new TextBlock { Text = "Create Instance Failed: " + type.FullName };
+                }
             }
             else
             {

--- a/samples/AvaloniaDemo.Perspectives/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo.Perspectives/ViewModels/MainWindowViewModel.cs
@@ -43,7 +43,7 @@ namespace AvaloniaDemo.ViewModels
                 if (layout != null)
                 {
                     var factory = new DemoFactory();
-                    factory.InitLayout(layout);
+                    factory?.InitLayout(layout);
                 }
             }
         }
@@ -68,8 +68,8 @@ namespace AvaloniaDemo.ViewModels
                     root.Close();
                 }
                 var factory = new DemoFactory();
-                var layout = factory.CreateLayout();
-                factory.InitLayout(layout);
+                var layout = factory?.CreateLayout();
+                factory?.InitLayout(layout);
                 DockControl.Layout = layout;
             }
         }
@@ -95,7 +95,7 @@ namespace AvaloniaDemo.ViewModels
                                 root.Close();
                             }
                             var factory = new DemoFactory();
-                            factory.InitLayout(layout);
+                            factory?.InitLayout(layout);
                             DockControl.Layout = layout;
                         }
                     }
@@ -127,7 +127,7 @@ namespace AvaloniaDemo.ViewModels
                 var clone = (IDock)dock.Clone();
                 if (clone != null)
                 {
-                    owner.Factory.AddDockable(owner, clone);
+                    owner.Factory?.AddDockable(owner, clone);
                     ApplyWindowLayout(clone);
                 }
             }
@@ -140,7 +140,7 @@ namespace AvaloniaDemo.ViewModels
                 if (DockControl.Layout is IDock root)
                 {
                     root.Navigate(dock);
-                    root.Factory.SetFocusedDockable(root, dock);
+                    root.Factory?.SetFocusedDockable(root, dock);
                     root.DefaultDockable = dock;
                 }
             }

--- a/samples/AvaloniaDemo.Perspectives/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo.Perspectives/ViewModels/MainWindowViewModel.cs
@@ -14,10 +14,10 @@ namespace AvaloniaDemo.ViewModels
 {
     public class MainWindowViewModel : StyledElement
     {
-        public static readonly StyledProperty<DockControl> DockControlProperty =
-            AvaloniaProperty.Register<MainWindowViewModel, DockControl>(nameof(DockControl));
+        public static readonly StyledProperty<DockControl?> DockControlProperty =
+            AvaloniaProperty.Register<MainWindowViewModel, DockControl?>(nameof(DockControl));
 
-        public DockControl DockControl
+        public DockControl? DockControl
         {
             get => GetValue(DockControlProperty);
             set => SetValue(DockControlProperty, value);
@@ -69,8 +69,11 @@ namespace AvaloniaDemo.ViewModels
                 }
                 var factory = new DemoFactory();
                 var layout = factory?.CreateLayout();
-                factory?.InitLayout(layout);
-                DockControl.Layout = layout;
+                if (layout != null)
+                {
+                    factory?.InitLayout(layout);
+                    DockControl.Layout = layout;
+                }
             }
         }
 
@@ -124,7 +127,7 @@ namespace AvaloniaDemo.ViewModels
         {
             if (dock != null && dock.Owner is IDock owner)
             {
-                var clone = (IDock)dock.Clone();
+                var clone = (IDock?)dock.Clone();
                 if (clone != null)
                 {
                     owner.Factory?.AddDockable(owner, clone);
@@ -137,7 +140,7 @@ namespace AvaloniaDemo.ViewModels
         {
             if (dock != null)
             {
-                if (DockControl.Layout is IDock root)
+                if (DockControl?.Layout is IDock root)
                 {
                     root.Navigate(dock);
                     root.Factory?.SetFocusedDockable(root, dock);
@@ -156,7 +159,7 @@ namespace AvaloniaDemo.ViewModels
             // TODO:
         }
 
-        private Window GetWindow()
+        private Window? GetWindow()
         {
             if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {

--- a/samples/AvaloniaDemo/App.xaml.cs
+++ b/samples/AvaloniaDemo/App.xaml.cs
@@ -29,7 +29,7 @@ namespace AvaloniaDemo
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var factory = new DemoFactory(new DemoData());
-            IDock layout = null;
+            IDock? layout = null;
 
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {
@@ -48,7 +48,11 @@ namespace AvaloniaDemo
 
                 mainWindowViewModel.Factory = factory;
                 mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
-                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+
+                if (mainWindowViewModel.Layout != null)
+                {
+                    mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+                }
 
                 mainWindow.Closing += (sender, e) =>
                 {
@@ -79,7 +83,11 @@ namespace AvaloniaDemo
 
                 mainWindowViewModel.Factory = factory;
                 mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
-                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+
+                if (mainWindowViewModel.Layout != null)
+                {
+                    mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+                }
 
                 singleViewLifetime.MainView = mainView;
             }

--- a/samples/AvaloniaDemo/App.xaml.cs
+++ b/samples/AvaloniaDemo/App.xaml.cs
@@ -47,8 +47,8 @@ namespace AvaloniaDemo
                 // TODO: Restore main window position, size and state.
 
                 mainWindowViewModel.Factory = factory;
-                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory.CreateLayout();
-                mainWindowViewModel.Factory.InitLayout(mainWindowViewModel.Layout);
+                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
+                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
 
                 mainWindow.Closing += (sender, e) =>
                 {
@@ -78,8 +78,8 @@ namespace AvaloniaDemo
                 };
 
                 mainWindowViewModel.Factory = factory;
-                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory.CreateLayout();
-                mainWindowViewModel.Factory.InitLayout(mainWindowViewModel.Layout);
+                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
+                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
 
                 singleViewLifetime.MainView = mainView;
             }

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PublishTrimmed>True</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />
@@ -28,12 +28,6 @@
   </ItemGroup>
 
   <Import Project="..\..\build\EmbedXaml.props" />
-
-  <PropertyGroup>
-    <PublishTrimmed>False</PublishTrimmed>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Metro\Dock.Avalonia.Themes.Metro.csproj" />

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishTrimmed>True</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
@@ -30,7 +30,7 @@
   <Import Project="..\..\build\EmbedXaml.props" />
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/AvaloniaDemo/ViewLocator.cs
+++ b/samples/AvaloniaDemo/ViewLocator.cs
@@ -12,12 +12,23 @@ namespace AvaloniaDemo
 
         public IControl Build(object data)
         {
-            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            var name = data.GetType()?.FullName?.Replace("ViewModel", "View");
+            if (name == null)
+            {
+                return new TextBlock { Text = "Invalid Data Type" };
+            }
             var type = Type.GetType(name);
-
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type);
+                var instance = Activator.CreateInstance(type);
+                if (instance != null)
+                {
+                    return (Control)instance;
+                }
+                else
+                {
+                    return new TextBlock { Text = "Create Instance Failed: " + type.FullName };
+                }
             }
             else
             {

--- a/samples/AvaloniaDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo/ViewModels/MainWindowViewModel.cs
@@ -12,23 +12,23 @@ namespace AvaloniaDemo.ViewModels
 {
     public class MainWindowViewModel : ReactiveObject
     {
-        private IDockSerializer _serializer;
-        private IFactory _factory;
-        private IDockable _layout;
+        private IDockSerializer? _serializer;
+        private IFactory? _factory;
+        private IDockable? _layout;
 
-        public IDockSerializer Serializer
+        public IDockSerializer? Serializer
         {
             get => _serializer;
             set => this.RaiseAndSetIfChanged(ref _serializer, value);
         }
 
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);
         }
 
-        public IDockable Layout
+        public IDockable? Layout
         {
             get => _layout;
             set => this.RaiseAndSetIfChanged(ref _layout, value);
@@ -41,8 +41,12 @@ namespace AvaloniaDemo.ViewModels
                 root.Close();
             }
             Factory = new DemoFactory(new DemoData());
-            Layout = Factory?.CreateLayout();
-            Factory?.InitLayout(Layout);
+            var layout = Factory?.CreateLayout();
+            if (layout != null)
+            {
+                Layout = layout;
+                Factory?.InitLayout(Layout);
+            }
         }
 
         public async void FileOpen()
@@ -53,13 +57,16 @@ namespace AvaloniaDemo.ViewModels
             var result = await dlg.ShowAsync(GetWindow());
             if (result != null)
             {
-                IDock layout = _serializer?.Load<RootDock>(result.FirstOrDefault());
-                if (Layout is IDock root)
+                IDock? layout = _serializer?.Load<RootDock>(result.FirstOrDefault());
+                if (layout != null)
                 {
-                    root.Close();
+                    if (Layout is IDock root)
+                    {
+                        root.Close();
+                    }
+                    Layout = layout;
+                    Factory?.InitLayout(Layout);
                 }
-                Layout = layout;
-                Factory?.InitLayout(Layout);
             }
         }
 
@@ -73,7 +80,7 @@ namespace AvaloniaDemo.ViewModels
             var result = await dlg.ShowAsync(GetWindow());
             if (result != null)
             {
-                Serializer.Save(result, Layout);
+                Serializer?.Save(result, Layout);
             }
         }
 
@@ -81,7 +88,7 @@ namespace AvaloniaDemo.ViewModels
         {
             if (dock != null && dock.Owner is IDock owner)
             {
-                var clone = (IDock)dock.Clone();
+                var clone = (IDock?)dock.Clone();
                 if (clone != null)
                 {
                     owner.Factory?.AddDockable(owner, clone);
@@ -113,7 +120,7 @@ namespace AvaloniaDemo.ViewModels
             // TODO:
         }
 
-        private Window GetWindow()
+        private Window? GetWindow()
         {
             if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {

--- a/samples/AvaloniaDemo/ViewModels/MainWindowViewModel.cs
+++ b/samples/AvaloniaDemo/ViewModels/MainWindowViewModel.cs
@@ -41,8 +41,8 @@ namespace AvaloniaDemo.ViewModels
                 root.Close();
             }
             Factory = new DemoFactory(new DemoData());
-            Layout = Factory.CreateLayout();
-            Factory.InitLayout(Layout);
+            Layout = Factory?.CreateLayout();
+            Factory?.InitLayout(Layout);
         }
 
         public async void FileOpen()
@@ -59,7 +59,7 @@ namespace AvaloniaDemo.ViewModels
                     root.Close();
                 }
                 Layout = layout;
-                Factory.InitLayout(Layout);
+                Factory?.InitLayout(Layout);
             }
         }
 
@@ -84,7 +84,7 @@ namespace AvaloniaDemo.ViewModels
                 var clone = (IDock)dock.Clone();
                 if (clone != null)
                 {
-                    owner.Factory.AddDockable(owner, clone);
+                    owner.Factory?.AddDockable(owner, clone);
                     ApplyWindowLayout(clone);
                 }
             }
@@ -97,7 +97,7 @@ namespace AvaloniaDemo.ViewModels
                 if (Layout is IDock root)
                 {
                     root.Navigate(dock);
-                    root.Factory.SetFocusedDockable(root, dock);
+                    root.Factory?.SetFocusedDockable(root, dock);
                     root.DefaultDockable = dock;
                 }
             }

--- a/samples/AvaloniaDemo/ViewModels/Views/DashboardViewModel.cs
+++ b/samples/AvaloniaDemo/ViewModels/Views/DashboardViewModel.cs
@@ -6,7 +6,7 @@ namespace AvaloniaDemo.ViewModels.Views
 {
     public class DashboardViewModel : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             var dashboardViewModel = new DashboardViewModel();
 

--- a/samples/AvaloniaDemo/ViewModels/Views/HomeViewModel.cs
+++ b/samples/AvaloniaDemo/ViewModels/Views/HomeViewModel.cs
@@ -6,7 +6,7 @@ namespace AvaloniaDemo.ViewModels.Views
 {
     public class HomeViewModel : RootDock
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             var homeViewModel = new HomeViewModel();
 

--- a/samples/AvaloniaDemo/Views/DragAndDropView.xaml.cs
+++ b/samples/AvaloniaDemo/Views/DragAndDropView.xaml.cs
@@ -8,20 +8,23 @@ namespace AvaloniaDemo.Views
 {
     public class DragAndDrop : UserControl
     {
-        private TextBlock _DropState;
-        private TextBlock _DragState;
-        private Border _DragMe;
+        private TextBlock? _DropState;
+        private TextBlock? _DragState;
+        private Border? _DragMe;
         private int DragCount = 0;
 
         public DragAndDrop()
         {
             this.InitializeComponent();
-            _DragMe.PointerPressed += DoDrag;
+            if (_DragMe != null)
+            {
+                _DragMe.PointerPressed += DoDrag;
+            }
             AddHandler(DragDrop.DropEvent, Drop);
             AddHandler(DragDrop.DragOverEvent, DragOver);
         }
 
-        private async void DoDrag(object sender, Avalonia.Input.PointerPressedEventArgs e)
+        private async void DoDrag(object? sender, Avalonia.Input.PointerPressedEventArgs e)
         {
             DataObject dragData = new DataObject();
             dragData.Set(DataFormats.Text, $"You have dragged text {++DragCount} times");
@@ -29,18 +32,27 @@ namespace AvaloniaDemo.Views
             switch (result)
             {
                 case DragDropEffects.Copy:
-                    _DragState.Text = "The text was copied";
+                    if (_DragState != null)
+                    {
+                        _DragState.Text = "The text was copied";
+                    }
                     break;
                 case DragDropEffects.Link:
-                    _DragState.Text = "The text was linked";
+                    if (_DragState != null)
+                    {
+                        _DragState.Text = "The text was linked";
+                    }
                     break;
                 case DragDropEffects.None:
-                    _DragState.Text = "The drag operation was canceled";
+                    if (_DragState != null)
+                    {
+                        _DragState.Text = "The drag operation was canceled";
+                    }
                     break;
             }
         }
 
-        private void DragOver(object sender, DragEventArgs e)
+        private void DragOver(object? sender, DragEventArgs e)
         {
             e.DragEffects = e.DragEffects & (DragDropEffects.Copy | DragDropEffects.Link);
             if (!e.Data.Contains(DataFormats.Text) && !e.Data.Contains(DataFormats.FileNames))
@@ -49,12 +61,22 @@ namespace AvaloniaDemo.Views
             }
         }
 
-        private void Drop(object sender, DragEventArgs e)
+        private void Drop(object? sender, DragEventArgs e)
         {
             if (e.Data.Contains(DataFormats.Text))
-                _DropState.Text = e.Data.GetText();
+            {
+                if (_DropState != null)
+                {
+                    _DropState.Text = e.Data.GetText();
+                }
+            }
             else if (e.Data.Contains(DataFormats.FileNames))
-                _DropState.Text = string.Join(Environment.NewLine, e.Data.GetFileNames());
+            {
+                if (_DropState != null)
+                {
+                    _DropState.Text = string.Join(Environment.NewLine, e.Data.GetFileNames());
+                }
+            }
         }
 
         private void InitializeComponent()

--- a/samples/Notepad/App.xaml.cs
+++ b/samples/Notepad/App.xaml.cs
@@ -46,8 +46,8 @@ namespace Notepad
                 // TODO: Restore main window position, size and state.
 
                 mainWindowViewModel.Factory = factory;
-                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory.CreateLayout();
-                mainWindowViewModel.Factory.InitLayout(mainWindowViewModel.Layout);
+                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
+                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
 
                 mainWindow.Closing += (sender, e) =>
                 {
@@ -77,8 +77,8 @@ namespace Notepad
                 };
 
                 mainWindowViewModel.Factory = factory;
-                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory.CreateLayout();
-                mainWindowViewModel.Factory.InitLayout(mainWindowViewModel.Layout);
+                mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
+                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
 
                 singleViewLifetime.MainView = mainView;
             }

--- a/samples/Notepad/App.xaml.cs
+++ b/samples/Notepad/App.xaml.cs
@@ -28,7 +28,7 @@ namespace Notepad
 #pragma warning restore CS0618 // Type or member is obsolete
 
             var factory = new NotepadFactory();
-            IDock layout = null;
+            IDock? layout = null;
 
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {
@@ -47,7 +47,11 @@ namespace Notepad
 
                 mainWindowViewModel.Factory = factory;
                 mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
-                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+
+                if (mainWindowViewModel.Layout != null)
+                {
+                    mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+                }
 
                 mainWindow.Closing += (sender, e) =>
                 {
@@ -78,7 +82,11 @@ namespace Notepad
 
                 mainWindowViewModel.Factory = factory;
                 mainWindowViewModel.Layout = layout ?? mainWindowViewModel.Factory?.CreateLayout();
-                mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+
+                if (mainWindowViewModel.Layout != null)
+                {
+                    mainWindowViewModel.Factory?.InitLayout(mainWindowViewModel.Layout);
+                }
 
                 singleViewLifetime.MainView = mainView;
             }

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -29,12 +29,6 @@
 
   <Import Project="..\..\build\EmbedXaml.props" />
 
-  <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Metro\Dock.Avalonia.Themes.Metro.csproj" />
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />

--- a/samples/Notepad/ViewLocator.cs
+++ b/samples/Notepad/ViewLocator.cs
@@ -12,12 +12,23 @@ namespace Notepad
 
         public IControl Build(object data)
         {
-            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            var name = data.GetType()?.FullName?.Replace("ViewModel", "View");
+            if (name == null)
+            {
+                return new TextBlock { Text = "Invalid Data Type" };
+            }
             var type = Type.GetType(name);
-
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type);
+                var instance = Activator.CreateInstance(type);
+                if (instance != null)
+                {
+                    return (Control)instance;
+                }
+                else
+                {
+                    return new TextBlock { Text = "Create Instance Failed: " + type.FullName };
+                }
             }
             else
             {

--- a/samples/Notepad/ViewModels/Documents/FileViewModel.cs
+++ b/samples/Notepad/ViewModels/Documents/FileViewModel.cs
@@ -7,9 +7,9 @@ namespace Notepad.ViewModels.Documents
 {
     public class FileViewModel : Document
     {
-        private string _path;
-        private string _text;
-        private string _encoding;
+        private string _path = string.Empty;
+        private string _text = string.Empty;
+        private string _encoding = string.Empty;
 
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
         public string Path

--- a/samples/Notepad/ViewModels/IDropTarget.cs
+++ b/samples/Notepad/ViewModels/IDropTarget.cs
@@ -4,7 +4,7 @@ namespace Notepad.ViewModels
 {
     public interface IDropTarget
     {
-        void DragOver(object sender, DragEventArgs e);
-        void Drop(object sender, DragEventArgs e);
+        void DragOver(object? sender, DragEventArgs e);
+        void Drop(object? sender, DragEventArgs e);
     }
 }

--- a/samples/Notepad/ViewModels/MainWindowViewModel.cs
+++ b/samples/Notepad/ViewModels/MainWindowViewModel.cs
@@ -17,23 +17,23 @@ namespace Notepad.ViewModels
     {
         public const string DocumentsDockId = "Files";
 
-        private IDockSerializer _serializer;
-        private IFactory _factory;
-        private IDock _layout;
+        private IDockSerializer? _serializer;
+        private IFactory? _factory;
+        private IDock? _layout;
 
-        public IDockSerializer Serializer
+        public IDockSerializer? Serializer
         {
             get => _serializer;
             set => this.RaiseAndSetIfChanged(ref _serializer, value);
         }
 
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);
         }
 
-        public IDock Layout
+        public IDock? Layout
         {
             get => _layout;
             set => this.RaiseAndSetIfChanged(ref _layout, value);
@@ -78,7 +78,7 @@ namespace Notepad.ViewModels
 
         private void AddFileViewModel(FileViewModel fileViewModel)
         {
-            if (Layout.ActiveDockable is IDock active)
+            if (Layout?.ActiveDockable is IDock active)
             {
                 if (active.Factory?.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
                 {
@@ -89,9 +89,9 @@ namespace Notepad.ViewModels
             }
         }
 
-        private FileViewModel GetFileViewModel()
+        private FileViewModel? GetFileViewModel()
         {
-            if (Layout.ActiveDockable is IDock active)
+            if (Layout?.ActiveDockable is IDock active)
             {
                 if (active.Factory?.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
                 {
@@ -193,7 +193,7 @@ namespace Notepad.ViewModels
             }
         }
 
-        public void DragOver(object sender, DragEventArgs e)
+        public void DragOver(object? sender, DragEventArgs e)
         {
             if (!e.Data.Contains(DataFormats.FileNames))
             {
@@ -202,7 +202,7 @@ namespace Notepad.ViewModels
             }
         }
 
-        public void Drop(object sender, DragEventArgs e)
+        public void Drop(object? sender, DragEventArgs e)
         {
             if (e.Data.Contains(DataFormats.FileNames))
             {
@@ -227,7 +227,9 @@ namespace Notepad.ViewModels
         private void CopyDocuments(IDock source, IDock target, string id)
         {
             if (source.Factory?.FindDockable(source, (d) => d.Id == id) is IDock sourceFiles
-                && target.Factory?.FindDockable(target, (d) => d.Id == id) is IDock targetFiles)
+                && target.Factory?.FindDockable(target, (d) => d.Id == id) is IDock targetFiles
+                && sourceFiles.VisibleDockables != null
+                && targetFiles.VisibleDockables != null)
             {
                 targetFiles.VisibleDockables.Clear();
                 targetFiles.ActiveDockable = null;
@@ -254,21 +256,24 @@ namespace Notepad.ViewModels
 
             // TODO:
 
-            if (Layout.ActiveDockable is IDock active)
+            if (Layout?.ActiveDockable is IDock active)
             {
-                var clone = (IDock)active.Clone();
-                clone.Title = clone.Title + "-copy";
-                active.Close();
-                Layout.Factory?.AddDockable(Layout, clone);
-                Layout.Navigate(clone);
-                Layout.Factory?.SetFocusedDockable(Layout, clone);
-                Layout.DefaultDockable = clone;
+                var clone = (IDock?)active.Clone();
+                if (clone != null)
+                {
+                    clone.Title = clone.Title + "-copy";
+                    active.Close();
+                    Layout.Factory?.AddDockable(Layout, clone);
+                    Layout.Navigate(clone);
+                    Layout.Factory?.SetFocusedDockable(Layout, clone);
+                    Layout.DefaultDockable = clone;
+                }
             }
         }
 
         public void WindowApplyWindowLayout(IDock dock)
         {
-            if (Layout.ActiveDockable is IDock active && dock != active)
+            if (Layout?.ActiveDockable is IDock active && dock != active)
             {
                 active.Close();
                 CopyDocuments(active, dock, DocumentsDockId);
@@ -303,17 +308,20 @@ namespace Notepad.ViewModels
 
             // TODO:
 
-            if (Layout.ActiveDockable is IDock active)
+            if (Layout?.ActiveDockable is IDock active)
             {
                 var layout = Factory?.CreateLayout();
-                Factory?.InitLayout(layout);
-                CopyDocuments(active, layout, DocumentsDockId);
-                Layout.Close();
-                Layout = layout;
+                if (layout != null)
+                {
+                    Factory?.InitLayout(layout);
+                    CopyDocuments(active, layout, DocumentsDockId);
+                    Layout?.Close();
+                    Layout = layout;
+                }
             }
         }
 
-        private Window GetWindow()
+        private Window? GetWindow()
         {
             if (Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
             {

--- a/samples/Notepad/ViewModels/MainWindowViewModel.cs
+++ b/samples/Notepad/ViewModels/MainWindowViewModel.cs
@@ -80,11 +80,11 @@ namespace Notepad.ViewModels
         {
             if (Layout.ActiveDockable is IDock active)
             {
-                if (active.Factory.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
+                if (active.Factory?.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
                 {
-                    Factory.AddDockable(files, fileViewModel);
-                    Factory.SetActiveDockable(fileViewModel);
-                    Factory.SetFocusedDockable(Layout, fileViewModel);
+                    Factory?.AddDockable(files, fileViewModel);
+                    Factory?.SetActiveDockable(fileViewModel);
+                    Factory?.SetFocusedDockable(Layout, fileViewModel);
                 }
             }
         }
@@ -93,7 +93,7 @@ namespace Notepad.ViewModels
         {
             if (Layout.ActiveDockable is IDock active)
             {
-                if (active.Factory.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
+                if (active.Factory?.FindDockable(active, (d) => d.Id == DocumentsDockId) is IDock files)
                 {
                     return files.ActiveDockable as FileViewModel;
                 }
@@ -226,8 +226,8 @@ namespace Notepad.ViewModels
 
         private void CopyDocuments(IDock source, IDock target, string id)
         {
-            if (source.Factory.FindDockable(source, (d) => d.Id == id) is IDock sourceFiles
-                && target.Factory.FindDockable(target, (d) => d.Id == id) is IDock targetFiles)
+            if (source.Factory?.FindDockable(source, (d) => d.Id == id) is IDock sourceFiles
+                && target.Factory?.FindDockable(target, (d) => d.Id == id) is IDock targetFiles)
             {
                 targetFiles.VisibleDockables.Clear();
                 targetFiles.ActiveDockable = null;
@@ -259,9 +259,9 @@ namespace Notepad.ViewModels
                 var clone = (IDock)active.Clone();
                 clone.Title = clone.Title + "-copy";
                 active.Close();
-                Layout.Factory.AddDockable(Layout, clone);
+                Layout.Factory?.AddDockable(Layout, clone);
                 Layout.Navigate(clone);
-                Layout.Factory.SetFocusedDockable(Layout, clone);
+                Layout.Factory?.SetFocusedDockable(Layout, clone);
                 Layout.DefaultDockable = clone;
             }
         }
@@ -273,7 +273,7 @@ namespace Notepad.ViewModels
                 active.Close();
                 CopyDocuments(active, dock, DocumentsDockId);
                 Layout.Navigate(dock);
-                Layout.Factory.SetFocusedDockable(Layout, dock);
+                Layout.Factory?.SetFocusedDockable(Layout, dock);
                 Layout.DefaultDockable = dock;
             }
         }
@@ -305,8 +305,8 @@ namespace Notepad.ViewModels
 
             if (Layout.ActiveDockable is IDock active)
             {
-                var layout = Factory.CreateLayout();
-                Factory.InitLayout(layout);
+                var layout = Factory?.CreateLayout();
+                Factory?.InitLayout(layout);
                 CopyDocuments(active, layout, DocumentsDockId);
                 Layout.Close();
                 Layout = layout;

--- a/samples/Notepad/ViewModels/Tools/FindViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/FindViewModel.cs
@@ -21,7 +21,7 @@ namespace Notepad.ViewModels.Tools
         {
             if (this.Context is IRootDock root && root.ActiveDockable is IDock active)
             {
-                if (active.Factory.FindDockable(active, (d) => d.Id == MainWindowViewModel.DocumentsDockId) is IDock files)
+                if (active.Factory?.FindDockable(active, (d) => d.Id == MainWindowViewModel.DocumentsDockId) is IDock files)
                 {
                     if (files.ActiveDockable is FileViewModel fileViewModel)
                     {

--- a/samples/Notepad/ViewModels/Tools/FindViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/FindViewModel.cs
@@ -8,7 +8,7 @@ namespace Notepad.ViewModels.Tools
 {
     public class FindViewModel : Tool
     {
-        private string _find;
+        private string _find = string.Empty;
 
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
         public string Find

--- a/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
@@ -29,7 +29,7 @@ namespace Notepad.ViewModels.Tools
         {
             if (this.Context is IRootDock root && root.ActiveDockable is IDock active)
             {
-                if (active.Factory.FindDockable(active, (d) => d.Id == MainWindowViewModel.DocumentsDockId) is IDock files)
+                if (active.Factory?.FindDockable(active, (d) => d.Id == MainWindowViewModel.DocumentsDockId) is IDock files)
                 {
                     if (files.ActiveDockable is FileViewModel fileViewModel)
                     {

--- a/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
@@ -8,8 +8,8 @@ namespace Notepad.ViewModels.Tools
 {
     public class ReplaceViewModel : Tool
     {
-        private string _find;
-        private string _replace;
+        private string _find = string.Empty;
+        private string _replace = string.Empty;
 
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
         public string Find

--- a/samples/Notepad/Views/MainView.xaml.cs
+++ b/samples/Notepad/Views/MainView.xaml.cs
@@ -14,7 +14,7 @@ namespace Notepad.Views
             AddHandler(DragDrop.DragOverEvent, DragOver);
         }
 
-        private void DragOver(object sender, DragEventArgs e)
+        private void DragOver(object? sender, DragEventArgs e)
         {
             if (this.DataContext is IDropTarget dropTarget)
             {
@@ -22,7 +22,7 @@ namespace Notepad.Views
             }
         }
 
-        private void Drop(object sender, DragEventArgs e)
+        private void Drop(object? sender, DragEventArgs e)
         {
             if (this.DataContext is IDropTarget dropTarget)
             {

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
     <PublishReadyToRun>True</PublishReadyToRun>
   </PropertyGroup>

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -7,7 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
-    <Nullable>disable</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -7,6 +7,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -9,6 +9,12 @@
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishTrimmed>True</PublishTrimmed>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>True</PublishReadyToRun>
+  </PropertyGroup>
+
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Rx.props" />
@@ -20,12 +26,6 @@
   </ItemGroup>
 
   <Import Project="..\..\build\EmbedXaml.props" />
-
-  <PropertyGroup>
-    <PublishTrimmed>True</PublishTrimmed>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />

--- a/src/Dock.Avalonia.Themes.Default/Dock.Avalonia.Themes.Default.csproj
+++ b/src/Dock.Avalonia.Themes.Default/Dock.Avalonia.Themes.Default.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Dock.Avalonia.Themes.Default/Dock.Avalonia.Themes.Default.csproj
+++ b/src/Dock.Avalonia.Themes.Default/Dock.Avalonia.Themes.Default.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Avalonia.Themes.Metro/Dock.Avalonia.Themes.Metro.csproj
+++ b/src/Dock.Avalonia.Themes.Metro/Dock.Avalonia.Themes.Metro.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Dock.Avalonia.Themes.Metro/Dock.Avalonia.Themes.Metro.csproj
+++ b/src/Dock.Avalonia.Themes.Metro/Dock.Avalonia.Themes.Metro.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Avalonia/AdornerHelper.cs
+++ b/src/Dock.Avalonia/AdornerHelper.cs
@@ -10,7 +10,7 @@ namespace Dock.Avalonia
 {
     internal class AdornerHelper
     {
-        public Control Adorner;
+        public Control? Adorner;
 
         public void AddAdorner(IVisual visual)
         {

--- a/src/Dock.Avalonia/Controls/DockPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/DockPanelSplitter.cs
@@ -14,7 +14,7 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DockPanelSplitter : Thumb
     {
-        private Control _element;
+        private Control? _element;
 
         /// <summary>
         /// Defines the <see cref="Thickness"/> property.
@@ -94,6 +94,11 @@ namespace Dock.Avalonia.Controls
 
         private void SetTargetHeight(double dy)
         {
+            if (_element == null)
+            {
+                return;
+            }
+
             double height = _element.DesiredSize.Height + dy;
 
             if (height < _element.MinHeight)
@@ -107,17 +112,25 @@ namespace Dock.Avalonia.Controls
             }
 
             var panel = GetPanel();
-            var dock = GetDock(this);
-            if (dock == global::Avalonia.Controls.Dock.Top && height > panel.DesiredSize.Height - Thickness)
+            if (panel != null)
             {
-                height = panel.DesiredSize.Height - Thickness;
-            }
+                var dock = GetDock(this);
+                if (dock == global::Avalonia.Controls.Dock.Top && height > panel.DesiredSize.Height - Thickness)
+                {
+                    height = panel.DesiredSize.Height - Thickness;
+                }
 
+            }
             _element.Height = height;
         }
 
         private void SetTargetWidth(double dx)
         {
+            if (_element == null)
+            {
+                return;
+            }
+
             double width = _element.DesiredSize.Width + dx;
 
             if (width < _element.MinWidth)
@@ -131,10 +144,13 @@ namespace Dock.Avalonia.Controls
             }
 
             var panel = GetPanel();
-            var dock = GetDock(this);
-            if (dock == global::Avalonia.Controls.Dock.Left && width > panel.DesiredSize.Width - Thickness)
+            if (panel != null)
             {
-                width = panel.DesiredSize.Width - Thickness;
+                var dock = GetDock(this);
+                if (dock == global::Avalonia.Controls.Dock.Left && width > panel.DesiredSize.Width - Thickness)
+                {
+                    width = panel.DesiredSize.Width - Thickness;
+                } 
             }
 
             _element.Width = width;
@@ -167,7 +183,7 @@ namespace Dock.Avalonia.Controls
             return DockPanel.GetDock(control);
         }
 
-        private Panel GetPanel()
+        private Panel? GetPanel()
         {
             if (this.Parent is ContentPresenter presenter)
             {
@@ -199,7 +215,10 @@ namespace Dock.Avalonia.Controls
                 int index = panel.Children.IndexOf(this.Parent);
                 if (index > 0 && panel.Children.Count > 0)
                 {
-                    _element = (panel.Children[index - 1] as ContentPresenter).Child as Control;
+                    if (panel.Children[index - 1] is ContentPresenter contentPresenter)
+                    {
+                        _element = contentPresenter.Child as Control;
+                    }
                 }
             }
             else

--- a/src/Dock.Avalonia/Controls/DockTarget.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.cs
@@ -15,17 +15,17 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DockTarget : TemplatedControl
     {
-        private Grid _topIndicator;
-        private Grid _bottomIndicator;
-        private Grid _leftIndicator;
-        private Grid _rightIndicator;
-        private Grid _centerIndicator;
+        private Grid? _topIndicator;
+        private Grid? _bottomIndicator;
+        private Grid? _leftIndicator;
+        private Grid? _rightIndicator;
+        private Grid? _centerIndicator;
 
-        private Control _topSelector;
-        private Control _bottomSelector;
-        private Control _leftSelector;
-        private Control _rightSelector;
-        private Control _centerSelector;
+        private Control? _topSelector;
+        private Control? _bottomSelector;
+        private Control? _leftSelector;
+        private Control? _rightSelector;
+        private Control? _centerSelector;
 
         static DockTarget()
         {
@@ -82,9 +82,9 @@ namespace Dock.Avalonia.Controls
             return result;
         }
 
-        private bool InvalidateIndicator(Control selector, Grid indicator, Point point, IVisual relativeTo, DockOperation operation, DragAction dragAction, Func<Point, DockOperation, DragAction, IVisual, bool> validate)
+        private bool InvalidateIndicator(Control? selector, Grid? indicator, Point point, IVisual relativeTo, DockOperation operation, DragAction dragAction, Func<Point, DockOperation, DragAction, IVisual, bool> validate)
         {
-            if (selector != null)
+            if (selector != null && indicator != null)
             {
                 var selectorPoint = relativeTo.TranslatePoint(point, selector);
                 if (selectorPoint != null && selector.InputHitTest(selectorPoint.Value) != null && validate(point, operation, dragAction, relativeTo) == true)

--- a/src/Dock.Avalonia/Controls/DockToolChrome.cs
+++ b/src/Dock.Avalonia/Controls/DockToolChrome.cs
@@ -52,11 +52,11 @@ namespace Dock.Avalonia.Controls
             set => SetValue(IsActiveProperty, value);
         }
 
-        internal Control Grip { get; private set; }
+        internal Control? Grip { get; private set; }
 
-        internal Button CloseButton { get; private set; }
+        internal Button? CloseButton { get; private set; }
 
-        private IDisposable _disposable;
+        private IDisposable? _disposable;
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -69,7 +69,7 @@ namespace Dock.Avalonia.Controls
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable.Dispose();
+            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)

--- a/src/Dock.Avalonia/Controls/DocumentControl.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.cs
@@ -16,7 +16,7 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DocumentControl : TemplatedControl
     {
-        private IDisposable _disposable;
+        private IDisposable? _disposable;
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -29,7 +29,7 @@ namespace Dock.Avalonia.Controls
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable.Dispose();
+            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)

--- a/src/Dock.Avalonia/Controls/HostWindow.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.cs
@@ -54,19 +54,19 @@ namespace Dock.Avalonia.Controls
 
         private HostWindowState _hostWindowState;
 
-        private Control _titleBar;
-        private Grid _bottomHorizontalGrip;
-        private Grid _bottomLeftGrip;
-        private Grid _bottomRightGrip;
-        private Grid _leftVerticalGrip;
-        private Grid _rightVerticalGrip;
-        private Grid _topHorizontalGrip;
-        private Grid _topLeftGrip;
-        private Grid _topRightGrip;
-        private Button _closeButton;
-        private Button _minimiseButton;
-        private Button _restoreButton;
-        private Image _icon;
+        private Control? _titleBar;
+        private Grid? _bottomHorizontalGrip;
+        private Grid? _bottomLeftGrip;
+        private Grid? _bottomRightGrip;
+        private Grid? _leftVerticalGrip;
+        private Grid? _rightVerticalGrip;
+        private Grid? _topHorizontalGrip;
+        private Grid? _topLeftGrip;
+        private Grid? _topRightGrip;
+        private Button? _closeButton;
+        private Button? _minimiseButton;
+        private Button? _restoreButton;
+        private Image? _icon;
         private bool _mouseDown;
         private Point _startPoint;
 

--- a/src/Dock.Avalonia/Controls/HostWindow.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.cs
@@ -74,7 +74,7 @@ namespace Dock.Avalonia.Controls
         public bool IsTracked { get; set; }
 
         /// <inheritdoc/>
-        public IDockWindow Window { get; set; }
+        public IDockWindow? Window { get; set; }
 
         /// <summary>
         /// Initializes new instance of the <see cref="HostWindow"/> class.

--- a/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
+++ b/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
@@ -31,7 +31,7 @@ namespace Dock.Avalonia.Controls
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>The loaded <see cref="object"/> instance.</returns>
-        public object ProvideValue(IServiceProvider serviceProvider)
+        public object? ProvideValue(IServiceProvider serviceProvider)
         {
             if (serviceProvider.GetService(typeof(IUriContext)) is IUriContext uriContext)
             {
@@ -40,13 +40,13 @@ namespace Dock.Avalonia.Controls
                 var obj = loader.Load(Source, baseUri);
                 return obj;
             }
-            return null;
+            return default;
         }
 
         /// <summary>
         /// Gets or sets the source URL.
         /// </summary>
         [ConstructorArgument("source")]
-        public Uri Source { get; set; }
+        public Uri? Source { get; set; }
     }
 }

--- a/src/Dock.Avalonia/Controls/MarkupExtensions/ReferenceExtension.cs
+++ b/src/Dock.Avalonia/Controls/MarkupExtensions/ReferenceExtension.cs
@@ -31,21 +31,21 @@ namespace Dock.Avalonia.Controls
         /// Gets or sets referenced object name.
         /// </summary>
         [ConstructorArgument("name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Provides a referenced object <see cref="object"/> instance.
         /// </summary>
         /// <param name="serviceProvider">The service provider.</param>
         /// <returns>The referenced <see cref="object"/> instance.</returns>
-        public object ProvideValue(IServiceProvider serviceProvider)
+        public object? ProvideValue(IServiceProvider serviceProvider)
         {
             if (serviceProvider.GetService(typeof(INameScope)) is INameScope nameScope)
             {
                 var element = nameScope.Find(Name);
                 return element;
             }
-            return null;
+            return default;
         }
     }
 }

--- a/src/Dock.Avalonia/Controls/MetroWindow.cs
+++ b/src/Dock.Avalonia/Controls/MetroWindow.cs
@@ -14,19 +14,19 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class MetroWindow : Window, IStyleable
     {
-        private Grid _titleBar;
-        private Grid _bottomHorizontalGrip;
-        private Grid _bottomLeftGrip;
-        private Grid _bottomRightGrip;
-        private Grid _leftVerticalGrip;
-        private Grid _rightVerticalGrip;
-        private Grid _topHorizontalGrip;
-        private Grid _topLeftGrip;
-        private Grid _topRightGrip;
-        private Button _closeButton;
-        private Button _minimiseButton;
-        private Button _restoreButton;
-        private Image _icon;
+        private Grid? _titleBar;
+        private Grid? _bottomHorizontalGrip;
+        private Grid? _bottomLeftGrip;
+        private Grid? _bottomRightGrip;
+        private Grid? _leftVerticalGrip;
+        private Grid? _rightVerticalGrip;
+        private Grid? _topHorizontalGrip;
+        private Grid? _topLeftGrip;
+        private Grid? _topRightGrip;
+        private Button? _closeButton;
+        private Button? _minimiseButton;
+        private Button? _restoreButton;
+        private Image? _icon;
         private bool _mouseDown;
 
         /// <summary>

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
@@ -235,7 +235,7 @@ namespace Dock.Avalonia.Controls
             }
         }
 
-        private ProportionalStackPanel GetPanel()
+        private ProportionalStackPanel? GetPanel()
         {
             if (Parent is ContentPresenter presenter)
             {
@@ -252,7 +252,7 @@ namespace Dock.Avalonia.Controls
             return null;
         }
 
-        private Control GetTargetElement()
+        private Control? GetTargetElement()
         {
             if (Parent is ContentPresenter presenter)
             {

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
@@ -87,13 +87,16 @@ namespace Dock.Avalonia.Controls
         /// <inheritdoc/>
         protected override void OnDragDelta(VectorEventArgs e)
         {
-            if (GetPanel().Orientation == Orientation.Vertical)
+            if (GetPanel() is ProportionalStackPanel panel)
             {
-                SetTargetProportion(e.Vector.Y);
-            }
-            else
-            {
-                SetTargetProportion(e.Vector.X);
+                if (panel.Orientation == Orientation.Vertical)
+                {
+                    SetTargetProportion(e.Vector.Y);
+                }
+                else
+                {
+                    SetTargetProportion(e.Vector.X);
+                }
             }
         }
 
@@ -103,6 +106,10 @@ namespace Dock.Avalonia.Controls
             base.OnAttachedToVisualTree(e);
 
             var panel = GetPanel();
+            if (panel == null)
+            {
+                return;
+            }
 
             _previousParentSize = panel.Bounds.Size;
 
@@ -141,6 +148,11 @@ namespace Dock.Avalonia.Controls
         {
             var target = GetTargetElement();
             var panel = GetPanel();
+            if (target == null || panel == null)
+            {
+                return;
+            }
+
             var children = panel.GetChildren();
 
             int index = children.IndexOf(this) + 1;
@@ -219,19 +231,22 @@ namespace Dock.Avalonia.Controls
 
         private void UpdateHeightOrWidth()
         {
-            if (GetPanel().Orientation == Orientation.Vertical)
+            if (GetPanel() is ProportionalStackPanel panel)
             {
-                Height = Thickness;
-                Width = double.NaN;
-                Cursor = new Cursor(StandardCursorType.SizeNorthSouth);
-                PseudoClasses.Add(":horizontal");
-            }
-            else
-            {
-                Width = Thickness;
-                Height = double.NaN;
-                Cursor = new Cursor(StandardCursorType.SizeWestEast);
-                PseudoClasses.Add(":vertical");
+                if (panel.Orientation == Orientation.Vertical)
+                {
+                    Height = Thickness;
+                    Width = double.NaN;
+                    Cursor = new Cursor(StandardCursorType.SizeNorthSouth);
+                    PseudoClasses.Add(":horizontal");
+                }
+                else
+                {
+                    Width = Thickness;
+                    Height = double.NaN;
+                    Cursor = new Cursor(StandardCursorType.SizeWestEast);
+                    PseudoClasses.Add(":vertical");
+                }
             }
         }
 
@@ -264,17 +279,26 @@ namespace Dock.Avalonia.Controls
                 int index = panel.Children.IndexOf(Parent);
                 if (index > 0 && panel.Children.Count > 0)
                 {
-                    return (panel.Children[index - 1] as ContentPresenter).Child as Control;
+                    if (panel.Children[index - 1] is ContentPresenter contentPresenter)
+                    {
+                        return contentPresenter.Child as Control;
+                    }
+                    else
+                    {
+                        return null;
+                    }
                 }
             }
             else
             {
                 var panel = GetPanel();
-
-                int index = panel.Children.IndexOf(this);
-                if (index > 0 && panel.Children.Count > 0)
+                if (panel != null)
                 {
-                    return panel.Children[index - 1] as Control;
+                    int index = panel.Children.IndexOf(this);
+                    if (index > 0 && panel.Children.Count > 0)
+                    {
+                        return panel.Children[index - 1] as Control;
+                    }
                 }
             }
 

--- a/src/Dock.Avalonia/Controls/ToolControl.cs
+++ b/src/Dock.Avalonia/Controls/ToolControl.cs
@@ -16,7 +16,7 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class ToolControl : TemplatedControl
     {
-        private IDisposable _disposable;
+        private IDisposable? _disposable;
 
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
@@ -29,7 +29,7 @@ namespace Dock.Avalonia.Controls
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable.Dispose();
+            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)

--- a/src/Dock.Avalonia/Dock.Avalonia.csproj
+++ b/src/Dock.Avalonia/Dock.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Dock.Avalonia/Dock.Avalonia.csproj
+++ b/src/Dock.Avalonia/Dock.Avalonia.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Avalonia/DockControlState.cs
+++ b/src/Dock.Avalonia/DockControlState.cs
@@ -19,13 +19,13 @@ namespace Dock.Avalonia
     {
         private readonly IDockManager _dockManager = new DockManager();
         private readonly AdornerHelper _adornerHelper = new AdornerHelper();
-        private IControl _dragControl = null;
-        private IControl _dropControl = null;
+        private IControl? _dragControl = null;
+        private IControl? _dropControl = null;
         private Point _dragStartPoint = default;
         private bool _pointerPressed = false;
         private bool _doDragDrop = false;
         private Point _targetPoint = default;
-        private IVisual _targetDockControl = null;
+        private IVisual? _targetDockControl = null;
 
         private void Enter(Point point, DragAction dragAction, IVisual relativeTo)
         {
@@ -100,7 +100,7 @@ namespace Dock.Avalonia
 
             if (_dragControl.DataContext is IDockable sourceDockable && _dropControl.DataContext is IDockable targetDockable)
             {
-                Debug.WriteLine($"Execute : {point} : {operation} : {dragAction} : {sourceDockable?.Title} -> {targetDockable?.Title}");
+                Debug.WriteLine($"Execute : {point} : {operation} : {dragAction} : {sourceDockable.Title} -> {targetDockable.Title}");
                 _dockManager.Position = DockHelpers.ToDockPoint(point);
                 _dockManager.ScreenPosition = DockHelpers.ToDockPoint(relativeTo.PointToScreen(point).ToPoint(1.0));
                 return _dockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, bExecute: true);

--- a/src/Dock.Avalonia/DockControlState.cs
+++ b/src/Dock.Avalonia/DockControlState.cs
@@ -186,7 +186,7 @@ namespace Dock.Avalonia
                             bool haveMinimumDragDistance = IsMinimumDragDistance(diff);
                             if (haveMinimumDragDistance == true)
                             {
-                                if (_dragControl.DataContext is IDockable targetDockable)
+                                if (_dragControl?.DataContext is IDockable targetDockable)
                                 {
                                     DockHelpers.ShowWindows(targetDockable);
                                 }
@@ -197,8 +197,8 @@ namespace Dock.Avalonia
                         if (_doDragDrop == true)
                         {
                             Point targetPoint = default;
-                            IVisual targetDockControl = null;
-                            IControl dropControl = null;
+                            IVisual? targetDockControl = null;
+                            IControl? dropControl = null;
 
                             foreach (var dockControl in dockControls)
                             {

--- a/src/Dock.Avalonia/DockHelpers.cs
+++ b/src/Dock.Avalonia/DockHelpers.cs
@@ -28,7 +28,7 @@ namespace Dock.Avalonia
                    element.IsAttachedToVisualTree;
         }
 
-        public static IEnumerable<IVisual> GetVisualsAt(IVisual visual, Point p, Func<IVisual, bool> filter)
+        public static IEnumerable<IVisual>? GetVisualsAt(IVisual visual, Point p, Func<IVisual, bool> filter)
         {
             var root = visual.GetVisualRoot();
             if (root != null)
@@ -42,9 +42,9 @@ namespace Dock.Avalonia
             return Enumerable.Empty<IVisual>();
         }
 
-        public static IControl GetControl(IInputElement input, Point point, AvaloniaProperty<bool> property)
+        public static IControl? GetControl(IInputElement input, Point point, AvaloniaProperty<bool> property)
         {
-            IEnumerable<IInputElement> inputElements = null;
+            IEnumerable<IInputElement>? inputElements = null;
             try
             {
                 inputElements = GetVisualsAt(input, point, IsHitTestVisible)?.Cast<IInputElement>();

--- a/src/Dock.Avalonia/HostWindowState.cs
+++ b/src/Dock.Avalonia/HostWindowState.cs
@@ -21,9 +21,9 @@ namespace Dock.Avalonia
         private Point _dragStartPoint = default;
         private bool _pointerPressed = false;
         private bool _doDragDrop = false;
-        private DockControl _targetDockControl = null;
+        private DockControl? _targetDockControl = null;
         private Point _targetPoint = default;
-        private IControl _targetDropControl = null;
+        private IControl? _targetDropControl = null;
         private DragAction _dragAction = default;
 
         public HostWindowState(HostWindow hostWindow)

--- a/src/Dock.Avalonia/HostWindowState.cs
+++ b/src/Dock.Avalonia/HostWindowState.cs
@@ -91,7 +91,7 @@ namespace Dock.Avalonia
                 return false;
             }
 
-            var layout = _hostWindow.Window.Layout;
+            var layout = _hostWindow.Window?.Layout;
 
             if (layout?.ActiveDockable is IDockable sourceDockable && _targetDropControl.DataContext is IDockable targetDockable)
             {
@@ -110,11 +110,11 @@ namespace Dock.Avalonia
                 return false;
             }
 
-            var layout = _hostWindow.Window.Layout;
+            var layout = _hostWindow.Window?.Layout;
 
             if (layout?.ActiveDockable is IDockable sourceDockable && _targetDropControl.DataContext is IDockable targetDockable)
             {
-                Debug.WriteLine($"Execute : {point} : {operation} : {dragAction} : {sourceDockable?.Title} -> {targetDockable?.Title}");
+                Debug.WriteLine($"Execute : {point} : {operation} : {dragAction} : {sourceDockable.Title} -> {targetDockable.Title}");
                 _dockManager.Position = DockHelpers.ToDockPoint(point);
                 _dockManager.ScreenPosition = DockHelpers.ToDockPoint(relativeTo.PointToScreen(point).ToPoint(1.0));
                 return _dockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, bExecute: true);
@@ -191,7 +191,7 @@ namespace Dock.Avalonia
                             {
                                 if (visual is DockControl dockControl)
                                 {
-                                    if (dockControl.Layout != _hostWindow.Window.Layout)
+                                    if (dockControl.Layout != _hostWindow.Window?.Layout)
                                     {
                                         var position = point + _dragStartPoint;
                                         var screenPoint = new PixelPoint((int)position.X, (int)position.Y);

--- a/src/Dock.Model.Avalonia/Controls/Document.cs
+++ b/src/Dock.Model.Avalonia/Controls/Document.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneDocumentDock(this);
         }

--- a/src/Dock.Model.Avalonia/Controls/PinDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/PinDock.cs
@@ -67,7 +67,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.ClonePinDock(this);
         }

--- a/src/Dock.Model.Avalonia/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/ProportionalDock.cs
@@ -37,7 +37,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneProportionalDock(this);
         }

--- a/src/Dock.Model.Avalonia/Controls/RootDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/RootDock.cs
@@ -127,7 +127,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneRootDock(this);
         }

--- a/src/Dock.Model.Avalonia/Controls/RootDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/RootDock.cs
@@ -16,49 +16,49 @@ namespace Dock.Model.Controls
         /// <summary>
         /// Defines the <see cref="Window"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IDockWindow> WindowProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IDockWindow>(nameof(Window), o => o.Window, (o, v) => o.Window = v);
+        public static readonly DirectProperty<RootDock, IDockWindow?> WindowProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IDockWindow?>(nameof(Window), o => o.Window, (o, v) => o.Window = v);
 
         /// <summary>
         /// Defines the <see cref="Windows"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IList<IDockWindow>> WindowsProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IList<IDockWindow>>(nameof(Windows), o => o.Windows, (o, v) => o.Windows = v);
+        public static readonly DirectProperty<RootDock, IList<IDockWindow>?> WindowsProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IList<IDockWindow>?>(nameof(Windows), o => o.Windows, (o, v) => o.Windows = v);
 
         /// <summary>
         /// Defines the <see cref="Top"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IPinDock> TopProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IPinDock>(nameof(Top), o => o.Top, (o, v) => o.Top = v);
+        public static readonly DirectProperty<RootDock, IPinDock?> TopProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IPinDock?>(nameof(Top), o => o.Top, (o, v) => o.Top = v);
 
         /// <summary>
         /// Defines the <see cref="Bottom"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IPinDock> BottomProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IPinDock>(nameof(Bottom), o => o.Bottom, (o, v) => o.Bottom = v);
+        public static readonly DirectProperty<RootDock, IPinDock?> BottomProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IPinDock?>(nameof(Bottom), o => o.Bottom, (o, v) => o.Bottom = v);
 
         /// <summary>
         /// Defines the <see cref="Left"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IPinDock> LeftProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IPinDock>(nameof(Left), o => o.Left, (o, v) => o.Left = v);
+        public static readonly DirectProperty<RootDock, IPinDock?> LeftProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IPinDock?>(nameof(Left), o => o.Left, (o, v) => o.Left = v);
 
         /// <summary>
         /// Defines the <see cref="Right"/> property.
         /// </summary>
-        public static readonly DirectProperty<RootDock, IPinDock> RightProperty =
-            AvaloniaProperty.RegisterDirect<RootDock, IPinDock>(nameof(Right), o => o.Right, (o, v) => o.Right = v);
+        public static readonly DirectProperty<RootDock, IPinDock?> RightProperty =
+            AvaloniaProperty.RegisterDirect<RootDock, IPinDock?>(nameof(Right), o => o.Right, (o, v) => o.Right = v);
 
-        private IDockWindow _window;
-        private IList<IDockWindow> _windows;
-        private IPinDock _top;
-        private IPinDock _bottom;
-        private IPinDock _left;
-        private IPinDock _right;
+        private IDockWindow? _window;
+        private IList<IDockWindow>? _windows;
+        private IPinDock? _top;
+        private IPinDock? _bottom;
+        private IPinDock? _left;
+        private IPinDock? _right;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockWindow Window
+        public IDockWindow? Window
         {
             get => _window;
             set => SetAndRaise(WindowProperty, ref _window, value);
@@ -66,7 +66,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockWindow> Windows
+        public IList<IDockWindow>? Windows
         {
             get => _windows;
             set => SetAndRaise(WindowsProperty, ref _windows, value);
@@ -74,7 +74,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Top
+        public IPinDock? Top
         {
             get => _top;
             set => SetAndRaise(TopProperty, ref _top, value);
@@ -82,7 +82,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Bottom
+        public IPinDock? Bottom
         {
             get => _bottom;
             set => SetAndRaise(BottomProperty, ref _bottom, value);
@@ -90,7 +90,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Left
+        public IPinDock? Left
         {
             get => _left;
             set => SetAndRaise(LeftProperty, ref _left, value);
@@ -98,7 +98,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Right
+        public IPinDock? Right
         {
             get => _right;
             set => SetAndRaise(RightProperty, ref _right, value);

--- a/src/Dock.Model.Avalonia/Controls/SplitterDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/SplitterDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneSplitterDock(this);
         }

--- a/src/Dock.Model.Avalonia/Controls/Tool.cs
+++ b/src/Dock.Model.Avalonia/Controls/Tool.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.Avalonia/Controls/ToolDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/ToolDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneToolDock(this);
         }

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -129,10 +129,10 @@ namespace Dock.Model
                 SetAndRaise(ActiveDockableProperty, ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory?.UpdateDockable(value, this);
+                    Factory.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory?.SetFocusedDockable(this, value);
+                Factory.SetFocusedDockable(this, value);
                 SetAndRaise(CanGoBackProperty, ref _canGoBack, _navigateAdapter?.CanGoBack ?? false);
                 SetAndRaise(CanGoForwardProperty, ref _canGoForward, _navigateAdapter?.CanGoForward ?? false);
             }

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -18,38 +18,38 @@ namespace Dock.Model
         /// <summary>
         /// Defines the <see cref="VisibleDockables"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IList<IDockable>> VisibleDockablesProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>>(nameof(VisibleDockables), o => o.VisibleDockables, (o, v) => o.VisibleDockables = v);
+        public static readonly DirectProperty<DockBase, IList<IDockable>?> VisibleDockablesProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>?>(nameof(VisibleDockables), o => o.VisibleDockables, (o, v) => o.VisibleDockables = v);
 
         /// <summary>
         /// Defines the <see cref="HiddenDockables"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IList<IDockable>> HiddenDockablesProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>>(nameof(HiddenDockables), o => o.HiddenDockables, (o, v) => o.HiddenDockables = v);
+        public static readonly DirectProperty<DockBase, IList<IDockable>?> HiddenDockablesProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>?>(nameof(HiddenDockables), o => o.HiddenDockables, (o, v) => o.HiddenDockables = v);
 
         /// <summary>
         /// Defines the <see cref="PinnedDockables"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IList<IDockable>> PinnedDockablesProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>>(nameof(PinnedDockables), o => o.PinnedDockables, (o, v) => o.PinnedDockables = v);
+        public static readonly DirectProperty<DockBase, IList<IDockable>?> PinnedDockablesProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IList<IDockable>?>(nameof(PinnedDockables), o => o.PinnedDockables, (o, v) => o.PinnedDockables = v);
 
         /// <summary>
         /// Defines the <see cref="ActiveDockable"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IDockable> ActiveDockableProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IDockable>(nameof(ActiveDockable), o => o.ActiveDockable, (o, v) => o.ActiveDockable = v);
+        public static readonly DirectProperty<DockBase, IDockable?> ActiveDockableProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IDockable?>(nameof(ActiveDockable), o => o.ActiveDockable, (o, v) => o.ActiveDockable = v);
 
         /// <summary>
         /// Defines the <see cref="DefaultDockable"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IDockable> DefaultDockableProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IDockable>(nameof(DefaultDockable), o => o.DefaultDockable, (o, v) => o.DefaultDockable = v);
+        public static readonly DirectProperty<DockBase, IDockable?> DefaultDockableProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IDockable?>(nameof(DefaultDockable), o => o.DefaultDockable, (o, v) => o.DefaultDockable = v);
 
         /// <summary>
         /// Defines the <see cref="FocusedDockable"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockBase, IDockable> FocusedDockableProperty =
-            AvaloniaProperty.RegisterDirect<DockBase, IDockable>(nameof(FocusedDockable), o => o.FocusedDockable, (o, v) => o.FocusedDockable = v);
+        public static readonly DirectProperty<DockBase, IDockable?> FocusedDockableProperty =
+            AvaloniaProperty.RegisterDirect<DockBase, IDockable?>(nameof(FocusedDockable), o => o.FocusedDockable, (o, v) => o.FocusedDockable = v);
 
         /// <summary>
         /// Defines the <see cref="Proportion"/> property.
@@ -82,12 +82,12 @@ namespace Dock.Model
             AvaloniaProperty.RegisterDirect<DockBase, bool>(nameof(CanGoForward), (o) => o.CanGoForward);
 
         internal INavigateAdapter _navigateAdapter;
-        private IList<IDockable> _visibleDockables;
-        private IList<IDockable> _hiddenDockables;
-        private IList<IDockable> _pinnedDockables;
-        private IDockable _activeDockable;
-        private IDockable _defaultDockable;
-        private IDockable _focusedDockable;
+        private IList<IDockable>? _visibleDockables;
+        private IList<IDockable>? _hiddenDockables;
+        private IList<IDockable>? _pinnedDockables;
+        private IDockable? _activeDockable;
+        private IDockable? _defaultDockable;
+        private IDockable? _focusedDockable;
         private double _proportion = double.NaN;
         private bool _isActive;
         private bool _isCollapsable = true;
@@ -97,7 +97,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         [Content]
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> VisibleDockables
+        public IList<IDockable>? VisibleDockables
         {
             get => _visibleDockables;
             set => SetAndRaise(VisibleDockablesProperty, ref _visibleDockables, value);
@@ -105,7 +105,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> HiddenDockables
+        public IList<IDockable>? HiddenDockables
         {
             get => _hiddenDockables;
             set => SetAndRaise(HiddenDockablesProperty, ref _hiddenDockables, value);
@@ -113,7 +113,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> PinnedDockables
+        public IList<IDockable>? PinnedDockables
         {
             get => _pinnedDockables;
             set => SetAndRaise(PinnedDockablesProperty, ref _pinnedDockables, value);
@@ -121,7 +121,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable ActiveDockable
+        public IDockable? ActiveDockable
         {
             get => _activeDockable;
             set
@@ -140,7 +140,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable DefaultDockable
+        public IDockable? DefaultDockable
         {
             get => _defaultDockable;
             set => SetAndRaise(DefaultDockableProperty, ref _defaultDockable, value);
@@ -148,7 +148,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable FocusedDockable
+        public IDockable? FocusedDockable
         {
             get => _focusedDockable;
             set => SetAndRaise(FocusedDockableProperty, ref _focusedDockable, value);

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -129,10 +129,13 @@ namespace Dock.Model
                 SetAndRaise(ActiveDockableProperty, ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory.UpdateDockable(value, this);
+                    Factory?.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory.SetFocusedDockable(this, value);
+                if (value != null)
+                {
+                    Factory?.SetFocusedDockable(this, value);
+                }
                 SetAndRaise(CanGoBackProperty, ref _canGoBack, _navigateAdapter?.CanGoBack ?? false);
                 SetAndRaise(CanGoForwardProperty, ref _canGoForward, _navigateAdapter?.CanGoForward ?? false);
             }

--- a/src/Dock.Model.Avalonia/Core/DockWindow.cs
+++ b/src/Dock.Model.Avalonia/Core/DockWindow.cs
@@ -210,7 +210,7 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public IDockWindow Clone()
+        public IDockWindow? Clone()
         {
             return CloneHelper.CloneDockWindow(this);
         }

--- a/src/Dock.Model.Avalonia/Core/DockWindow.cs
+++ b/src/Dock.Model.Avalonia/Core/DockWindow.cs
@@ -58,26 +58,26 @@ namespace Dock.Model
         /// <summary>
         /// Defines the <see cref="Owner"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockWindow, IDockable> OwnerProperty =
-            AvaloniaProperty.RegisterDirect<DockWindow, IDockable>(nameof(Owner), o => o.Owner, (o, v) => o.Owner = v);
+        public static readonly DirectProperty<DockWindow, IDockable?> OwnerProperty =
+            AvaloniaProperty.RegisterDirect<DockWindow, IDockable?>(nameof(Owner), o => o.Owner, (o, v) => o.Owner = v);
 
         /// <summary>
         /// Defines the <see cref="Factory"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockWindow, IFactory> FactoryProperty =
-            AvaloniaProperty.RegisterDirect<DockWindow, IFactory>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
+        public static readonly DirectProperty<DockWindow, IFactory?> FactoryProperty =
+            AvaloniaProperty.RegisterDirect<DockWindow, IFactory?>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
 
         /// <summary>
         /// Defines the <see cref="Layout"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockWindow, IRootDock> LayoutProperty =
-            AvaloniaProperty.RegisterDirect<DockWindow, IRootDock>(nameof(Layout), o => o.Layout, (o, v) => o.Layout = v);
+        public static readonly DirectProperty<DockWindow, IRootDock?> LayoutProperty =
+            AvaloniaProperty.RegisterDirect<DockWindow, IRootDock?>(nameof(Layout), o => o.Layout, (o, v) => o.Layout = v);
 
         /// <summary>
         /// Defines the <see cref="Host"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockWindow, IHostWindow> HostProperty =
-            AvaloniaProperty.RegisterDirect<DockWindow, IHostWindow>(nameof(Host), o => o.Host, (o, v) => o.Host = v);
+        public static readonly DirectProperty<DockWindow, IHostWindow?> HostProperty =
+            AvaloniaProperty.RegisterDirect<DockWindow, IHostWindow?>(nameof(Host), o => o.Host, (o, v) => o.Host = v);
 
         private IHostAdapter _hostAdapter;
         private string _id;
@@ -87,10 +87,10 @@ namespace Dock.Model
         private double _height;
         private bool _topmost;
         private string _title;
-        private IDockable _owner;
-        private IFactory _factory;
-        private IRootDock _layout;
-        private IHostWindow _host;
+        private IDockable? _owner;
+        private IFactory? _factory;
+        private IRootDock? _layout;
+        private IHostWindow? _host;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -150,7 +150,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => SetAndRaise(OwnerProperty, ref _owner, value);
@@ -158,7 +158,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => SetAndRaise(FactoryProperty, ref _factory, value);
@@ -167,7 +167,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         [Content]
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IRootDock Layout
+        public IRootDock? Layout
         {
             get => _layout;
             set => SetAndRaise(LayoutProperty, ref _layout, value);
@@ -175,7 +175,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IHostWindow Host
+        public IHostWindow? Host
         {
             get => _host;
             set => SetAndRaise(HostProperty, ref _host, value);

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -41,8 +41,8 @@ namespace Dock.Model
         public static readonly DirectProperty<DockableBase, IFactory?> FactoryProperty =
             AvaloniaProperty.RegisterDirect<DockableBase, IFactory?>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
 
-        private string _id;
-        private string _title;
+        private string _id = string.Empty;
+        private string _title = string.Empty;
         private object? _context;
         private IDockable? _owner;
         private IFactory? _factory;

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -26,26 +26,26 @@ namespace Dock.Model
         /// <summary>
         /// Defines the <see cref="Context"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockableBase, object> ContextProperty =
-            AvaloniaProperty.RegisterDirect<DockableBase, object>(nameof(Context), o => o.Context, (o, v) => o.Context = v);
+        public static readonly DirectProperty<DockableBase, object?> ContextProperty =
+            AvaloniaProperty.RegisterDirect<DockableBase, object?>(nameof(Context), o => o.Context, (o, v) => o.Context = v);
 
         /// <summary>
         /// Defines the <see cref="Owner"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockableBase, IDockable> OwnerProperty =
-            AvaloniaProperty.RegisterDirect<DockableBase, IDockable>(nameof(Owner), o => o.Owner, (o, v) => o.Owner = v);
+        public static readonly DirectProperty<DockableBase, IDockable?> OwnerProperty =
+            AvaloniaProperty.RegisterDirect<DockableBase, IDockable?>(nameof(Owner), o => o.Owner, (o, v) => o.Owner = v);
 
         /// <summary>
         /// Defines the <see cref="Factory"/> property.
         /// </summary>
-        public static readonly DirectProperty<DockableBase, IFactory> FactoryProperty =
-            AvaloniaProperty.RegisterDirect<DockableBase, IFactory>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
+        public static readonly DirectProperty<DockableBase, IFactory?> FactoryProperty =
+            AvaloniaProperty.RegisterDirect<DockableBase, IFactory?>(nameof(Factory), o => o.Factory, (o, v) => o.Factory = v);
 
         private string _id;
         private string _title;
-        private object _context;
-        private IDockable _owner;
-        private IFactory _factory;
+        private object? _context;
+        private IDockable? _owner;
+        private IFactory? _factory;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -65,7 +65,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public object Context
+        public object? Context
         {
             get => _context;
             set => SetAndRaise(ContextProperty, ref _context, value);
@@ -73,7 +73,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => SetAndRaise(OwnerProperty, ref _owner, value);
@@ -81,7 +81,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => SetAndRaise(FactoryProperty, ref _factory, value);

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -99,6 +99,6 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public abstract IDockable Clone();
+        public abstract IDockable? Clone();
     }
 }

--- a/src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj
+++ b/src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj
+++ b/src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Dock.Model.INPC/Controls/Document.cs
+++ b/src/Dock.Model.INPC/Controls/Document.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.INPC/Controls/DocumentDock.cs
+++ b/src/Dock.Model.INPC/Controls/DocumentDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneDocumentDock(this);
         }

--- a/src/Dock.Model.INPC/Controls/PinDock.cs
+++ b/src/Dock.Model.INPC/Controls/PinDock.cs
@@ -48,7 +48,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.ClonePinDock(this);
         }

--- a/src/Dock.Model.INPC/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.INPC/Controls/ProportionalDock.cs
@@ -30,7 +30,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneProportionalDock(this);
         }

--- a/src/Dock.Model.INPC/Controls/RootDock.cs
+++ b/src/Dock.Model.INPC/Controls/RootDock.cs
@@ -88,7 +88,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneRootDock(this);
         }

--- a/src/Dock.Model.INPC/Controls/RootDock.cs
+++ b/src/Dock.Model.INPC/Controls/RootDock.cs
@@ -11,16 +11,16 @@ namespace Dock.Model.Controls
     [DataContract(IsReference = true)]
     public class RootDock : DockBase, IRootDock
     {
-        private IDockWindow _window;
-        private IList<IDockWindow> _windows;
-        private IPinDock _top;
-        private IPinDock _bottom;
-        private IPinDock _left;
-        private IPinDock _right;
+        private IDockWindow? _window;
+        private IList<IDockWindow>? _windows;
+        private IPinDock? _top;
+        private IPinDock? _bottom;
+        private IPinDock? _left;
+        private IPinDock? _right;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockWindow Window
+        public IDockWindow? Window
         {
             get => _window;
             set => this.RaiseAndSetIfChanged(ref _window, value);
@@ -28,7 +28,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockWindow> Windows
+        public IList<IDockWindow>? Windows
         {
             get => _windows;
             set => this.RaiseAndSetIfChanged(ref _windows, value);
@@ -36,7 +36,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Top
+        public IPinDock? Top
         {
             get => _top;
             set => this.RaiseAndSetIfChanged(ref _top, value);
@@ -44,7 +44,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Bottom
+        public IPinDock? Bottom
         {
             get => _bottom;
             set => this.RaiseAndSetIfChanged(ref _bottom, value);
@@ -52,7 +52,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Left
+        public IPinDock? Left
         {
             get => _left;
             set => this.RaiseAndSetIfChanged(ref _left, value);
@@ -60,7 +60,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Right
+        public IPinDock? Right
         {
             get => _right;
             set => this.RaiseAndSetIfChanged(ref _right, value);

--- a/src/Dock.Model.INPC/Controls/SplitterDock.cs
+++ b/src/Dock.Model.INPC/Controls/SplitterDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneSplitterDock(this);
         }

--- a/src/Dock.Model.INPC/Controls/Tool.cs
+++ b/src/Dock.Model.INPC/Controls/Tool.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.INPC/Controls/ToolDock.cs
+++ b/src/Dock.Model.INPC/Controls/ToolDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneToolDock(this);
         }

--- a/src/Dock.Model.INPC/Core/DockBase.cs
+++ b/src/Dock.Model.INPC/Core/DockBase.cs
@@ -12,12 +12,12 @@ namespace Dock.Model
     public abstract class DockBase : DockableBase, IDock
     {
         internal INavigateAdapter _navigateAdapter;
-        private IList<IDockable> _visibleDockables;
-        private IList<IDockable> _hiddenDockables;
-        private IList<IDockable> _pinnedDockables;
-        private IDockable _activeDockable;
-        private IDockable _defaultDockable;
-        private IDockable _focusedDockable;
+        private IList<IDockable>? _visibleDockables;
+        private IList<IDockable>? _hiddenDockables;
+        private IList<IDockable>? _pinnedDockables;
+        private IDockable? _activeDockable;
+        private IDockable? _defaultDockable;
+        private IDockable? _focusedDockable;
         private double _proportion = double.NaN;
         private bool _isActive;
         private bool _isCollapsable = true;
@@ -32,7 +32,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> VisibleDockables
+        public IList<IDockable>? VisibleDockables
         {
             get => _visibleDockables;
             set => this.RaiseAndSetIfChanged(ref _visibleDockables, value);
@@ -40,7 +40,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> HiddenDockables
+        public IList<IDockable>? HiddenDockables
         {
             get => _hiddenDockables;
             set => this.RaiseAndSetIfChanged(ref _hiddenDockables, value);
@@ -48,7 +48,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> PinnedDockables
+        public IList<IDockable>? PinnedDockables
         {
             get => _pinnedDockables;
             set => this.RaiseAndSetIfChanged(ref _pinnedDockables, value);
@@ -56,7 +56,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable ActiveDockable
+        public IDockable? ActiveDockable
         {
             get => _activeDockable;
             set
@@ -75,7 +75,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable DefaultDockable
+        public IDockable? DefaultDockable
         {
             get => _defaultDockable;
             set => this.RaiseAndSetIfChanged(ref _defaultDockable, value);
@@ -83,7 +83,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable FocusedDockable
+        public IDockable? FocusedDockable
         {
             get => _focusedDockable;
             set => this.RaiseAndSetIfChanged(ref _focusedDockable, value);

--- a/src/Dock.Model.INPC/Core/DockBase.cs
+++ b/src/Dock.Model.INPC/Core/DockBase.cs
@@ -64,10 +64,13 @@ namespace Dock.Model
                 this.RaiseAndSetIfChanged(ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory.UpdateDockable(value, this);
+                    Factory?.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory.SetFocusedDockable(this, value);
+                if (value != null)
+                {
+                    Factory?.SetFocusedDockable(this, value);
+                }
                 this.RaisePropertyChanged(nameof(CanGoBack));
                 this.RaisePropertyChanged(nameof(CanGoForward));
             }

--- a/src/Dock.Model.INPC/Core/DockBase.cs
+++ b/src/Dock.Model.INPC/Core/DockBase.cs
@@ -64,10 +64,10 @@ namespace Dock.Model
                 this.RaiseAndSetIfChanged(ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory?.UpdateDockable(value, this);
+                    Factory.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory?.SetFocusedDockable(this, value);
+                Factory.SetFocusedDockable(this, value);
                 this.RaisePropertyChanged(nameof(CanGoBack));
                 this.RaisePropertyChanged(nameof(CanGoForward));
             }

--- a/src/Dock.Model.INPC/Core/DockWindow.cs
+++ b/src/Dock.Model.INPC/Core/DockWindow.cs
@@ -19,10 +19,10 @@ namespace Dock.Model
         private double _height;
         private bool _topmost;
         private string _title;
-        private IDockable _owner;
-        private IFactory _factory;
-        private IRootDock _layout;
-        private IHostWindow _host;
+        private IDockable? _owner;
+        private IFactory? _factory;
+        private IRootDock? _layout;
+        private IHostWindow? _host;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -82,7 +82,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => this.RaiseAndSetIfChanged(ref _owner, value);
@@ -90,7 +90,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);
@@ -98,7 +98,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IRootDock Layout
+        public IRootDock? Layout
         {
             get => _layout;
             set => this.RaiseAndSetIfChanged(ref _layout, value);
@@ -106,7 +106,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IHostWindow Host
+        public IHostWindow? Host
         {
             get => _host;
             set => this.RaiseAndSetIfChanged(ref _host, value);

--- a/src/Dock.Model.INPC/Core/DockWindow.cs
+++ b/src/Dock.Model.INPC/Core/DockWindow.cs
@@ -141,7 +141,7 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public IDockWindow Clone()
+        public IDockWindow? Clone()
         {
             return CloneHelper.CloneDockWindow(this);
         }

--- a/src/Dock.Model.INPC/Core/DockableBase.cs
+++ b/src/Dock.Model.INPC/Core/DockableBase.cs
@@ -12,9 +12,9 @@ namespace Dock.Model
     {
         private string _id;
         private string _title;
-        private object _context;
-        private IDockable _owner;
-        private IFactory _factory;
+        private object? _context;
+        private IDockable? _owner;
+        private IFactory? _factory;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -34,7 +34,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public object Context
+        public object? Context
         {
             get => _context;
             set => this.RaiseAndSetIfChanged(ref _context, value);
@@ -42,7 +42,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => this.RaiseAndSetIfChanged(ref _owner, value);
@@ -50,7 +50,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);

--- a/src/Dock.Model.INPC/Core/DockableBase.cs
+++ b/src/Dock.Model.INPC/Core/DockableBase.cs
@@ -68,6 +68,6 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public abstract IDockable Clone();
+        public abstract IDockable? Clone();
     }
 }

--- a/src/Dock.Model.INPC/Core/DockableBase.cs
+++ b/src/Dock.Model.INPC/Core/DockableBase.cs
@@ -10,8 +10,8 @@ namespace Dock.Model
     [DataContract(IsReference = true)]
     public abstract class DockableBase : ObservableObject, IDockable
     {
-        private string _id;
-        private string _title;
+        private string _id = string.Empty;
+        private string _title = string.Empty;
         private object? _context;
         private IDockable? _owner;
         private IFactory? _factory;

--- a/src/Dock.Model.INPC/Dock.Model.INPC.csproj
+++ b/src/Dock.Model.INPC/Dock.Model.INPC.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Model.INPC/Dock.Model.INPC.csproj
+++ b/src/Dock.Model.INPC/Dock.Model.INPC.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Dock.Model.INPC/ObservableObject.cs
+++ b/src/Dock.Model.INPC/ObservableObject.cs
@@ -13,8 +13,9 @@ namespace Dock.Model
         /// <summary>
         /// Occurs when a property value changes.
         /// </summary>
+#pragma warning disable CS8618
         public event PropertyChangedEventHandler PropertyChanged;
-
+#pragma warning restore CS8618
         /// <summary>
         /// Notify observers about property changes.
         /// </summary>

--- a/src/Dock.Model.INPC/ObservableObject.cs
+++ b/src/Dock.Model.INPC/ObservableObject.cs
@@ -19,7 +19,7 @@ namespace Dock.Model
         /// Notify observers about property changes.
         /// </summary>
         /// <param name="propertyName">The property name that changed.</param>
-        public void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+        public void RaisePropertyChanged([CallerMemberName] string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
@@ -32,7 +32,7 @@ namespace Dock.Model
         /// <param name="value">The new field value.</param>
         /// <param name="propertyName">The property name that changed.</param>
         /// <returns>True if backing field value changed.</returns>
-        public bool RaiseAndSetIfChanged<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        public bool RaiseAndSetIfChanged<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
         {
             if (!Equals(field, value))
             {

--- a/src/Dock.Model.ReactiveUI/Controls/Document.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/Document.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneDocumentDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
@@ -49,7 +49,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.ClonePinDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ProportionalDock.cs
@@ -31,7 +31,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneProportionalDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
@@ -89,7 +89,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneRootDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
@@ -12,16 +12,16 @@ namespace Dock.Model.Controls
     [DataContract(IsReference = true)]
     public class RootDock : DockBase, IRootDock
     {
-        private IDockWindow _window;
-        private IList<IDockWindow> _windows;
-        private IPinDock _top;
-        private IPinDock _bottom;
-        private IPinDock _left;
-        private IPinDock _right;
+        private IDockWindow? _window;
+        private IList<IDockWindow>? _windows;
+        private IPinDock? _top;
+        private IPinDock? _bottom;
+        private IPinDock? _left;
+        private IPinDock? _right;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockWindow Window
+        public IDockWindow? Window
         {
             get => _window;
             set => this.RaiseAndSetIfChanged(ref _window, value);
@@ -29,7 +29,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockWindow> Windows
+        public IList<IDockWindow>? Windows
         {
             get => _windows;
             set => this.RaiseAndSetIfChanged(ref _windows, value);
@@ -37,7 +37,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Top
+        public IPinDock? Top
         {
             get => _top;
             set => this.RaiseAndSetIfChanged(ref _top, value);
@@ -45,7 +45,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Bottom
+        public IPinDock? Bottom
         {
             get => _bottom;
             set => this.RaiseAndSetIfChanged(ref _bottom, value);
@@ -53,7 +53,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Left
+        public IPinDock? Left
         {
             get => _left;
             set => this.RaiseAndSetIfChanged(ref _left, value);
@@ -61,7 +61,7 @@ namespace Dock.Model.Controls
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IPinDock Right
+        public IPinDock? Right
         {
             get => _right;
             set => this.RaiseAndSetIfChanged(ref _right, value);

--- a/src/Dock.Model.ReactiveUI/Controls/SplitterDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/SplitterDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneSplitterDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Controls/Tool.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/Tool.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/src/Dock.Model.ReactiveUI/Controls/ToolDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ToolDock.cs
@@ -20,7 +20,7 @@ namespace Dock.Model.Controls
         }
 
         /// <inheritdoc/>
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return CloneHelper.CloneToolDock(this);
         }

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -13,12 +13,12 @@ namespace Dock.Model
     public abstract class DockBase : DockableBase, IDock
     {
         internal INavigateAdapter _navigateAdapter;
-        private IList<IDockable> _visibleDockables;
-        private IList<IDockable> _hiddenDockables;
-        private IList<IDockable> _pinnedDockables;
-        private IDockable _activeDockable;
-        private IDockable _defaultDockable;
-        private IDockable _focusedDockable;
+        private IList<IDockable>? _visibleDockables;
+        private IList<IDockable>? _hiddenDockables;
+        private IList<IDockable>? _pinnedDockables;
+        private IDockable? _activeDockable;
+        private IDockable? _defaultDockable;
+        private IDockable? _focusedDockable;
         private double _proportion = double.NaN;
         private bool _isCollapsable = true;
         private bool _isActive;
@@ -33,7 +33,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> VisibleDockables
+        public IList<IDockable>? VisibleDockables
         {
             get => _visibleDockables;
             set => this.RaiseAndSetIfChanged(ref _visibleDockables, value);
@@ -41,7 +41,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> HiddenDockables
+        public IList<IDockable>? HiddenDockables
         {
             get => _hiddenDockables;
             set => this.RaiseAndSetIfChanged(ref _hiddenDockables, value);
@@ -49,7 +49,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IList<IDockable> PinnedDockables
+        public IList<IDockable>? PinnedDockables
         {
             get => _pinnedDockables;
             set => this.RaiseAndSetIfChanged(ref _pinnedDockables, value);
@@ -57,7 +57,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable ActiveDockable
+        public IDockable? ActiveDockable
         {
             get => _activeDockable;
             set
@@ -65,10 +65,10 @@ namespace Dock.Model
                 this.RaiseAndSetIfChanged(ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory?.UpdateDockable(value, this);
+                    Factory.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory?.SetFocusedDockable(this, value);
+                Factory.SetFocusedDockable(this, value);
                 this.RaisePropertyChanged(nameof(CanGoBack));
                 this.RaisePropertyChanged(nameof(CanGoForward));
             }
@@ -76,7 +76,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable DefaultDockable
+        public IDockable? DefaultDockable
         {
             get => _defaultDockable;
             set => this.RaiseAndSetIfChanged(ref _defaultDockable, value);
@@ -84,7 +84,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IDockable FocusedDockable
+        public IDockable? FocusedDockable
         {
             get => _focusedDockable;
             set => this.RaiseAndSetIfChanged(ref _focusedDockable, value);

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -65,10 +65,10 @@ namespace Dock.Model
                 this.RaiseAndSetIfChanged(ref _activeDockable, value);
                 if (value != null)
                 {
-                    Factory.UpdateDockable(value, this);
+                    Factory?.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory.SetFocusedDockable(this, value);
+                Factory?.SetFocusedDockable(this, value);
                 this.RaisePropertyChanged(nameof(CanGoBack));
                 this.RaisePropertyChanged(nameof(CanGoForward));
             }

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -68,7 +68,10 @@ namespace Dock.Model
                     Factory?.UpdateDockable(value, this);
                     value.OnSelected();
                 }
-                Factory?.SetFocusedDockable(this, value);
+                if (value != null)
+                {
+                    Factory?.SetFocusedDockable(this, value);
+                }
                 this.RaisePropertyChanged(nameof(CanGoBack));
                 this.RaisePropertyChanged(nameof(CanGoForward));
             }

--- a/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
@@ -20,10 +20,10 @@ namespace Dock.Model
         private double _height;
         private bool _topmost;
         private string _title;
-        private IDockable _owner;
-        private IFactory _factory;
-        private IRootDock _layout;
-        private IHostWindow _host;
+        private IDockable? _owner;
+        private IFactory? _factory;
+        private IRootDock? _layout;
+        private IHostWindow? _host;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -83,7 +83,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => this.RaiseAndSetIfChanged(ref _owner, value);
@@ -91,7 +91,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);
@@ -99,7 +99,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
-        public IRootDock Layout
+        public IRootDock? Layout
         {
             get => _layout;
             set => this.RaiseAndSetIfChanged(ref _layout, value);
@@ -107,7 +107,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IHostWindow Host
+        public IHostWindow? Host
         {
             get => _host;
             set => this.RaiseAndSetIfChanged(ref _host, value);

--- a/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
@@ -142,7 +142,7 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public IDockWindow Clone()
+        public IDockWindow? Clone()
         {
             return CloneHelper.CloneDockWindow(this);
         }

--- a/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
@@ -69,6 +69,6 @@ namespace Dock.Model
         }
 
         /// <inheritdoc/>
-        public abstract IDockable Clone();
+        public abstract IDockable? Clone();
     }
 }

--- a/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
@@ -11,11 +11,11 @@ namespace Dock.Model
     [DataContract(IsReference = true)]
     public abstract class DockableBase : ReactiveObject, IDockable
     {
-        private string _id;
-        private string _title;
-        private object _context;
-        private IDockable _owner;
-        private IFactory _factory;
+        private string _id = string.Empty;
+        private string _title = string.Empty;
+        private object? _context;
+        private IDockable? _owner;
+        private IFactory? _factory;
 
         /// <inheritdoc/>
         [DataMember(IsRequired = false, EmitDefaultValue = true)]
@@ -35,7 +35,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public object Context
+        public object? Context
         {
             get => _context;
             set => this.RaiseAndSetIfChanged(ref _context, value);
@@ -43,7 +43,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IDockable Owner
+        public IDockable? Owner
         {
             get => _owner;
             set => this.RaiseAndSetIfChanged(ref _owner, value);
@@ -51,7 +51,7 @@ namespace Dock.Model
 
         /// <inheritdoc/>
         [IgnoreDataMember]
-        public IFactory Factory
+        public IFactory? Factory
         {
             get => _factory;
             set => this.RaiseAndSetIfChanged(ref _factory, value);

--- a/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
+++ b/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
+++ b/src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Dock.Model/Adapters/HostAdapter.cs
+++ b/src/Dock.Model/Adapters/HostAdapter.cs
@@ -37,6 +37,11 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void Present(bool isDialog)
         {
+            if (_window.Layout == null)
+            {
+                return;
+            }
+
             if (_window.Host == null)
             {
                 _window.Host = _window.Factory?.GetHostWindow(_window.Id);

--- a/src/Dock.Model/Adapters/HostAdapter.cs
+++ b/src/Dock.Model/Adapters/HostAdapter.cs
@@ -22,7 +22,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void Save()
         {
-            if (_window.Host != null)
+            if (!(_window.Host is null))
             {
                 _window.Host.GetPosition(out double x, out double y);
                 _window.X = x;
@@ -37,21 +37,21 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void Present(bool isDialog)
         {
-            if (_window.Layout == null)
+            if (_window.Layout is null)
             {
                 return;
             }
 
-            if (_window.Host == null)
+            if (_window.Host is null)
             {
                 _window.Host = _window.Factory?.GetHostWindow(_window.Id);
-                if (_window.Host != null)
+                if (!(_window.Host is null))
                 {
                     _window.Host.Window = this._window;
                 }
             }
 
-            if (_window.Host != null)
+            if (!(_window.Host is null))
             {
                 _window.Host.Present(isDialog);
                 _window.Host.SetPosition(_window.X, _window.Y);
@@ -66,7 +66,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void Exit()
         {
-            if (_window.Host != null)
+            if (!(_window.Host is null))
             {
                 Save();
                 _window.Host.IsTracked = false;

--- a/src/Dock.Model/Adapters/NavigateAdapter.cs
+++ b/src/Dock.Model/Adapters/NavigateAdapter.cs
@@ -14,7 +14,7 @@ namespace Dock.Model
             return e.SelectMany(c =>
             {
                 var r = f(c);
-                if (r == null)
+                if (r is null)
                     return Enumerable.Empty<T>();
                 else
                     return r.Flatten(f);
@@ -54,7 +54,7 @@ namespace Dock.Model
             if (_back.Count > 0)
             {
                 var root = _back.Pop();
-                if (_dock.ActiveDockable != null)
+                if (!(_dock.ActiveDockable is null))
                 {
                     _forward.Push(_dock.ActiveDockable);
                 }
@@ -68,7 +68,7 @@ namespace Dock.Model
             if (_forward.Count > 0)
             {
                 var root = _forward.Pop();
-                if (_dock.ActiveDockable != null)
+                if (!(_dock.ActiveDockable is null))
                 {
                     _back.Push(_dock.ActiveDockable);
                 }
@@ -132,9 +132,9 @@ namespace Dock.Model
                 previousDock.Close();
             }
 
-            if (dockable != null && _dock.ActiveDockable != dockable)
+            if (!(dockable is null) && _dock.ActiveDockable != dockable)
             {
-                if (_dock.ActiveDockable != null && bSnapshot == true)
+                if (!(_dock.ActiveDockable is null) && bSnapshot == true)
                 {
                     PushBack(_dock.ActiveDockable);
                 }
@@ -157,7 +157,7 @@ namespace Dock.Model
         private void NavigateToUseVisible(string id, bool bSnapshot)
         {
             var result = _dock.VisibleDockables.FirstOrDefault(v => v.Id == id);
-            if (result != null)
+            if (!(result is null))
             {
                 Navigate(result, bSnapshot);
             }
@@ -169,7 +169,7 @@ namespace Dock.Model
 
         private void NavigateToUseAllVisible(string id, bool bSnapshot)
         {
-            if (_dock.VisibleDockables == null)
+            if (_dock.VisibleDockables is null)
             {
                 return;
             }
@@ -184,7 +184,7 @@ namespace Dock.Model
             });
 
             var result = visible?.FirstOrDefault(v => v.Id == id);
-            if (result != null)
+            if (!(result is null))
             {
                 Navigate(result, bSnapshot);
             }
@@ -193,7 +193,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void ShowWindows()
         {
-            if (_dock is IRootDock rootDock && rootDock.Windows != null)
+            if (_dock is IRootDock rootDock && !(rootDock.Windows is null))
             {
                 foreach (var window in rootDock.Windows)
                 {
@@ -209,7 +209,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public void ExitWindows()
         {
-            if (_dock is IRootDock rootDock && rootDock.Windows != null)
+            if (_dock is IRootDock rootDock && !(rootDock.Windows is null))
             {
                 foreach (var window in rootDock.Windows)
                 {

--- a/src/Dock.Model/Adapters/NavigateAdapter.cs
+++ b/src/Dock.Model/Adapters/NavigateAdapter.cs
@@ -9,7 +9,7 @@ namespace Dock.Model
 {
     internal static class EnumerableExtensions
     {
-        public static IEnumerable<T> Flatten<T>(this IEnumerable<T> e, Func<T, IEnumerable<T>> f)
+        public static IEnumerable<T>? Flatten<T>(this IEnumerable<T> e, Func<T, IEnumerable<T>?> f)
         {
             return e.SelectMany(c =>
             {
@@ -169,6 +169,11 @@ namespace Dock.Model
 
         private void NavigateToUseAllVisible(string id, bool bSnapshot)
         {
+            if (_dock.VisibleDockables == null)
+            {
+                return;
+            }
+
             var visible = _dock.VisibleDockables.Flatten(v =>
             {
                 if (v is IDock n)
@@ -177,7 +182,8 @@ namespace Dock.Model
                 }
                 return null;
             });
-            var result = visible.FirstOrDefault(v => v.Id == id);
+
+            var result = visible?.FirstOrDefault(v => v.Id == id);
             if (result != null)
             {
                 Navigate(result, bSnapshot);

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -23,38 +23,50 @@ namespace Dock.Model
             target.IsActive = source.IsActive;
             target.IsCollapsable = source.IsCollapsable;
 
-            if (source.VisibleDockables != null)
+            if (!(source.VisibleDockables is null))
             {
                 target.VisibleDockables = source.Factory?.CreateList<IDockable>();
-                if (target.VisibleDockables != null)
+                if (!(target.VisibleDockables is null))
                 {
                     foreach (var visible in source.VisibleDockables)
                     {
-                        target.VisibleDockables.Add(visible.Clone());
+                        var clone = visible.Clone();
+                        if (!(clone is null))
+                        {
+                            target.VisibleDockables.Add(clone);
+                        }
                     }
                 }
             }
 
-            if (source.HiddenDockables != null)
+            if (!(source.HiddenDockables is null))
             {
                 target.HiddenDockables = source.Factory?.CreateList<IDockable>();
                 if (target.HiddenDockables != null)
                 {
                     foreach (var hidden in source.HiddenDockables)
                     {
-                        target.HiddenDockables.Add(hidden.Clone());
+                        var clone = hidden.Clone();
+                        if (!(clone is null))
+                        {
+                            target.HiddenDockables.Add(clone);
+                        }
                     }
                 }
             }
 
-            if (source.PinnedDockables != null)
+            if (!(source.PinnedDockables is null))
             {
                 target.PinnedDockables = source.Factory?.CreateList<IDockable>();
-                if (target.PinnedDockables != null)
+                 if (!(target.PinnedDockables is null))
                 {
                     foreach (var pinned in source.PinnedDockables)
                     {
-                        target.PinnedDockables.Add(pinned.Clone());
+                        var clone = pinned.Clone();
+                        if (!(clone is null))
+                        {
+                            target.PinnedDockables.Add(clone);
+                        }
                     }
                 }
             }

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -102,7 +102,7 @@ namespace Dock.Model
 
             if (source.Windows != null)
             {
-                target.Windows = source.Factory.CreateList<IDockWindow>();
+                target.Windows = source.Factory?.CreateList<IDockWindow>();
                 if (target.Windows == null)
                 {
                     throw new Exception($"Could not create {nameof(target.Windows)} list.");
@@ -164,12 +164,15 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IRootDock"/> class.</returns>
-        public static IRootDock CloneRootDock(IRootDock source)
+        public static IRootDock? CloneRootDock(IRootDock source)
         {
-            var target = source.Factory.CreateRootDock();
+            var target = source.Factory?.CreateRootDock();
 
-            CloneDockProperties(source, target);
-            CloneRootDockProperties(source, target);
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+                CloneRootDockProperties(source, target);
+            }
 
             return target;
         }
@@ -179,12 +182,15 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IPinDock"/> class.</returns>
-        public static IPinDock ClonePinDock(IPinDock source)
+        public static IPinDock? ClonePinDock(IPinDock source)
         {
-            var target = source.Factory.CreatePinDock();
+            var target = source.Factory?.CreatePinDock();
 
-            CloneDockProperties(source, target);
-            ClonePinDockProperties(source, target);
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+                ClonePinDockProperties(source, target);
+            }
 
             return target;
         }
@@ -194,12 +200,15 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IProportionalDock"/> class.</returns>
-        public static IProportionalDock CloneProportionalDock(IProportionalDock source)
+        public static IProportionalDock? CloneProportionalDock(IProportionalDock source)
         {
-            var target = source.Factory.CreateProportionalDock();
+            var target = source.Factory?.CreateProportionalDock();
 
-            CloneDockProperties(source, target);
-            CloneProportionalDockProperties(source, target);
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+                CloneProportionalDockProperties(source, target);
+            }
 
             return target;
         }
@@ -209,11 +218,15 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="ISplitterDock"/> class.</returns>
-        public static ISplitterDock CloneSplitterDock(ISplitterDock source)
+        public static ISplitterDock? CloneSplitterDock(ISplitterDock source)
         {
-            var target = source.Factory.CreateSplitterDock();
+            var target = source.Factory?.CreateSplitterDock();
 
-            CloneDockProperties(source, target);
+
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+            }
 
             return target;
         }
@@ -223,11 +236,14 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IToolDock"/> class.</returns>
-        public static IToolDock CloneToolDock(IToolDock source)
+        public static IToolDock? CloneToolDock(IToolDock source)
         {
-            var target = source.Factory.CreateToolDock();
+            var target = source.Factory?.CreateToolDock();
 
-            CloneDockProperties(source, target);
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+            }
 
             return target;
         }
@@ -237,11 +253,14 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IDocumentDock"/> class.</returns>
-        public static IDocumentDock CloneDocumentDock(IDocumentDock source)
+        public static IDocumentDock? CloneDocumentDock(IDocumentDock source)
         {
-            var target = source.Factory.CreateDocumentDock();
+            var target = source.Factory?.CreateDocumentDock();
 
-            CloneDockProperties(source, target);
+            if (target != null)
+            {
+                CloneDockProperties(source, target);
+            }
 
             return target;
         }
@@ -251,13 +270,15 @@ namespace Dock.Model
         /// </summary>
         /// <param name="source">The source object.</param>
         /// <returns>TThe new instance or reference of the <see cref="IDockWindow"/> class.</returns>
-        public static IDockWindow CloneDockWindow(IDockWindow source)
+        public static IDockWindow? CloneDockWindow(IDockWindow source)
         {
             source.Save();
 
-            var target = source.Factory.CreateDockWindow();
-
-            CloneDockWindowProperties(source, target);
+            var target = source.Factory?.CreateDockWindow();
+            if (target != null)
+            {
+                CloneDockWindowProperties(source, target);
+            }
 
             return target;
         }

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -95,10 +95,26 @@ namespace Dock.Model
         public static void CloneRootDockProperties(IRootDock source, IRootDock target)
         {
             target.Window = null;
-            target.Top = (IPinDock)source.Top?.Clone();
-            target.Bottom = (IPinDock)source.Bottom?.Clone();
-            target.Left = (IPinDock)source.Left?.Clone();
-            target.Right = (IPinDock)source.Right?.Clone();
+
+            if (source.Top != null)
+            {
+                target.Top = (IPinDock)source.Top.Clone();
+            }
+
+            if (source.Bottom != null)
+            {
+                target.Bottom = (IPinDock)source.Bottom.Clone();
+            }
+
+            if (source.Left != null)
+            {
+                target.Left = (IPinDock)source.Left.Clone();
+            }
+
+            if (source.Right != null)
+            {
+                target.Right = (IPinDock)source.Right.Clone();
+            }
 
             if (source.Windows != null)
             {
@@ -152,7 +168,11 @@ namespace Dock.Model
             target.Topmost = source.Topmost;
             target.Title = source.Title;
 
-            target.Layout = (IRootDock)source.Layout?.Clone();
+            if (source.Layout != null)
+            {
+                target.Layout = (IRootDock)source.Layout.Clone();
+            }
+
             if (target.Layout != null)
             {
                 target.Layout.Window = target;

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -42,7 +42,7 @@ namespace Dock.Model
             if (!(source.HiddenDockables is null))
             {
                 target.HiddenDockables = source.Factory?.CreateList<IDockable>();
-                if (target.HiddenDockables != null)
+                if (!(target.HiddenDockables is null))
                 {
                     foreach (var hidden in source.HiddenDockables)
                     {
@@ -58,7 +58,7 @@ namespace Dock.Model
             if (!(source.PinnedDockables is null))
             {
                 target.PinnedDockables = source.Factory?.CreateList<IDockable>();
-                 if (!(target.PinnedDockables is null))
+                if (!(target.PinnedDockables is null))
                 {
                     foreach (var pinned in source.PinnedDockables)
                     {
@@ -71,7 +71,7 @@ namespace Dock.Model
                 }
             }
 
-            if (source.ActiveDockable != null && source.VisibleDockables != null)
+            if (!(source.ActiveDockable is null) && !(source.VisibleDockables is null))
             {
                 int indexActiveDockable = source.VisibleDockables.IndexOf(source.ActiveDockable);
                 if (indexActiveDockable >= 0)
@@ -80,7 +80,7 @@ namespace Dock.Model
                 }
             }
 
-            if (source.DefaultDockable != null && source.VisibleDockables != null)
+            if (!(source.DefaultDockable is null) && !(source.VisibleDockables is null))
             {
                 int indexDefaultDockable = source.VisibleDockables.IndexOf(source.DefaultDockable);
                 if (indexDefaultDockable >= 0)
@@ -89,7 +89,7 @@ namespace Dock.Model
                 }
             }
 
-            if (source.FocusedDockable != null && source.VisibleDockables != null)
+            if (!(source.FocusedDockable is null) && !(source.VisibleDockables is null))
             {
                 int indexFocusedDockable = source.VisibleDockables.IndexOf(source.FocusedDockable);
                 if (indexFocusedDockable >= 0)
@@ -108,37 +108,39 @@ namespace Dock.Model
         {
             target.Window = null;
 
-            if (source.Top != null)
+            if (!(source.Top is null))
             {
-                target.Top = (IPinDock)source.Top.Clone();
+                target.Top = (IPinDock?)source.Top.Clone();
             }
 
-            if (source.Bottom != null)
+            if (!(source.Bottom is null))
             {
-                target.Bottom = (IPinDock)source.Bottom.Clone();
+                target.Bottom = (IPinDock?)source.Bottom.Clone();
             }
 
-            if (source.Left != null)
+            if (!(source.Left is null))
             {
-                target.Left = (IPinDock)source.Left.Clone();
+                target.Left = (IPinDock?)source.Left.Clone();
             }
 
-            if (source.Right != null)
+            if (!(source.Right is null))
             {
-                target.Right = (IPinDock)source.Right.Clone();
+                target.Right = (IPinDock?)source.Right.Clone();
             }
 
-            if (source.Windows != null)
+            if (!(source.Windows is null))
             {
                 target.Windows = source.Factory?.CreateList<IDockWindow>();
-                if (target.Windows == null)
+                if (!(target.Windows is null))
                 {
-                    throw new Exception($"Could not create {nameof(target.Windows)} list.");
-                }
-
-                foreach (var window in source.Windows)
-                {
-                    target.Windows.Add(window.Clone());
+                    foreach (var window in source.Windows)
+                    {
+                        var clone = window.Clone();
+                        if (!(clone is null))
+                        {
+                            target.Windows.Add(clone);
+                        }
+                    }
                 }
             }
         }
@@ -180,12 +182,12 @@ namespace Dock.Model
             target.Topmost = source.Topmost;
             target.Title = source.Title;
 
-            if (source.Layout != null)
+            if (!(source.Layout is null))
             {
-                target.Layout = (IRootDock)source.Layout.Clone();
+                target.Layout = (IRootDock?)source.Layout.Clone();
             }
 
-            if (target.Layout != null)
+            if (!(target.Layout is null))
             {
                 target.Layout.Window = target;
             }
@@ -200,7 +202,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreateRootDock();
 
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
                 CloneRootDockProperties(source, target);
@@ -218,7 +220,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreatePinDock();
 
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
                 ClonePinDockProperties(source, target);
@@ -236,7 +238,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreateProportionalDock();
 
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
                 CloneProportionalDockProperties(source, target);
@@ -254,8 +256,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreateSplitterDock();
 
-
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
             }
@@ -272,7 +273,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreateToolDock();
 
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
             }
@@ -289,7 +290,7 @@ namespace Dock.Model
         {
             var target = source.Factory?.CreateDocumentDock();
 
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockProperties(source, target);
             }
@@ -307,7 +308,7 @@ namespace Dock.Model
             source.Save();
 
             var target = source.Factory?.CreateDockWindow();
-            if (target != null)
+            if (!(target is null))
             {
                 CloneDockWindowProperties(source, target);
             }

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 using Dock.Model.Controls;
 
 namespace Dock.Model
@@ -24,49 +25,64 @@ namespace Dock.Model
 
             if (source.VisibleDockables != null)
             {
-                target.VisibleDockables = source.Factory.CreateList<IDockable>();
-                foreach (var visible in source.VisibleDockables)
+                target.VisibleDockables = source.Factory?.CreateList<IDockable>();
+                if (target.VisibleDockables != null)
                 {
-                    target.VisibleDockables.Add(visible.Clone());
+                    foreach (var visible in source.VisibleDockables)
+                    {
+                        target.VisibleDockables.Add(visible.Clone());
+                    }
                 }
             }
 
             if (source.HiddenDockables != null)
             {
-                target.HiddenDockables = source.Factory.CreateList<IDockable>();
-                foreach (var hidden in source.HiddenDockables)
+                target.HiddenDockables = source.Factory?.CreateList<IDockable>();
+                if (target.HiddenDockables != null)
                 {
-                    target.HiddenDockables.Add(hidden.Clone());
+                    foreach (var hidden in source.HiddenDockables)
+                    {
+                        target.HiddenDockables.Add(hidden.Clone());
+                    }
                 }
             }
 
             if (source.PinnedDockables != null)
             {
-                target.PinnedDockables = source.Factory.CreateList<IDockable>();
-                foreach (var pinned in source.PinnedDockables)
+                target.PinnedDockables = source.Factory?.CreateList<IDockable>();
+                if (target.PinnedDockables != null)
                 {
-                    target.PinnedDockables.Add(pinned.Clone());
+                    foreach (var pinned in source.PinnedDockables)
+                    {
+                        target.PinnedDockables.Add(pinned.Clone());
+                    }
                 }
             }
 
-            if (source.VisibleDockables != null)
+            if (source.ActiveDockable != null && source.VisibleDockables != null)
             {
                 int indexActiveDockable = source.VisibleDockables.IndexOf(source.ActiveDockable);
                 if (indexActiveDockable >= 0)
                 {
-                    target.ActiveDockable = target.VisibleDockables[indexActiveDockable];
+                    target.ActiveDockable = target.VisibleDockables?[indexActiveDockable];
                 }
+            }
 
+            if (source.DefaultDockable != null && source.VisibleDockables != null)
+            {
                 int indexDefaultDockable = source.VisibleDockables.IndexOf(source.DefaultDockable);
                 if (indexDefaultDockable >= 0)
                 {
-                    target.DefaultDockable = target.VisibleDockables[indexDefaultDockable];
+                    target.DefaultDockable = target.VisibleDockables?[indexDefaultDockable];
                 }
+            }
 
+            if (source.FocusedDockable != null && source.VisibleDockables != null)
+            {
                 int indexFocusedDockable = source.VisibleDockables.IndexOf(source.FocusedDockable);
                 if (indexFocusedDockable >= 0)
                 {
-                    target.FocusedDockable = target.VisibleDockables[indexFocusedDockable];
+                    target.FocusedDockable = target.VisibleDockables?[indexFocusedDockable];
                 }
             }
         }
@@ -87,6 +103,11 @@ namespace Dock.Model
             if (source.Windows != null)
             {
                 target.Windows = source.Factory.CreateList<IDockWindow>();
+                if (target.Windows == null)
+                {
+                    throw new Exception($"Could not create {nameof(target.Windows)} list.");
+                }
+
                 foreach (var window in source.Windows)
                 {
                     target.Windows.Add(window.Clone());

--- a/src/Dock.Model/Controls/IRootDock.cs
+++ b/src/Dock.Model/Controls/IRootDock.cs
@@ -13,32 +13,32 @@ namespace Dock.Model.Controls
         /// <summary>
         /// Gets or sets owner window.
         /// </summary>
-        IDockWindow Window { get; set; }
+        IDockWindow? Window { get; set; }
 
         /// <summary>
         /// Gets or sets windows.
         /// </summary>
-        IList<IDockWindow> Windows { get; set; }
+        IList<IDockWindow>? Windows { get; set; }
 
         /// <summary>
         /// Gets or sets top pin dock.
         /// </summary>
-        IPinDock Top { get; set; }
+        IPinDock? Top { get; set; }
 
         /// <summary>
         /// Gets or sets bottom pin dock.
         /// </summary>
-        IPinDock Bottom { get; set; }
+        IPinDock? Bottom { get; set; }
 
         /// <summary>
         /// Gets or sets left pin dock.
         /// </summary>
-        IPinDock Left { get; set; }
+        IPinDock? Left { get; set; }
 
         /// <summary>
         /// Gets or sets right pin dock.
         /// </summary>
-        IPinDock Right { get; set; }
+        IPinDock? Right { get; set; }
 
         /// <summary>
         /// Show windows.

--- a/src/Dock.Model/Core/IDock.cs
+++ b/src/Dock.Model/Core/IDock.cs
@@ -13,32 +13,32 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets visible dockables.
         /// </summary>
-        IList<IDockable> VisibleDockables { get; set; }
+        IList<IDockable>? VisibleDockables { get; set; }
 
         /// <summary>
         /// Gets or sets hidden dockables.
         /// </summary>
-        IList<IDockable> HiddenDockables { get; set; }
+        IList<IDockable>? HiddenDockables { get; set; }
 
         /// <summary>
         /// Gets or sets pinned dockables.
         /// </summary>
-        IList<IDockable> PinnedDockables { get; set; }
+        IList<IDockable>? PinnedDockables { get; set; }
 
         /// <summary>
         /// Gets or sets avtive dockable.
         /// </summary>
-        IDockable ActiveDockable { get; set; }
+        IDockable? ActiveDockable { get; set; }
 
         /// <summary>
         /// Gets or sets default dockable.
         /// </summary>
-        IDockable DefaultDockable { get; set; }
+        IDockable? DefaultDockable { get; set; }
 
         /// <summary>
         /// Gets or sets the focused dockable.
         /// </summary>
-        IDockable FocusedDockable { get; set; }
+        IDockable? FocusedDockable { get; set; }
 
         /// <summary> 
         /// Gets or sets splitter proportion. 

--- a/src/Dock.Model/Core/IDockWindow.cs
+++ b/src/Dock.Model/Core/IDockWindow.cs
@@ -85,6 +85,6 @@ namespace Dock.Model
         /// Clones <see cref="IDockWindow"/> object.
         /// </summary>
         /// <returns>The new instance or reference of the <see cref="IDockWindow"/> class.</returns>
-        IDockWindow Clone();
+        IDockWindow? Clone();
     }
 }

--- a/src/Dock.Model/Core/IDockWindow.cs
+++ b/src/Dock.Model/Core/IDockWindow.cs
@@ -48,22 +48,22 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets window owner dockable.
         /// </summary>
-        IDockable Owner { get; set; }
+        IDockable? Owner { get; set; }
 
         /// <summary>
         /// Gets or sets dock factory.
         /// </summary>
-        IFactory Factory { get; set; }
+        IFactory? Factory { get; set; }
 
         /// <summary>
         /// Gets or sets layout.
         /// </summary>
-        IRootDock Layout { get; set; }
+        IRootDock? Layout { get; set; }
 
         /// <summary>
         /// Gets or sets dock window.
         /// </summary>
-        IHostWindow Host { get; set; }
+        IHostWindow? Host { get; set; }
 
         /// <summary>
         /// Saves window properties.

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -21,18 +21,18 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets dockable context.
         /// </summary>
-        object Context { get; set; }
+        object? Context { get; set; }
 
         /// <summary>
         /// Gets or sets dockable owner.
         /// </summary>
         /// <remarks>If owner is null than dockable is root.</remarks>
-        IDockable Owner { get; set; }
+        IDockable? Owner { get; set; }
 
         /// <summary>
         /// Gets or sets dockable factory.
         /// </summary>
-        IFactory Factory { get; set; }
+        IFactory? Factory { get; set; }
 
         /// <summary>
         /// Called when the dockable is closed.

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -26,7 +26,6 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets dockable owner.
         /// </summary>
-        /// <remarks>If owner is null than dockable is root.</remarks>
         IDockable? Owner { get; set; }
 
         /// <summary>

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -49,6 +49,6 @@ namespace Dock.Model
         /// Clones <see cref="IDockable"/> object.
         /// </summary>
         /// <returns>The new instance or reference of the <see cref="IDockable"/> class.</returns>
-        IDockable Clone();
+        IDockable? Clone();
     }
 }

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -14,17 +14,17 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets <see cref="IDockable.Context"/> locator registry.
         /// </summary>
-        IDictionary<string, Func<object>> ContextLocator { get; set; }
+        IDictionary<string, Func<object>>? ContextLocator { get; set; }
 
         /// <summary>
         /// Gets or sets <see cref="IHostWindow"/> locator registry.
         /// </summary>
-        IDictionary<string, Func<IHostWindow>> HostWindowLocator { get; set; }
+        IDictionary<string, Func<IHostWindow>>? HostWindowLocator { get; set; }
 
         /// <summary>
         /// Gets or sets <see cref="IDockable"/> locator registry.
         /// </summary>
-        IDictionary<string, Func<IDockable>> DockableLocator { get; set; }
+        IDictionary<string, Func<IDockable>>? DockableLocator { get; set; }
 
         /// <summary>
         /// Creates list of type <see cref="IList{T}"/>.
@@ -87,21 +87,21 @@ namespace Dock.Model
         /// </summary>
         /// <param name="id">The object id.</param>
         /// <returns>The located context.</returns>
-        object GetContext(string id);
+        object? GetContext(string id);
 
         /// <summary>
         /// Gets registered host window.
         /// </summary>
         /// <param name="id">The host id.</param>
         /// <returns>The located host.</returns>
-        IHostWindow GetHostWindow(string id);
+        IHostWindow? GetHostWindow(string id);
 
         /// <summary>
         /// Gets registered dockable.
         /// </summary>
         /// <param name="id">The host id.</param>
         /// <returns>The located dockable.</returns>
-        IDockable GetDockable(string id);
+        IDockable? GetDockable(string id);
 
         /// <summary>
         /// Initialize layout.
@@ -114,14 +114,14 @@ namespace Dock.Model
         /// </summary>
         /// <param name="window">The window to update.</param>
         /// <param name="owner">The window owner dockable.</param>
-        void UpdateDockWindow(IDockWindow window, IDockable owner);
+        void UpdateDockWindow(IDockWindow window, IDockable? owner);
 
         /// <summary>
         /// Updates dockable.
         /// </summary>
         /// <param name="dockable">The dockable to update.</param>
         /// <param name="owner">The owner dockable.</param>
-        void UpdateDockable(IDockable dockable, IDockable owner);
+        void UpdateDockable(IDockable dockable, IDockable? owner);
 
         /// <summary>
         /// Adds <see cref="IDockable"/> into dock <see cref="IDock.VisibleDockables"/> collection.
@@ -170,7 +170,7 @@ namespace Dock.Model
         /// </summary>
         /// <param name="dockable">The dockable to find root for.</param>
         /// <returns>The root dockable instance or null if root dockable was not found.</returns>
-        IRootDock FindRoot(IDockable dockable);
+        IRootDock? FindRoot(IDockable dockable);
 
         /// <summary>
         /// Searches dock for dockable.
@@ -178,7 +178,7 @@ namespace Dock.Model
         /// <param name="dock">The dock.</param>
         /// <param name="predicate">The predicate to filter dockables.</param>
         /// <returns>The dockable instance or null if dockable was not found.</returns>
-        IDockable FindDockable(IDock dock, Func<IDockable, bool> predicate);
+        IDockable? FindDockable(IDock dock, Func<IDockable, bool> predicate);
 
         /// <summary>
         /// Pins dockable.
@@ -222,7 +222,7 @@ namespace Dock.Model
         /// <param name="targetDock">The target dock.</param>
         /// <param name="sourceDockable">The source dockable.</param>
         /// <param name="targetDockable">The target dockable.</param>
-        void MoveDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable targetDockable);
+        void MoveDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable? targetDockable);
 
         /// <summary>
         /// Swaps dockable into between <see cref="IDock.VisibleDockables"/> collections.
@@ -255,7 +255,7 @@ namespace Dock.Model
         /// </summary>
         /// <param name="dockable">The dockable to embed into window.</param>
         /// <returns>The new instance of the <see cref="IDockWindow"/> class.</returns>
-        IDockWindow CreateWindowFrom(IDockable dockable);
+        IDockWindow? CreateWindowFrom(IDockable dockable);
 
         /// <summary>
         /// Splits dock to the <see cref="DockOperation.Window"/> and updates <see cref="IDockable.Owner"/> layout.

--- a/src/Dock.Model/Core/IHostWindow.cs
+++ b/src/Dock.Model/Core/IHostWindow.cs
@@ -16,7 +16,7 @@ namespace Dock.Model
         /// <summary>
         /// Gets or sets dock window.
         /// </summary>
-        IDockWindow Window { get; set; }
+        IDockWindow? Window { get; set; }
 
         /// <summary>
         /// Presents host.

--- a/src/Dock.Model/Dock.Model.csproj
+++ b/src/Dock.Model/Dock.Model.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Model/Dock.Model.csproj
+++ b/src/Dock.Model/Dock.Model.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -26,10 +26,10 @@ namespace Dock.Model
                 }
             }
             var targetDockable = targetDock.ActiveDockable;
-            if (targetDockable == null)
+            if (targetDockable is null)
             {
                 targetDockable = targetDock.VisibleDockables.LastOrDefault();
-                if (targetDockable == null)
+                if (targetDockable is null)
                 {
                     if (bExecute)
                     {
@@ -54,10 +54,10 @@ namespace Dock.Model
         internal bool SwapDockable(IDockable sourceDockable, IDock sourceDockableOwner, IDock targetDock, bool bExecute)
         {
             var targetDockable = targetDock.ActiveDockable;
-            if (targetDockable == null)
+            if (targetDockable is null)
             {
                 targetDockable = targetDock.VisibleDockables.LastOrDefault();
-                if (targetDockable == null)
+                if (targetDockable is null)
                 {
                     return false;
                 }

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -20,7 +20,7 @@ namespace Dock.Model
         {
             if (sourceDockableOwner == targetDock)
             {
-                if (targetDock.VisibleDockables.Count == 1)
+                if (targetDock.VisibleDockables?.Count == 1)
                 {
                     return false;
                 }
@@ -109,7 +109,7 @@ namespace Dock.Model
                 case ITool _:
                     if (sourceDockableOwner == targetDock)
                     {
-                        if (targetDock.VisibleDockables.Count == 1)
+                        if (targetDock.VisibleDockables?.Count == 1)
                         {
                             return false;
                         }
@@ -122,7 +122,7 @@ namespace Dock.Model
                 case IDocument _:
                     if (sourceDockableOwner == targetDock)
                     {
-                        if (targetDock.VisibleDockables.Count == 1)
+                        if (targetDock.VisibleDockables?.Count == 1)
                         {
                             return false;
                         }
@@ -150,7 +150,7 @@ namespace Dock.Model
                     {
                         //if (sourceDockableOwner is IDocumentDock)
                         //{
-                        //    if (sourceDockableOwner.VisibleDockables.Count == 1)
+                        //    if (sourceDockableOwner.VisibleDockables?.Count == 1)
                         //    {
                         //        return false;
                         //    }

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -100,7 +100,7 @@ namespace Dock.Model
 
             if (layout is IDock dock)
             {
-                if (dock.DefaultDockable != null)
+                if (!(dock.DefaultDockable is null))
                 {
                     dock.ActiveDockable = dock.DefaultDockable;
                 }
@@ -116,7 +116,7 @@ namespace Dock.Model
         public virtual void UpdateDockWindow(IDockWindow window, IDockable? owner)
         {
             window.Host = GetHostWindow(window.Id);
-            if (window.Host != null)
+            if (!(window.Host is null))
             {
                 window.Host.Window = window;
             }
@@ -124,7 +124,7 @@ namespace Dock.Model
             window.Owner = owner;
             window.Factory = this;
 
-            if (window.Layout != null)
+            if (!(window.Layout is null))
             {
                 UpdateDockable(window.Layout, window.Layout.Owner);
             }
@@ -144,7 +144,7 @@ namespace Dock.Model
             {
                 dock.Factory = this;
 
-                if (dock.VisibleDockables != null)
+                if (!(dock.VisibleDockables is null))
                 {
                     foreach (var child in dock.VisibleDockables)
                     {
@@ -155,7 +155,7 @@ namespace Dock.Model
 
             if (dockable is IRootDock rootDock)
             {
-                if (rootDock.Windows != null)
+                if (!(rootDock.Windows is null))
                 {
                     foreach (var child in rootDock.Windows)
                     {
@@ -169,7 +169,7 @@ namespace Dock.Model
         public virtual void AddDockable(IDock dock, IDockable dockable)
         {
             UpdateDockable(dockable, dock);
-            if (dock.VisibleDockables == null)
+            if (dock.VisibleDockables is null)
             {
                 dock.VisibleDockables = CreateList<IDockable>();
             }
@@ -182,7 +182,7 @@ namespace Dock.Model
             if (index >= 0)
             {
                 UpdateDockable(dockable, dock);
-                if (dock.VisibleDockables == null)
+                if (dock.VisibleDockables is null)
                 {
                     dock.VisibleDockables = CreateList<IDockable>();
                 }
@@ -193,7 +193,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void AddWindow(IRootDock rootDock, IDockWindow window)
         {
-            if (rootDock.Windows == null)
+            if (rootDock.Windows is null)
             {
                 rootDock.Windows = CreateList<IDockWindow>();
             }
@@ -231,19 +231,19 @@ namespace Dock.Model
         /// <inheritdoc />
         public void SetFocusedDockable(IDock dock, IDockable dockable)
         {
-            if (dock.ActiveDockable != null && FindRoot(dock.ActiveDockable) is IRootDock root)
+            if (!(dock.ActiveDockable is null) && FindRoot(dock.ActiveDockable) is IRootDock root)
             {
-                if (root.FocusedDockable?.Owner != null)
+                if (!(root.FocusedDockable?.Owner is null))
                 {
                     SetIsActive(root.FocusedDockable.Owner, false);
                 }
 
-                if (dockable != null)
+                if (!(dockable is null))
                 {
                     root.FocusedDockable = dockable;
                 }
 
-                if (root.FocusedDockable?.Owner != null)
+                if (!(root.FocusedDockable?.Owner is null))
                 {
                     SetIsActive(root.FocusedDockable.Owner, true);
                 }
@@ -253,7 +253,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual IRootDock? FindRoot(IDockable dockable)
         {
-            if (dockable?.Owner == null)
+            if (dockable.Owner is null)
             {
                 return null;
             }
@@ -272,7 +272,7 @@ namespace Dock.Model
                 return dock;
             }
 
-            if (dock.VisibleDockables != null)
+            if (!(dock.VisibleDockables is null))
             {
                 foreach (var dockable in dock.VisibleDockables)
                 {
@@ -284,7 +284,7 @@ namespace Dock.Model
                     if (dockable is IDock childDock)
                     {
                         var result = FindDockable(childDock, predicate);
-                        if (result != null)
+                        if (!(result is null))
                         {
                             return result;
                         }
@@ -294,11 +294,11 @@ namespace Dock.Model
 
             if (dock is IRootDock rootDock)
             {
-                if (rootDock.Windows != null)
+                if (!(rootDock.Windows is null))
                 {
                     foreach (var window in rootDock.Windows)
                     {
-                        if (window.Layout != null)
+                        if (!(window.Layout is null))
                         {
                             if (predicate(window.Layout) == true)
                             {
@@ -306,7 +306,7 @@ namespace Dock.Model
                             }
 
                             var result = FindDockable(window.Layout, predicate);
-                            if (result != null)
+                            if (!(result is null))
                             {
                                 return result;
                             }
@@ -322,7 +322,7 @@ namespace Dock.Model
         {
             // TODO: Find closest pin dock to the dockable (Top, Bottom, Left or Right).
 
-            if (root.Left == null)
+            if (root.Left is null)
             {
                 root.Left = CreatePinDock();
                 root.Left.Alignment = Alignment.Left;
@@ -337,7 +337,7 @@ namespace Dock.Model
         {
             RemoveDockable(dockable, true);
 
-            if (pinDock.VisibleDockables == null)
+            if (pinDock.VisibleDockables is null)
             {
                 pinDock.VisibleDockables = CreateList<IDockable>();
             }
@@ -351,7 +351,7 @@ namespace Dock.Model
         {
             // TODO: Implement dockable pinning.
 
-            if (dockable != null && FindRoot(dockable) is IRootDock root)
+            if (FindRoot(dockable) is IRootDock root)
             {
                 if (PinClosestPinDock(root, dockable) is IPinDock pinDock)
                 {
@@ -362,9 +362,9 @@ namespace Dock.Model
 
         private void Collapse(IDock dock)
         {
-            if (dock.IsCollapsable && dock.VisibleDockables != null && dock.VisibleDockables.Count == 0)
+            if (dock.IsCollapsable && !(dock.VisibleDockables is null) && dock.VisibleDockables.Count == 0)
             {
-                if (dock.Owner is IDock ownerDock && ownerDock.VisibleDockables != null)
+                if (dock.Owner is IDock ownerDock && !(ownerDock.VisibleDockables is null))
                 {
                     var toRemove = new List<IDockable>();
                     var dockIndex = ownerDock.VisibleDockables.IndexOf(dock);
@@ -402,7 +402,7 @@ namespace Dock.Model
                     }
                 }
 
-                if (dock is IRootDock rootDock && rootDock.Window != null)
+                if (dock is IRootDock rootDock && !(rootDock.Window is null))
                 {
                     RemoveWindow(rootDock.Window);
                 }
@@ -416,7 +416,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void RemoveDockable(IDockable dockable, bool collapse)
         {
-            if (dockable?.Owner is IDock dock && dock.VisibleDockables != null)
+            if (dockable?.Owner is IDock dock && !(dock.VisibleDockables is null))
             {
                 int index = dock.VisibleDockables.IndexOf(dockable);
                 if (index < 0)
@@ -481,7 +481,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void MoveDockable(IDock dock, IDockable sourceDockable, IDockable targetDockable)
         {
-            if (dock.VisibleDockables == null)
+            if (dock.VisibleDockables is null)
             {
                 return;
             }
@@ -500,7 +500,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void SwapDockable(IDock dock, IDockable sourceDockable, IDockable targetDockable)
         {
-            if (dock.VisibleDockables == null)
+            if (dock.VisibleDockables is null)
             {
                 return;
             }
@@ -522,10 +522,10 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void MoveDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable? targetDockable)
         {
-            if (targetDock.VisibleDockables == null)
+            if (targetDock.VisibleDockables is null)
             {
                 targetDock.VisibleDockables = CreateList<IDockable>();
-                if (targetDock.VisibleDockables == null)
+                if (targetDock.VisibleDockables is null)
                 {
                     return;
                 }
@@ -533,7 +533,7 @@ namespace Dock.Model
 
             int targetIndex = 0;
 
-            if (targetDockable != null && targetDock.VisibleDockables != null)
+            if (!(targetDockable is null) && !(targetDock.VisibleDockables is null))
             {
                 targetIndex = targetDock.VisibleDockables.IndexOf(targetDockable);
                 if (targetIndex >= 0)
@@ -546,12 +546,12 @@ namespace Dock.Model
                 }
             }
 
-            if (sourceDockable?.Owner is IDock dock && dock.VisibleDockables != null)
+            if (sourceDockable?.Owner is IDock dock && !(dock.VisibleDockables is null))
             {
                 RemoveDockable(sourceDockable, sourceDock != targetDock);
             }
 
-            if (targetDock.VisibleDockables != null && sourceDockable != null)
+            if (!(targetDock.VisibleDockables is null) && !(sourceDockable is null))
             {
                 targetDock.VisibleDockables.Insert(targetIndex, sourceDockable);
                 UpdateDockable(sourceDockable, targetDock);
@@ -562,7 +562,7 @@ namespace Dock.Model
         /// <inheritdoc/>
         public virtual void SwapDockable(IDock sourceDock, IDock targetDock, IDockable sourceDockable, IDockable targetDockable)
         {
-            if (sourceDock.VisibleDockables == null || targetDock.VisibleDockables == null)
+            if (sourceDock.VisibleDockables is null || targetDock.VisibleDockables is null)
             {
                 return;
             }
@@ -597,12 +597,12 @@ namespace Dock.Model
             else
             {
                 split = CreateProportionalDock();
-                if (split != null)
+                if (!(split is null))
                 {
                     split.Id = nameof(IProportionalDock);
                     split.Title = nameof(IProportionalDock);
                     split.VisibleDockables = CreateList<IDockable>();
-                    if (split.VisibleDockables != null)
+                    if (!(split.VisibleDockables is null))
                     {
                         split.VisibleDockables.Add(dockable);
                         split.ActiveDockable = dockable;
@@ -639,7 +639,7 @@ namespace Dock.Model
             {
                 case DockOperation.Left:
                 case DockOperation.Top:
-                    if (layout.VisibleDockables != null && split != null)
+                    if (!(layout.VisibleDockables is null) && !(split is null))
                     {
                         layout.VisibleDockables.Add(split);
                         layout.ActiveDockable = split;
@@ -647,7 +647,7 @@ namespace Dock.Model
                     break;
                 case DockOperation.Right:
                 case DockOperation.Bottom:
-                    if (layout.VisibleDockables != null)
+                    if (!(layout.VisibleDockables is null))
                     {
                         layout.VisibleDockables.Add(dock);
                         layout.ActiveDockable = dock;
@@ -655,7 +655,7 @@ namespace Dock.Model
                     break;
             }
 
-            if (layout.VisibleDockables != null)
+            if (!(layout.VisibleDockables is null))
             {
                 layout.VisibleDockables.Add(splitter);
             }
@@ -664,7 +664,7 @@ namespace Dock.Model
             {
                 case DockOperation.Left:
                 case DockOperation.Top:
-                    if (layout.VisibleDockables != null)
+                    if (!(layout.VisibleDockables is null))
                     {
                         layout.VisibleDockables.Add(dock);
                         layout.ActiveDockable = dock;
@@ -672,7 +672,7 @@ namespace Dock.Model
                     break;
                 case DockOperation.Right:
                 case DockOperation.Bottom:
-                    if (layout.VisibleDockables != null && split != null)
+                    if (!(layout.VisibleDockables is null) && !(split is null))
                     {
                         layout.VisibleDockables.Add(split);
                         layout.ActiveDockable = split;
@@ -693,7 +693,7 @@ namespace Dock.Model
                 case DockOperation.Top:
                 case DockOperation.Bottom:
                     {
-                        if (dock.Owner is IDock ownerDock && ownerDock.VisibleDockables != null)
+                        if (dock.Owner is IDock ownerDock && !(ownerDock.VisibleDockables is null))
                         {
                             var layout = CreateSplitLayout(dock, dockable, operation);
                             int index = ownerDock.VisibleDockables.IndexOf(dock);
@@ -722,14 +722,14 @@ namespace Dock.Model
                 case ITool tool:
                     {
                         target = CreateToolDock();
-                        if (target != null)
+                        if (!(target is null))
                         {
                             target.Id = nameof(IToolDock);
                             target.Title = nameof(IToolDock);
                             if (target is IDock dock)
                             {
                                 dock.VisibleDockables = CreateList<IDockable>();
-                                if (dock.VisibleDockables != null)
+                                if (!(dock.VisibleDockables is null))
                                 {
                                     dock.VisibleDockables.Add(dockable);
                                     dock.ActiveDockable = dockable;
@@ -742,14 +742,14 @@ namespace Dock.Model
                 case IDocument document:
                     {
                         target = CreateDocumentDock();
-                        if (target != null)
+                        if (!(target is null))
                         {
                             target.Id = nameof(IDocumentDock);
                             target.Title = nameof(IDocumentDock);
                             if (target is IDock dock)
                             {
                                 dock.VisibleDockables = CreateList<IDockable>();
-                                if (dock.VisibleDockables != null)
+                                if (!(dock.VisibleDockables is null))
                                 {
                                     dock.VisibleDockables.Add(dockable);
                                     dock.ActiveDockable = dockable;
@@ -793,7 +793,7 @@ namespace Dock.Model
             root.Id = nameof(IRootDock);
             root.Title = nameof(IRootDock);
             root.VisibleDockables = CreateList<IDockable>();
-            if (root.VisibleDockables != null && target != null)
+            if (!(root.VisibleDockables is null) && !(target is null))
             {
                 root.VisibleDockables.Add(target);
                 root.ActiveDockable = target;
@@ -818,13 +818,13 @@ namespace Dock.Model
         public virtual void SplitToWindow(IDock dock, IDockable dockable, double x, double y, double width, double height)
         {
             var rootDock = FindRoot(dock);
-            if (rootDock == null)
+            if (rootDock is null)
             {
                 return;
             }
             RemoveDockable(dockable, true);
             var window = CreateWindowFrom(dockable);
-            if (window != null)
+            if (!(window is null))
             {
                 AddWindow(rootDock, window);
                 window.X = x;

--- a/src/Dock.Serializer/Dock.Serializer.csproj
+++ b/src/Dock.Serializer/Dock.Serializer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Nullable>enable</Nullable>

--- a/src/Dock.Serializer/Dock.Serializer.csproj
+++ b/src/Dock.Serializer/Dock.Serializer.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Dock.Serializer/DockSerializer.cs
+++ b/src/Dock.Serializer/DockSerializer.cs
@@ -72,11 +72,7 @@ namespace Dock.Serializer
             using (var streamReader = new System.IO.StreamReader(stream, Encoding.UTF8))
             {
                 var text = streamReader.ReadToEnd();
-                if (!string.IsNullOrWhiteSpace(text))
-                {
-                    return Deserialize<T>(text);
-                }
-                return default;
+                return Deserialize<T>(text);
             }
         }
 

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -219,21 +219,21 @@ namespace Dock.Avalonia.UnitTests.Controls
             target1.Arrange(new Rect(target1.DesiredSize));
 
             var items1 = target1.Items as List<IControl>;
-            var target2 = items1[4] as ItemsControl;
-            var items2 = target2.Items as List<IControl>;
+            var target2 = items1?[4] as ItemsControl;
+            var items2 = target2?.Items as List<IControl>;
 
             Assert.Equal(new Size(1000, 500), target1.Bounds.Size);
-            Assert.Equal(new Rect(0, 0, 0, 0), items1[0].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items1[1].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items1[2].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items1[3].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items1[4].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items1?[0].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items1?[1].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items1?[2].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items1?[3].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items1?[4].Bounds);
 
-            Assert.Equal(new Size(0, 0), target2.Bounds.Size);
-            Assert.Equal(new Rect(0, 0, 0, 0), items2[0].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items2[1].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items2[2].Bounds);
-            Assert.Equal(new Rect(0, 0, 0, 0), items2[3].Bounds);
+            Assert.Equal(new Size(0, 0), target2?.Bounds.Size);
+            Assert.Equal(new Rect(0, 0, 0, 0), items2?[0].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items2?[1].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items2?[2].Bounds);
+            Assert.Equal(new Rect(0, 0, 0, 0), items2?[3].Bounds);
         }
     }
 }

--- a/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>True</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.Avalonia.UnitTests
 
     public class TestDockBase : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
@@ -12,6 +12,8 @@ namespace Dock.Model.Avalonia.UnitTests
         {
             var actual = new TestDockableBase();
             Assert.NotNull(actual);
+            Assert.Equal(string.Empty, actual.Id);
+            Assert.Equal(string.Empty, actual.Title);
         }
     }
 

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.Avalonia.UnitTests
 
     public class TestDockableBase : DockableBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>True</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.INPC.UnitTests
 
     public class TestDockBase : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
@@ -12,6 +12,8 @@ namespace Dock.Model.INPC.UnitTests
         {
             var actual = new TestDockableBase();
             Assert.NotNull(actual);
+            Assert.Equal(string.Empty, actual.Id);
+            Assert.Equal(string.Empty, actual.Title);
         }
     }
 

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.INPC.UnitTests
 
     public class TestDockableBase : DockableBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.INPC.UnitTests/Dock.Model.INPC.UnitTests.csproj
+++ b/tests/Dock.Model.INPC.UnitTests/Dock.Model.INPC.UnitTests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>True</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.ReactiveUI.UnitTests
 
     public class TestDockBase : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
@@ -12,6 +12,8 @@ namespace Dock.Model.ReactiveUI.UnitTests
         {
             var actual = new TestDockableBase();
             Assert.NotNull(actual);
+            Assert.Equal(string.Empty, actual.Id);
+            Assert.Equal(string.Empty, actual.Title);
         }
     }
 

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
@@ -17,7 +17,7 @@ namespace Dock.Model.ReactiveUI.UnitTests
 
     public class TestDockableBase : DockableBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>True</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.Test/Controls/Document.cs
+++ b/tests/Dock.Model.Test/Controls/Document.cs
@@ -5,7 +5,7 @@ namespace Dock.Model.Controls
 {
     public class Document : DockableBase, IDocument
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/tests/Dock.Model.Test/Controls/DocumentDock.cs
+++ b/tests/Dock.Model.Test/Controls/DocumentDock.cs
@@ -7,7 +7,7 @@ namespace Dock.Model.Controls
 {
     public class DocumentDock : DockBase, IDocumentDock
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Controls/PinDock.cs
+++ b/tests/Dock.Model.Test/Controls/PinDock.cs
@@ -13,7 +13,7 @@ namespace Dock.Model.Controls
 
         public bool AutoHide { get; set; } = true;
 
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Controls/ProportionalDock.cs
+++ b/tests/Dock.Model.Test/Controls/ProportionalDock.cs
@@ -9,7 +9,7 @@ namespace Dock.Model.Controls
     {
         public Orientation Orientation { get; set; }
 
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Controls/RootDock.cs
+++ b/tests/Dock.Model.Test/Controls/RootDock.cs
@@ -8,17 +8,17 @@ namespace Dock.Model.Controls
 {
     public class RootDock : DockBase, IRootDock
     {
-        public IDockWindow Window { get; set; }
+        public IDockWindow? Window { get; set; }
 
-        public IList<IDockWindow> Windows { get; set; }
+        public IList<IDockWindow>? Windows { get; set; }
 
-        public IPinDock Top { get; set; }
+        public IPinDock? Top { get; set; }
 
-        public IPinDock Bottom { get; set; }
+        public IPinDock? Bottom { get; set; }
 
-        public IPinDock Left { get; set; }
+        public IPinDock? Left { get; set; }
 
-        public IPinDock Right { get; set; }
+        public IPinDock? Right { get; set; }
 
         public virtual void ShowWindows()
         {

--- a/tests/Dock.Model.Test/Controls/RootDock.cs
+++ b/tests/Dock.Model.Test/Controls/RootDock.cs
@@ -30,7 +30,7 @@ namespace Dock.Model.Controls
             _navigateAdapter?.ExitWindows();
         }
 
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Controls/SplitterDock.cs
+++ b/tests/Dock.Model.Test/Controls/SplitterDock.cs
@@ -7,7 +7,7 @@ namespace Dock.Model.Controls
 {
     public class SplitterDock : DockBase, ISplitterDock
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Controls/Tool.cs
+++ b/tests/Dock.Model.Test/Controls/Tool.cs
@@ -5,7 +5,7 @@ namespace Dock.Model.Controls
 {
     public class Tool : DockableBase, ITool, IDocument
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             return this;
         }

--- a/tests/Dock.Model.Test/Controls/ToolDock.cs
+++ b/tests/Dock.Model.Test/Controls/ToolDock.cs
@@ -7,7 +7,7 @@ namespace Dock.Model.Controls
 {
     public class ToolDock : DockBase, IToolDock
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Core/DockBase.cs
+++ b/tests/Dock.Model.Test/Core/DockBase.cs
@@ -8,17 +8,17 @@ namespace Dock.Model
     {
         internal INavigateAdapter _navigateAdapter;
 
-        public IList<IDockable> VisibleDockables { get; set; }
+        public IList<IDockable>? VisibleDockables { get; set; }
 
-        public IList<IDockable> HiddenDockables { get; set; }
+        public IList<IDockable>? HiddenDockables { get; set; }
 
-        public IList<IDockable> PinnedDockables { get; set; }
+        public IList<IDockable>? PinnedDockables { get; set; }
 
-        public IDockable ActiveDockable { get; set; }
+        public IDockable? ActiveDockable { get; set; }
 
-        public IDockable DefaultDockable { get; set; }
+        public IDockable? DefaultDockable { get; set; }
 
-        public IDockable FocusedDockable { get; set; }
+        public IDockable? FocusedDockable { get; set; }
 
         public double Proportion { get; set; } = double.NaN;
 

--- a/tests/Dock.Model.Test/Core/DockWindow.cs
+++ b/tests/Dock.Model.Test/Core/DockWindow.cs
@@ -24,16 +24,18 @@ namespace Dock.Model
 
         public string Title { get; set; }
 
-        public IDockable Owner { get; set; }
+        public IDockable? Owner { get; set; }
 
-        public IFactory Factory { get; set; }
+        public IFactory? Factory { get; set; }
 
-        public IRootDock Layout { get; set; }
+        public IRootDock? Layout { get; set; }
 
-        public IHostWindow Host { get; set; }
+        public IHostWindow? Host { get; set; }
 
         public DockWindow()
         {
+            Id = nameof(IDockWindow);
+            Title = nameof(IDockWindow);
             _hostAdapter = new HostAdapter(this);
         }
 

--- a/tests/Dock.Model.Test/Core/DockWindow.cs
+++ b/tests/Dock.Model.Test/Core/DockWindow.cs
@@ -52,7 +52,7 @@ namespace Dock.Model
             _hostAdapter.Exit();
         }
 
-        public IDockWindow Clone()
+        public IDockWindow? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/Core/DockableBase.cs
+++ b/tests/Dock.Model.Test/Core/DockableBase.cs
@@ -24,6 +24,6 @@ namespace Dock.Model
         {
         }
 
-        public abstract IDockable Clone();
+        public abstract IDockable? Clone();
     }
 }

--- a/tests/Dock.Model.Test/Core/DockableBase.cs
+++ b/tests/Dock.Model.Test/Core/DockableBase.cs
@@ -5,15 +5,15 @@ namespace Dock.Model
 {
     public abstract class DockableBase : IDockable
     {
-        public string Id { get; set; }
+        public string Id { get; set; } = string.Empty;
 
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
 
-        public object Context { get; set; }
+        public object? Context { get; set; }
 
-        public IDockable Owner { get; set; }
+        public IDockable? Owner { get; set; }
 
-        public IFactory Factory { get; set; }
+        public IFactory? Factory { get; set; }
 
         public virtual bool OnClose()
         {

--- a/tests/Dock.Model.Test/Dock.Model.Test.csproj
+++ b/tests/Dock.Model.Test/Dock.Model.Test.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>False</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.Test/Dock.Model.Test.csproj
+++ b/tests/Dock.Model.Test/Dock.Model.Test.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />

--- a/tests/Dock.Model.Test/Dock.Model.Test.csproj
+++ b/tests/Dock.Model.Test/Dock.Model.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Model.Test/HostWindow.cs
+++ b/tests/Dock.Model.Test/HostWindow.cs
@@ -8,7 +8,7 @@ namespace Dock.Model
     {
         public bool IsTracked { get; set; }
 
-        public IDockWindow Window { get; set; }
+        public IDockWindow? Window { get; set; }
 
         public void Present(bool isDialog)
         {

--- a/tests/Dock.Model.Test/ViewModels/Views/DashboardViewModel.cs
+++ b/tests/Dock.Model.Test/ViewModels/Views/DashboardViewModel.cs
@@ -5,7 +5,7 @@ namespace Dock.Model
 {
     public class DashboardViewModel : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.Test/ViewModels/Views/HomeViewModel.cs
+++ b/tests/Dock.Model.Test/ViewModels/Views/HomeViewModel.cs
@@ -5,7 +5,7 @@ namespace Dock.Model
 {
     public class HomeViewModel : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.UnitTests/Core/TestDock.cs
+++ b/tests/Dock.Model.UnitTests/Core/TestDock.cs
@@ -7,7 +7,7 @@ namespace Dock.Model.UnitTests
 {
     public class TestDock : DockBase
     {
-        public override IDockable Clone()
+        public override IDockable? Clone()
         {
             throw new NotImplementedException();
         }

--- a/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
+++ b/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
@@ -8,6 +8,7 @@
     <IsTestProject>True</IsTestProject>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/tests/Dock.Model.UnitTests/DockManagerTests.cs
+++ b/tests/Dock.Model.UnitTests/DockManagerTests.cs
@@ -17,7 +17,9 @@ namespace Dock.Model.UnitTests
         public void Validate_sourceDockable_Null()
         {
             var manager = new DockManager();
+#pragma warning disable CS8625
             var actual = manager.ValidateDockable(null, null, DragAction.Move, DockOperation.Fill, false);
+#pragma warning restore CS8625
             Assert.False(actual);
         }
     }


### PR DESCRIPTION
Fixes #113 

### Projects

- [x] Dock.Model
- [x] Dock.Model.Avalonia
- [x] Dock.Model.INPC
- [x] Dock.Model.ReactiveUI
- [x] Dock.Serializer
- [x] Dock.Avalonia
- [x] Dock.Avalonia.Themes.Default
- [x] Dock.Avalonia.Themes.Metro
- [x] Dock.Model.Avalonia.UnitTests
- [x] Dock.Model.INPC.UnitTests
- [x] Dock.Model.ReactiveUI.UnitTests
- [x] Dock.Model.Test
- [x] Dock.Avalonia.UnitTests
- [x] AvaloniaDemo
- [x] AvaloniaDemo.Experimental
- [x] AvaloniaDemo.Perspectives
- [x] Notepad
- [x] ProportionalStackPanelDemo

### Rules

1) Try not to use nullable types if possible.
2) If we use `null` and it's a valid concept, then add the `?`.
3) Then after adding `?` see where compiler warns us about issues.
4) Never use `x != null` and `x == null`.
5) Replace with `x is {}` and `x is null`