### PR TITLE
[WIP] Displaying and hiding pinned views

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.102
     - name: Build
       run: dotnet build -c Release
     - name: Test
@@ -46,38 +46,38 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.102
     - name: Publish
       if: github.event_name != 'pull_request'
       run: |
-        dotnet publish -c Release -f netcoreapp3.0 -r win7-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.0-win7-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
-        dotnet publish -c Release -f netcoreapp3.0 -r win7-x64 -o ./artifacts/AvaloniaDemo.Experimental-netcoreapp3.0-win7-x64 ./samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
-        dotnet publish -c Release -f netcoreapp3.0 -r win7-x64 -o ./artifacts/AvaloniaDemo.Perspectives-netcoreapp3.0-win7-x64 ./samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
-        dotnet publish -c Release -f netcoreapp3.0 -r win7-x64 -o ./artifacts/Notepad-netcoreapp3.0-win7-x64 ./samples/Notepad/Notepad.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r win7-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.1-win7-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r win7-x64 -o ./artifacts/AvaloniaDemo.Experimental-netcoreapp3.1-win7-x64 ./samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r win7-x64 -o ./artifacts/AvaloniaDemo.Perspectives-netcoreapp3.1-win7-x64 ./samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r win7-x64 -o ./artifacts/Notepad-netcoreapp3.1-win7-x64 ./samples/Notepad/Notepad.csproj
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo-netcoreapp3.0-win7-x64
-        path: ./artifacts/AvaloniaDemo-netcoreapp3.0-win7-x64
+        name: AvaloniaDemo-netcoreapp3.1-win7-x64
+        path: ./artifacts/AvaloniaDemo-netcoreapp3.1-win7-x64
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo.Experimental-netcoreapp3.0-win7-x64
-        path: ./artifacts/AvaloniaDemo.Experimental-netcoreapp3.0-win7-x64
+        name: AvaloniaDemo.Experimental-netcoreapp3.1-win7-x64
+        path: ./artifacts/AvaloniaDemo.Experimental-netcoreapp3.1-win7-x64
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo.Perspectives-netcoreapp3.0-win7-x64
-        path: ./artifacts/AvaloniaDemo.Perspectives-netcoreapp3.0-win7-x64
+        name: AvaloniaDemo.Perspectives-netcoreapp3.1-win7-x64
+        path: ./artifacts/AvaloniaDemo.Perspectives-netcoreapp3.1-win7-x64
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: Notepad-netcoreapp3.0-win7-x64
-        path: ./artifacts/Notepad-netcoreapp3.0-win7-x64
+        name: Notepad-netcoreapp3.1-win7-x64
+        path: ./artifacts/Notepad-netcoreapp3.1-win7-x64
 
   publish-ubuntu:
     name: Publish ubuntu-latest
@@ -87,24 +87,24 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.102
     - name: Publish
       if: github.event_name != 'pull_request'
       run: |
-        dotnet publish -c Release -f netcoreapp3.0 -r debian.8-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.0-debian.8-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
-        dotnet publish -c Release -f netcoreapp3.0 -r ubuntu.14.04-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.0-ubuntu.14.04-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r debian.8-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.1-debian.8-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
+        dotnet publish -c Release -f netcoreapp3.1 -r ubuntu.14.04-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.1-ubuntu.14.04-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo-netcoreapp3.0-debian.8-x64
-        path: ./artifacts/AvaloniaDemo-netcoreapp3.0-debian.8-x64
+        name: AvaloniaDemo-netcoreapp3.1-debian.8-x64
+        path: ./artifacts/AvaloniaDemo-netcoreapp3.1-debian.8-x64
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo-netcoreapp3.0-ubuntu.14.04-x64
-        path: ./artifacts/AvaloniaDemo-netcoreapp3.0-ubuntu.14.04-x64
+        name: AvaloniaDemo-netcoreapp3.1-ubuntu.14.04-x64
+        path: ./artifacts/AvaloniaDemo-netcoreapp3.1-ubuntu.14.04-x64
 
   publish-macOS:
     name: Publish macOS-latest
@@ -114,13 +114,13 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.0.100
+        dotnet-version: 3.1.102
     - name: Publish
       if: github.event_name != 'pull_request'
-      run: dotnet publish -c Release -f netcoreapp3.0 -r osx.10.12-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.0-osx.10.12-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
+      run: dotnet publish -c Release -f netcoreapp3.1 -r osx.10.12-x64 -o ./artifacts/AvaloniaDemo-netcoreapp3.1-osx.10.12-x64 ./samples/AvaloniaDemo/AvaloniaDemo.csproj
     - name: Artifacts
       if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@master
       with:
-        name: AvaloniaDemo-netcoreapp3.0-osx.10.12-x64
-        path: ./artifacts/AvaloniaDemo-netcoreapp3.0-osx.10.12-x64
+        name: AvaloniaDemo-netcoreapp3.1-osx.10.12-x64
+        path: ./artifacts/AvaloniaDemo-netcoreapp3.1-osx.10.12-x64

--- a/Dock.sln
+++ b/Dock.sln
@@ -32,6 +32,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{A2F3E41E-D53C-49A1-9089-2FE2C3F0FE73}"
 	ProjectSection(SolutionItems) = preProject
 		build\Avalonia.Desktop.props = build\Avalonia.Desktop.props
+		build\Avalonia.Diagnostics.props = build\Avalonia.Diagnostics.props
 		build\Avalonia.props = build\Avalonia.props
 		build\Base.props = build\Base.props
 		build\EmbedXaml.props = build\EmbedXaml.props

--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Wiesław Šoltés
+Copyright (c) Wiesław Šoltés
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build status](https://dev.azure.com/wieslawsoltes/GitHub/_apis/build/status/Sources/Dock)](https://dev.azure.com/wieslawsoltes/GitHub/_build/latest?definitionId=55)
 
 [![NuGet](https://img.shields.io/nuget/v/Dock.Model.svg)](https://www.nuget.org/packages/Dock.Model)
+[![NuGet](https://img.shields.io/nuget/dt/Dock.Model.svg)](https://www.nuget.org/packages/Dock.Model)
 [![MyGet](https://img.shields.io/myget/dock-nightly/vpre/Dock.Model.svg?label=myget)](https://www.myget.org/gallery/dock-nightly) 
 
 A docking layout system.

--- a/build/Avalonia.AvaloniaEdit.props
+++ b/build/Avalonia.AvaloniaEdit.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.9.0" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="0.10.0-preview1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
   </ItemGroup>

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-preview2" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-preview3" />
     <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2019013001" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -3,6 +3,5 @@
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop" Version="0.9.999-cibuild*" />
     <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2019013001" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.1" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.9.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.999-cibuild*" />
     <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2019013001" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="1.68.1" />
   </ItemGroup>

--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-preview1" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.10.0-preview2" />
     <PackageReference Include="Avalonia.Angle.Windows.Natives" Version="2.1.0.2019013001" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.9.999-cibuild*" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.9.999-cibuild*" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-preview1" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-preview2" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-preview2" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="0.10.0-preview3" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0-preview1" />
+    <PackageReference Include="Avalonia" Version="0.10.0-preview2" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="0.10.0-preview2" />
+    <PackageReference Include="Avalonia" Version="0.10.0-preview3" />
   </ItemGroup>
 </Project>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.9.4</VersionPrefix>
+    <VersionPrefix>0.9.4.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>

--- a/build/Base.props
+++ b/build/Base.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>0.10.0</VersionPrefix>
-    <VersionSuffix>preview2</VersionSuffix>
+    <VersionSuffix>preview3</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Description>A docking layout system.</Description>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.10.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionPrefix>0.10.999</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Description>A docking layout system.</Description>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.10.0</VersionPrefix>
-    <VersionSuffix>preview3</VersionSuffix>
+    <VersionPrefix>0.10.999</VersionPrefix>
+    <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Description>A docking layout system.</Description>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.9.4.1</VersionPrefix>
+    <VersionPrefix>0.9.999</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>0.10.999</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>0.10.0</VersionPrefix>
+    <VersionSuffix>preview2</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Description>A docking layout system.</Description>

--- a/build/build/Build.cs
+++ b/build/build/Build.cs
@@ -6,6 +6,7 @@ using Nuke.Common.Git;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
 using static Nuke.Common.EnvironmentInfo;
+using Nuke.Common.IO;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.IO.PathConstruction;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;

--- a/build/build/_build.csproj
+++ b/build/build/_build.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="0.23.4" />
+    <PackageReference Include="Nuke.Common" Version="0.24.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100",
+    "version": "3.1.100",
     "rollForward": "latestMajor"
   }
 }

--- a/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+++ b/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
@@ -24,6 +24,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
 
   <ItemGroup>

--- a/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
+++ b/samples/AvaloniaDemo.Experimental/AvaloniaDemo.Experimental.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/AvaloniaDemo.Experimental/Program.cs
+++ b/samples/AvaloniaDemo.Experimental/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Logging.Serilog;
 
 namespace AvaloniaDemo
 {

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
@@ -24,6 +24,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
 
   <ItemGroup>

--- a/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
+++ b/samples/AvaloniaDemo.Perspectives/AvaloniaDemo.Perspectives.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/AvaloniaDemo.Perspectives/Program.cs
+++ b/samples/AvaloniaDemo.Perspectives/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Logging.Serilog;
 
 namespace AvaloniaDemo
 {

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
@@ -20,6 +20,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
 

--- a/samples/AvaloniaDemo/AvaloniaDemo.csproj
+++ b/samples/AvaloniaDemo/AvaloniaDemo.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/AvaloniaDemo/DemoFactory.cs
+++ b/samples/AvaloniaDemo/DemoFactory.cs
@@ -209,7 +209,11 @@ namespace AvaloniaDemo
                 Id = "Home",
                 Title = "Home",
                 ActiveDockable = mainLayout,
-                VisibleDockables = CreateList<IDockable>(mainLayout)
+                VisibleDockables = CreateList<IDockable>(mainLayout),
+                Left = CreatePinDock(),
+                Right = CreatePinDock(),
+                Top = CreatePinDock(),
+                Bottom = CreatePinDock()
             };
 
             var root = CreateRootDock();

--- a/samples/AvaloniaDemo/Program.cs
+++ b/samples/AvaloniaDemo/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Logging.Serilog;
 
 namespace AvaloniaDemo
 {

--- a/samples/AvaloniaDemo/Views/Documents/Document1View.xaml
+++ b/samples/AvaloniaDemo/Views/Documents/Document1View.xaml
@@ -4,8 +4,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:views="clr-namespace:AvaloniaDemo.Views;assembly=AvaloniaDemo"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Documents;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:Document1ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="Gray">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Documents/Document2View.xaml
+++ b/samples/AvaloniaDemo/Views/Documents/Document2View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Documents;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:Document2ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="Gray">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/MainView.xaml
+++ b/samples/AvaloniaDemo/Views/MainView.xaml
@@ -6,19 +6,21 @@
              xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
              xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
              xmlns:views="clr-namespace:AvaloniaDemo.Views;assembly=AvaloniaDemo"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="1280" d:DesignHeight="680">
+             d:DesignWidth="1280" d:DesignHeight="680"
+             x:DataType="vm:MainWindowViewModel" x:CompileBindings="True">
     <Grid RowDefinitions="Auto,Auto,*,25" ColumnDefinitions="*,200" Background="Transparent">
         <views:MenuView Grid.Row="0" Grid.Column="0"/>
         <idc:NavigationControl DataContext="{Binding Layout}" Margin="4" Grid.Row="1"/>
         <idc:DockControl x:Name="dockControl" Layout="{Binding Layout}" Margin="4" Grid.Row="2" Grid.Column="0"/>
-        <TextBlock Text="{Binding #dockControl.Layout.ActiveDockable.FocusedDockable}" Margin="4" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2"/>
+        <TextBlock Text="{Binding #dockControl.Layout.ActiveDockable.FocusedDockable}" Margin="4" Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" x:CompileBindings="False"/>
         <Grid RowDefinitions="Auto,*,Auto" Grid.Row="1" Grid.RowSpan="2" Grid.Column="1">
             <StackPanel Grid.Row="0">
-                <Button Content="Save Window Layout" Command="{Binding SaveWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2"/>
-                <Button Content="Apply Window Layout" Command="{Binding ApplyWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2"/>
-                <Button Content="Manage Window Layouts" Command="{Binding ManageWindowLayouts}" CommandParameter="{Binding #dockControl.Layout}" Margin="4,2"/>
-                <Button Content="Reset Window Layout" Command="{Binding ResetWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2"/>
+                <Button Content="Save Window Layout" Command="{Binding SaveWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2" x:CompileBindings="False"/>
+                <Button Content="Apply Window Layout" Command="{Binding ApplyWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2" x:CompileBindings="False"/>
+                <Button Content="Manage Window Layouts" Command="{Binding ManageWindowLayouts}" CommandParameter="{Binding #dockControl.Layout}" Margin="4,2" x:CompileBindings="False"/>
+                <Button Content="Reset Window Layout" Command="{Binding ResetWindowLayout}" CommandParameter="{Binding #visibleDockables.SelectedItem}" Margin="4,2" x:CompileBindings="False"/>
             </StackPanel>
             <ListBox x:Name="visibleDockables" Items="{Binding #dockControl.Layout.VisibleDockables}" Margin="4" Grid.Row="1">
                 <ListBox.DataTemplates>

--- a/samples/AvaloniaDemo/Views/MainView.xaml
+++ b/samples/AvaloniaDemo/Views/MainView.xaml
@@ -29,7 +29,7 @@
                     </DataTemplate>
                 </ListBox.DataTemplates>
             </ListBox>
-            <TextBox Text="{Binding #visibleDockables.SelectedItem.Title}" Margin="4" Grid.Row="2"/>
+            <TextBox Text="{Binding #visibleDockables.SelectedItem.Title}" Margin="4" Grid.Row="2" x:CompileBindings="False"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/samples/AvaloniaDemo/Views/MenuView.xaml
+++ b/samples/AvaloniaDemo/Views/MenuView.xaml
@@ -5,8 +5,10 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
              xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="1280" d:DesignHeight="20">
+             d:DesignWidth="1280" d:DesignHeight="20"
+             x:DataType="vm:MainWindowViewModel" x:CompileBindings="True">
     <Menu>
         <MenuItem Header="_File">
             <MenuItem Header="_New" Command="{Binding FileNew}"/>

--- a/samples/AvaloniaDemo/Views/MenuView.xaml
+++ b/samples/AvaloniaDemo/Views/MenuView.xaml
@@ -11,45 +11,45 @@
              x:DataType="vm:MainWindowViewModel" x:CompileBindings="True">
     <Menu>
         <MenuItem Header="_File">
-            <MenuItem Header="_New" Command="{Binding FileNew}"/>
+            <MenuItem Header="_New" Command="{Binding FileNew}" x:CompileBindings="False"/>
             <Separator/>
-            <MenuItem Header="_Open..." Command="{Binding FileOpen}"/>
+            <MenuItem Header="_Open..." Command="{Binding FileOpen}" x:CompileBindings="False"/>
             <Separator/>
-            <MenuItem Header="Save _As..." Command="{Binding FileSaveAs}"/>
+            <MenuItem Header="Save _As..." Command="{Binding FileSaveAs}" x:CompileBindings="False"/>
         </MenuItem>
         <MenuItem Header="_View">
             <MenuItem Header="_Windows">
-                <MenuItem Header="_Exit" Command="{Binding Layout.ExitWindows}"/>
+                <MenuItem Header="_Exit" Command="{Binding Layout.ExitWindows}" x:CompileBindings="False"/>
                 <Separator/>
-                <MenuItem Header="_Show" Command="{Binding Layout.ShowWindows}"/>
+                <MenuItem Header="_Show" Command="{Binding Layout.ShowWindows}" x:CompileBindings="False"/>
             </MenuItem>
         </MenuItem>
         <MenuItem Header="_Options">
             <MenuItem x:Name="OptionsIsDragEnabled" Header="Enable Drag">
                 <MenuItem.Icon>
-                    <CheckBox IsChecked="{Binding $parent[Window].(id:DockProperties.IsDragEnabled)}" BorderThickness="0" IsHitTestVisible="False"/>
+                    <CheckBox IsChecked="{Binding $parent[Window].(id:DockProperties.IsDragEnabled)}" BorderThickness="0" IsHitTestVisible="False" x:CompileBindings="False"/>
                 </MenuItem.Icon>
             </MenuItem>
             <Separator/>
             <MenuItem x:Name="OptionsIsDropEnabled" Header="Enable Drop">
                 <MenuItem.Icon>
-                    <CheckBox IsChecked="{Binding $parent[Window].(id:DockProperties.IsDropEnabled)}" BorderThickness="0" IsHitTestVisible="False"/>
+                    <CheckBox IsChecked="{Binding $parent[Window].(id:DockProperties.IsDropEnabled)}" BorderThickness="0" IsHitTestVisible="False" x:CompileBindings="False"/>
                 </MenuItem.Icon>
             </MenuItem>
         </MenuItem>
         <MenuItem Header="_Window">
-            <MenuItem Header="_Save Window Layout" Command="{Binding SaveWindowLayout}" CommandParameter="{Binding Layout.ActiveDockable}"/>
-            <MenuItem Header="_Apply Window Layout" Items="{Binding Layout.VisibleDockables}">
+            <MenuItem Header="_Save Window Layout" Command="{Binding SaveWindowLayout}" CommandParameter="{Binding Layout.ActiveDockable}" x:CompileBindings="False"/>
+            <MenuItem Header="_Apply Window Layout" Items="{Binding Layout.VisibleDockables}" x:CompileBindings="False">
                 <MenuItem.Styles>
                     <Style Selector="MenuItem">
                         <Setter Property="Header" Value="{Binding Title}"/>
-                        <Setter Property="Command" Value="{Binding $parent.DataContext.ApplyWindowLayout}"/>
+                        <Setter Property="Command" Value="{Binding $parent.DataContext.ApplyWindowLayout}" x:CompileBindings="False"/>
                         <Setter Property="CommandParameter" Value="{Binding}"/>
                     </Style>
                 </MenuItem.Styles>
             </MenuItem>
-            <MenuItem Header="_Manage Window Layouts" Command="{Binding ManageWindowLayouts}" CommandParameter="{Binding Layout}"/>
-            <MenuItem Header="_Reset Window Layout" Command="{Binding ResetWindowLayout}" CommandParameter="{Binding Layout.ActiveDockable}"/>
+            <MenuItem Header="_Manage Window Layouts" Command="{Binding ManageWindowLayouts}" CommandParameter="{Binding Layout}" x:CompileBindings="False"/>
+            <MenuItem Header="_Reset Window Layout" Command="{Binding ResetWindowLayout}" CommandParameter="{Binding Layout.ActiveDockable}" x:CompileBindings="False"/>
         </MenuItem>
     </Menu>
 </UserControl>

--- a/samples/AvaloniaDemo/Views/Tools/LeftBottomTool1View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/LeftBottomTool1View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:LeftBottomTool1ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/LeftBottomTool2View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/LeftBottomTool2View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:LeftBottomTool2ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/LeftTopTool1View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/LeftTopTool1View.xaml
@@ -4,8 +4,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:views="clr-namespace:AvaloniaDemo.Views;assembly=AvaloniaDemo"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:LeftTopTool1ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/LeftTopTool2View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/LeftTopTool2View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:LeftTopTool2ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/RightBottomTool1View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/RightBottomTool1View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:RightBottomTool1ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/RightBottomTool2View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/RightBottomTool2View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:RightBottomTool2ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/RightTopTool1View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/RightTopTool1View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:RightTopTool1ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Tools/RightTopTool2View.xaml
+++ b/samples/AvaloniaDemo/Views/Tools/RightTopTool2View.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Tools;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:RightTopTool2ViewModel" x:CompileBindings="True">
     <Grid Focusable="True" Background="WhiteSmoke">
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Views/DashboardView.xaml
+++ b/samples/AvaloniaDemo/Views/Views/DashboardView.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Views;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:DashboardViewModel" x:CompileBindings="True">
     <Grid>
         <StackPanel>
             <TextBlock Text="{Binding Id}"/>

--- a/samples/AvaloniaDemo/Views/Views/DashboardView.xaml
+++ b/samples/AvaloniaDemo/Views/Views/DashboardView.xaml
@@ -12,7 +12,7 @@
             <TextBlock Text="{Binding Id}"/>
             <TextBlock Text="{Binding Title}"/>
             <TextBlock Text="{Binding Context}"/>
-            <Button Content="Home" Command="{Binding Context.Navigate}" CommandParameter="Home"/>
+            <Button Content="Home" Command="{Binding Context.Navigate}" CommandParameter="Home" x:CompileBindings="False"/>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/samples/AvaloniaDemo/Views/Views/HomeView.xaml
+++ b/samples/AvaloniaDemo/Views/Views/HomeView.xaml
@@ -3,8 +3,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:vm="clr-namespace:AvaloniaDemo.ViewModels.Views;assembly=AvaloniaDemo"
              mc:Ignorable="d"
-             d:DesignWidth="300" d:DesignHeight="400">
+             d:DesignWidth="300" d:DesignHeight="400"
+             x:DataType="vm:HomeViewModel" x:CompileBindings="True">
     <Grid RowDefinitions="*,25">
         <ContentControl Content="{Binding ActiveDockable}" Margin="4" Grid.Row="0"/>
         <TextBlock Text="{Binding FocusedDockable}" Margin="4" Grid.Row="1"/>

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
@@ -20,6 +20,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
   <Import Project="..\..\build\Newtonsoft.Json.props" />
   <Import Project="..\..\build\ReactiveUI.props" />
 

--- a/samples/Notepad/Notepad.csproj
+++ b/samples/Notepad/Notepad.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/Notepad/Program.cs
+++ b/samples/Notepad/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Logging.Serilog;
 
 namespace Notepad
 {

--- a/samples/ProportionalStackPanelDemo/Program.cs
+++ b/samples/ProportionalStackPanelDemo/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Avalonia;
-using Avalonia.Logging.Serilog;
 
 namespace ProportionalStackPanelDemo
 {

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
@@ -20,6 +20,7 @@
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="obj\**" />

--- a/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
+++ b/samples/ProportionalStackPanelDemo/ProportionalStackPanelDemo.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PublishTrimmed>False</PublishTrimmed>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
+    <PublishReadyToRun>False</PublishReadyToRun>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Dock.Avalonia.Themes.Default.DefaultTheme">
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/DockPanelSplitter.xaml"/>

--- a/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml
@@ -9,6 +9,8 @@
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/ToolControl.xaml"/>
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/NavigationControl.xaml"/>
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/DockControl.xaml"/>
+    <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/PinDockControl.xaml"/>
+    <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/PinHostControl.xaml"/>
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/HostWindow.xaml"/>
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Default/MetroWindow.xaml"/>
     <Style>

--- a/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml.cs
+++ b/src/Dock.Avalonia.Themes.Default/DefaultTheme.xaml.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Avalonia.Styling;
 
 namespace Dock.Avalonia.Themes.Default

--- a/src/Dock.Avalonia.Themes.Default/DockControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockControl.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Default/DockControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockControl.xaml
@@ -14,7 +14,7 @@
         </Style.Resources>
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentControl Content="{TemplateBinding Layout}">
+                <ContentControl Content="{TemplateBinding Layout}" x:CompileBindings="True">
                     <ContentControl.DataTemplates>
                         <DataTemplate DataType="Controls:ISplitterDock">
                             <idc:ProportionalStackPanelSplitter Background="Transparent"/>

--- a/src/Dock.Avalonia.Themes.Default/DockControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockControl.xaml
@@ -32,44 +32,21 @@
                             </idc:DockToolChrome>
                         </DataTemplate>
                         <DataTemplate DataType="Controls:IProportionalDock">
-                            <ItemsControl Items="{Binding VisibleDockables}" idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <idc:ProportionalStackPanel Name="DropProportional" id:DockProperties.IsDropArea="True" Background="Transparent" Orientation="{Binding Orientation, Converter={StaticResource OrientationConverter}}"/>
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
+                                <ItemsControl Items="{Binding VisibleDockables}" idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <idc:ProportionalStackPanel Name="DropProportional" id:DockProperties.IsDropArea="True" Background="Transparent" Orientation="{Binding Orientation, Converter={StaticResource OrientationConverter}}"/>
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                </ItemsControl>
                         </DataTemplate>
                         <DataTemplate DataType="Controls:IPinDock">
-                            <DockPanel Name="DropPin" id:DockProperties.IsDropArea="True" Background="Transparent">
-                                <TabStrip Items="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" Focusable="false" ClipToBounds="False" DockPanel.Dock="{Binding Alignment, Converter={StaticResource AlignmentConverter}}">
-                                    <TabStrip.Styles>
-                                        <Style Selector="TabStrip:empty">
-                                            <Setter Property="IsVisible" Value="False" />
-                                        </Style>
-                                        <Style Selector="TabStrip /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
-                                            <Setter Property="Orientation" Value="Vertical"/>
-                                        </Style>
-                                    </TabStrip.Styles>
-                                    <TabStrip.DataTemplates>
-                                        <DataTemplate DataType="Dock:IDockable">
-                                            <StackPanel Name="DragPin" id:DockProperties.IsDragArea="True" id:DockProperties.IsDropArea="True" Background="Transparent" Orientation="Horizontal" Spacing="2">
-                                                <TextBlock Text="{Binding Title}" Classes="drag" Margin="2" />
-                                            </StackPanel>
-                                        </DataTemplate>
-                                    </TabStrip.DataTemplates>
-                                </TabStrip>
-                                <ContentControl Content="{Binding ActiveDockable}" IsVisible="{Binding IsExpanded}"/>
-                            </DockPanel>
+                            <idc:PinDockControl/>
                         </DataTemplate>
                         <DataTemplate DataType="Controls:IRootDock">
-                            <DockPanel Name="DropRoot" id:DockProperties.IsDropArea="False" Background="Transparent">
-                                <ContentControl Content="{Binding Top}" DockPanel.Dock="Top"/>
-                                <ContentControl Content="{Binding Bottom}" DockPanel.Dock="Bottom"/>
-                                <ContentControl Content="{Binding Left}" DockPanel.Dock="Left"/>
-                                <ContentControl Content="{Binding Right}" DockPanel.Dock="Right"/>
+                            <idc:PinHostControl>
                                 <Carousel Items="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" IsVirtualized="False"/>
-                            </DockPanel>
+                            </idc:PinHostControl>
                         </DataTemplate>
                     </ContentControl.DataTemplates>
                 </ContentControl>

--- a/src/Dock.Avalonia.Themes.Default/DockControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockControl.xaml
@@ -14,7 +14,7 @@
         </Style.Resources>
         <Setter Property="Template">
             <ControlTemplate>
-                <ContentControl Content="{TemplateBinding Layout}" x:CompileBindings="True">
+                <ContentControl Content="{TemplateBinding Layout}" x:DataType="Dock:IDock" x:CompileBindings="True">
                     <ContentControl.DataTemplates>
                         <DataTemplate DataType="Controls:ISplitterDock">
                             <idc:ProportionalStackPanelSplitter Background="Transparent"/>

--- a/src/Dock.Avalonia.Themes.Default/DockPanelSplitter.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockPanelSplitter.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
     <Style Selector="idc|DockPanelSplitter">

--- a/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
     <Style Selector="idc|DockTarget">

--- a/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
@@ -14,11 +14,11 @@
                     <Grid Background="Purple" ColumnSpan="2" RowSpan="2" Opacity="0" Name="PART_CenterIndicator" />
                     <Grid RowSpan="2" ColumnSpan="2">
                         <Grid MaxWidth="125" MaxHeight="125" RowDefinitions="*,*,*" ColumnDefinitions="*,*,*">
-                            <Image Name="PART_TopSelector" Source="avares://Dock.Avalonia.Themes.Default/Assets/DockAnchorableTop.png" Height="40" Width="40" Grid.Column="1" />
-                            <Image Name="PART_BottomSelector" Source="avares://Dock.Avalonia.Themes.Default/Assets/DockAnchorableBottom.png" Height="40" Width="40" Grid.Row="2" Grid.Column="1" />
-                            <Image Name="PART_LeftSelector" Source="avares://Dock.Avalonia.Themes.Default/Assets/DockAnchorableLeft.png" Height="40" Width="40" Grid.Row="1" />
-                            <Image Name="PART_RightSelector" Source="avares://Dock.Avalonia.Themes.Default/Assets/DockAnchorableRight.png" Height="40" Width="40" Grid.Row="1" Grid.Column="2" />
-                            <Image Name="PART_CenterSelector" Source="avares://Dock.Avalonia.Themes.Default/Assets/DockDocumentInside.png" Height="40" Width="40" Grid.Row="1" Grid.Column="1" />
+                            <Image Name="PART_TopSelector" Source="/Assets/DockAnchorableTop.png" Height="40" Width="40" Grid.Column="1" />
+                            <Image Name="PART_BottomSelector" Source="/Assets/DockAnchorableBottom.png" Height="40" Width="40" Grid.Row="2" Grid.Column="1" />
+                            <Image Name="PART_LeftSelector" Source="/Assets/DockAnchorableLeft.png" Height="40" Width="40" Grid.Row="1" />
+                            <Image Name="PART_RightSelector" Source="/Assets/DockAnchorableRight.png" Height="40" Width="40" Grid.Row="1" Grid.Column="2" />
+                            <Image Name="PART_CenterSelector" Source="/Assets/DockDocumentInside.png" Height="40" Width="40" Grid.Row="1" Grid.Column="1" />
                         </Grid>
                     </Grid>
                 </Grid>

--- a/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockTarget.xaml
@@ -6,7 +6,7 @@
     <Style Selector="idc|DockTarget">
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid Name="grid" RowDefinitions="*,*" ColumnDefinitions="*,*">
+                <Grid Name="grid" RowDefinitions="*,*" ColumnDefinitions="*,*" x:CompileBindings="True">
                     <Grid Background="Red" ColumnSpan="2" Opacity="0" Name="PART_TopIndicator" />
                     <Grid Background="Blue" Grid.Row="1" ColumnSpan="2" Opacity="0" Name="PART_BottomIndicator" />
                     <Grid Background="Green" RowSpan="2" Opacity="0" Name="PART_LeftIndicator" />

--- a/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
@@ -19,7 +19,7 @@
                     <Border Name="PART_Border" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
                         <Grid Name="PART_Grip">
                             <DockPanel LastChildFill="True" Margin="8 0">
-                                <TextBlock DockPanel.Dock="Left" Text="{Binding ActiveDockable.Title}" HorizontalAlignment="Left" TextAlignment="Center" VerticalAlignment="Center" Height="25"  Margin="0 8 8 0" Background="{Binding #Part_Grip.Background}" />
+                                <TextBlock DockPanel.Dock="Left" Text="{Binding ActiveDockable.Title}" HorizontalAlignment="Left" TextAlignment="Left" VerticalAlignment="Center" Height="25"  Margin="0 8 8 0" Background="{Binding #Part_Grip.Background}" />
                                 <Button Classes="chromeButton" DockPanel.Dock="Right" Name="PART_CloseButton" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding ActiveDockable}">
                                     <Image Source="avares://Dock.Avalonia.Themes.Default/Assets/PinClose_Dark.png" Height="13" Width="13" Stretch="None" />
                                 </Button>

--- a/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DockToolChrome.xaml
@@ -3,7 +3,8 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
-        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">
     <Style Selector="Button.chromeButton">
         <Setter Property="Margin" Value="2 0 0 0" />
         <Setter Property="Padding" Value="0" />
@@ -15,15 +16,15 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid RowDefinitions="25,*">
+                <Grid RowDefinitions="25,*" x:DataType="Dock:IDock" x:CompileBindings="True">
                     <Border Name="PART_Border" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
                         <Grid Name="PART_Grip">
                             <DockPanel LastChildFill="True" Margin="8 0">
-                                <TextBlock DockPanel.Dock="Left" Text="{Binding ActiveDockable.Title}" HorizontalAlignment="Left" TextAlignment="Left" VerticalAlignment="Center" Height="25"  Margin="0 8 8 0" Background="{Binding #Part_Grip.Background}" />
-                                <Button Classes="chromeButton" DockPanel.Dock="Right" Name="PART_CloseButton" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding ActiveDockable}">
+                                <TextBlock DockPanel.Dock="Left" Text="{Binding ActiveDockable.Title}" HorizontalAlignment="Left" TextAlignment="Left" VerticalAlignment="Center" Height="25"  Margin="0 8 8 0" Background="{Binding #Part_Grip.Background}" x:CompileBindings="False" />
+                                <Button Classes="chromeButton" DockPanel.Dock="Right" Name="PART_CloseButton" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding ActiveDockable}" x:CompileBindings="False">
                                     <Image Source="avares://Dock.Avalonia.Themes.Default/Assets/PinClose_Dark.png" Height="13" Width="13" Stretch="None" />
                                 </Button>
-                                <Button Classes="chromeButton" DockPanel.Dock="Right" Command="{Binding Owner.Factory.PinDockable}" CommandParameter="{Binding ActiveDockable}">
+                                <Button Classes="chromeButton" DockPanel.Dock="Right" Command="{Binding Owner.Factory.PinDockable}" CommandParameter="{Binding ActiveDockable}" x:CompileBindings="False">
                                     <Image Source="avares://Dock.Avalonia.Themes.Default/Assets/PinAutoHide_Dark.png" Height="13" Width="13" Stretch="None" />
                                 </Button>
                                 <Button Classes="chromeButton" DockPanel.Dock="Right">

--- a/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
@@ -45,7 +45,6 @@
                     <TabStrip Name="PART_TabStrip" id:DockProperties.IsDropArea="True" Background="Transparent" Items="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" Focusable="false" ClipToBounds="False" ZIndex="1" DockPanel.Dock="Top">
                         <TabStrip.Styles>
                             <Style Selector="TabStrip">
-                                <Setter Property="MaxHeight" Value="24" />
                                 <Setter Property="ItemsPanel">
                                     <ItemsPanelTemplate>
                                         <WrapPanel ClipToBounds="False" />

--- a/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
@@ -9,7 +9,7 @@
     <Style Selector="idc|DocumentControl">
         <Setter Property="Template">
             <ControlTemplate>
-                <DockPanel Name="DropDocumentDock" id:DockProperties.IsDropArea="True" Background="Transparent" Grid.Row="1" ZIndex="1">
+                <DockPanel Name="DropDocumentDock" id:DockProperties.IsDropArea="True" Background="Transparent" Grid.Row="1" ZIndex="1" x:DataType="Controls:IDocumentDock" x:CompileBindings="True">
                     <DockPanel.Styles>
                         <Style Selector="TextBlock.drag">
                             <Setter Property="Background" Value="Transparent"/>
@@ -83,9 +83,9 @@
                                 <StackPanel Name="DragDocument" id:DockProperties.IsDragArea="True" id:DockProperties.IsDropArea="True" Background="Transparent" Orientation="Horizontal" Spacing="2">
                                     <StackPanel Orientation="Horizontal" Margin="2" TextBlock.FontSize="12">
                                         <TextBlock Text="{Binding Title}" />
-                                        <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" />
+                                        <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" x:CompileBindings="False"/>
                                     </StackPanel>
-                                    <Button Height="14" Width="14" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding}" Classes="documentTabButton">
+                                    <Button Height="14" Width="14" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding}" Classes="documentTabButton" x:CompileBindings="False">
                                         <Button.Styles>
                                             <Style Selector="Button">
                                                 <Setter Property="BorderThickness" Value="0"/>
@@ -99,7 +99,7 @@
                             </DataTemplate>
                         </TabStrip.DataTemplates>
                     </TabStrip>
-                    <Grid Background="{DynamicResource ApplicationAccentBrushLow}" Height="2" DockPanel.Dock="Top" IsVisible="{Binding #PART_TabStrip.IsVisible}" />
+                    <Grid Background="{DynamicResource ApplicationAccentBrushLow}" Height="2" DockPanel.Dock="Top" IsVisible="{Binding #PART_TabStrip.IsVisible}" x:CompileBindings="False" />
                     <Border BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderLowBrush}">
                         <Carousel Items="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable}" IsVirtualized="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
                     </Border>

--- a/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
@@ -9,6 +9,7 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
         <Setter Property="FontFamily" Value="{TemplateBinding FontFamily}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="HasSystemDecorations" Value="True" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="WindowState" Value="Normal" />

--- a/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/HostWindow.xaml
@@ -17,7 +17,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}">
+                <Border Background="{TemplateBinding Background}" x:DataType="Dock:IHostWindow" x:CompileBindings="True">
                     <VisualLayerManager>
                         <ContentPresenter Name="PART_ContentPresenter"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
@@ -41,10 +41,10 @@
         <Setter Property="Margin" Value="0" />
     </Style>
     <Style Selector="idc|HostWindow">
-        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" />
+        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" x:CompileBindings="False" />
         <Setter Property="Content">
             <Template>
-                <idc:DockControl Layout="{Binding}"/>
+                <idc:DockControl Layout="{Binding}" x:DataType="Dock:IHostWindow" x:CompileBindings="True"/>
             </Template>
         </Setter>
     </Style>

--- a/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
         xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">

--- a/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
@@ -7,6 +7,7 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
         <Setter Property="FontFamily" Value="{TemplateBinding FontFamily}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
                 <Border Background="{TemplateBinding Background}">

--- a/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Default/MetroWindow.xaml
@@ -2,7 +2,8 @@
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">
     <Style Selector="idc|MetroWindow">
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
@@ -10,7 +11,7 @@
         <Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border Background="{TemplateBinding Background}">
+                <Border Background="{TemplateBinding Background}" x:DataType="Dock:IHostWindow" x:CompileBindings="True">
                     <VisualLayerManager>
                         <ContentPresenter Name="PART_ContentPresenter"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/src/Dock.Avalonia.Themes.Default/NavigationControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/NavigationControl.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
         xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">

--- a/src/Dock.Avalonia.Themes.Default/NavigationControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/NavigationControl.xaml
@@ -2,18 +2,19 @@
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">
     <Style Selector="idc|NavigationControl">
         <Setter Property="Template">
             <ControlTemplate>
-                <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto">
-                    <Button Content="Back" Command="{Binding GoBack}" IsEnabled="{Binding CanGoBack}" Grid.Column="0"/>
-                    <Button Content="Forward" Command="{Binding GoForward}" IsEnabled="{Binding CanGoForward}" Grid.Column="1"/>
-                    <Button Content="Home" Command="{Binding Navigate}" CommandParameter="{Binding DefaultDockable}" Grid.Column="2"/>
+                <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto" x:DataType="Dock:IDock" x:CompileBindings="True">
+                    <Button Content="Back" Command="{Binding GoBack}" IsEnabled="{Binding CanGoBack}" Grid.Column="0" x:CompileBindings="False"/>
+                    <Button Content="Forward" Command="{Binding GoForward}" IsEnabled="{Binding CanGoForward}" Grid.Column="1" x:CompileBindings="False"/>
+                    <Button Content="Home" Command="{Binding Navigate}" CommandParameter="{Binding DefaultDockable}" Grid.Column="2" x:CompileBindings="False"/>
                     <TextBox x:Name="Id" Text="" Grid.Column="3"/>
-                    <Button Content="Navigate" Command="{Binding Navigate}" CommandParameter="{Binding #Id.Text}" Grid.Column="4"/>
-                    <Button Content="ShowWindows" Command="{Binding ActiveDockable.ShowWindows}" Grid.Column="5"/>
-                    <Button Content="ExitWindows" Command="{Binding ActiveDockable.ExitWindows}" Grid.Column="6"/>
+                    <Button Content="Navigate" Command="{Binding Navigate}" CommandParameter="{Binding #Id.Text}" Grid.Column="4" x:CompileBindings="False"/>
+                    <Button Content="ShowWindows" Command="{Binding ActiveDockable.ShowWindows}" Grid.Column="5" x:CompileBindings="False"/>
+                    <Button Content="ExitWindows" Command="{Binding ActiveDockable.ExitWindows}" Grid.Column="6" x:CompileBindings="False"/>
                 </Grid>
             </ControlTemplate>
         </Setter>

--- a/src/Dock.Avalonia.Themes.Default/PinDockControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/PinDockControl.xaml
@@ -1,0 +1,32 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model"
+        xmlns:Controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model">
+    <Style Selector="idc|PinDockControl">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel Name="DropPin" id:DockProperties.IsDropArea="True" Background="Transparent">
+                    <TabStrip Items="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable, Mode=TwoWay}" Focusable="false" ClipToBounds="False" DockPanel.Dock="{Binding Alignment, Converter={StaticResource AlignmentConverter}}">
+                        <TabStrip.Styles>
+                            <Style Selector="TabStrip:empty">
+                                <Setter Property="IsVisible" Value="False" />
+                            </Style>
+                            <Style Selector="TabStrip /template/ ItemsPresenter#PART_ItemsPresenter > WrapPanel">
+                                <Setter Property="Orientation" Value="Vertical"/>
+                            </Style>
+                        </TabStrip.Styles>
+                        <TabStrip.DataTemplates>
+                            <DataTemplate DataType="Dock:IDockable">
+                                <StackPanel Name="DragPin" id:DockProperties.IsDragArea="True" id:DockProperties.IsDropArea="True" Background="Transparent" Orientation="Horizontal" Spacing="2">
+                                    <TextBlock Text="{Binding Title}" Classes="drag" Margin="2" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </TabStrip.DataTemplates>
+                    </TabStrip>
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/src/Dock.Avalonia.Themes.Default/PinHostControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/PinHostControl.xaml
@@ -1,0 +1,109 @@
+﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
+<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:converters="clr-namespace:Dock.Avalonia.Converters;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model"
+        xmlns:Controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model">
+
+    <Style Selector="idc|PinHostControl">
+        <Style.Resources>
+            <converters:PinDockToGridLengthConverter x:Key="PinDockToGridLengthConverter"/>
+        </Style.Resources>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel Background="Transparent">
+                    <ContentControl Content="{Binding Left}" DockPanel.Dock="Left"/>
+                    <ContentControl Content="{Binding Right}" DockPanel.Dock="Right"/>
+                    <Grid>
+                        <Panel x:Name="LeftPanel"
+                               HorizontalAlignment="Left" DataContext="{Binding Left}" IsVisible="{Binding IsExpanded, FallbackValue=False}"
+                               Background="White" ZIndex="100">
+                            <idc:DockToolChrome IsActive="{Binding IsActive}" Content="{Binding ActiveDockable}"/>
+                        </Panel>
+                        <Panel x:Name="RightPanel"
+                               HorizontalAlignment="Right" DataContext="{Binding Right}" IsVisible="{Binding IsExpanded, FallbackValue=False}"
+                               Background="White" ZIndex="100">
+                            <idc:DockToolChrome IsActive="{Binding IsActive}" Content="{Binding ActiveDockable}"/>
+                        </Panel>
+                        <Grid Background="Transparent">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition>
+                                    <ColumnDefinition.Width>
+                                        <MultiBinding Converter="{StaticResource PinDockToGridLengthConverter}">
+                                            <Binding Path="#LeftPanel.Bounds.Width"/>
+                                            <Binding Path="Left.IsExpanded"/>
+                                            <Binding Path="Left.AutoHide"/>
+                                        </MultiBinding>
+                                    </ColumnDefinition.Width>
+                                </ColumnDefinition>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition>
+                                    <ColumnDefinition.Width>
+                                        <MultiBinding Converter="{StaticResource PinDockToGridLengthConverter}">
+                                            <Binding Path="#RightPanel.Bounds.Width"/>
+                                            <Binding Path="Right.IsExpanded"/>
+                                            <Binding Path="Right.AutoHide"/>
+                                        </MultiBinding>
+                                    </ColumnDefinition.Width>
+                                </ColumnDefinition>
+                            </Grid.ColumnDefinitions>
+                            <Panel Grid.Column="1">
+                                <DockPanel id:DockProperties.IsDropArea="False" Background="Transparent">
+                                    <ContentControl Content="{Binding Top}" DockPanel.Dock="Top"/>
+                                    <ContentControl Content="{Binding Bottom}" DockPanel.Dock="Bottom"/>
+                                    <Grid>
+                                        <Panel x:Name="TopPanel"
+                                               VerticalAlignment="Top" DataContext="{Binding Top}" IsVisible="{Binding IsExpanded, FallbackValue=False}"
+                                               Background="White" ZIndex="100">
+                                            <idc:DockToolChrome IsActive="{Binding IsActive}" Content="{Binding ActiveDockable}"/>
+                                        </Panel>
+                                        <Panel x:Name="BottomPanel"
+                                               VerticalAlignment="Bottom" DataContext="{Binding Bottom}" IsVisible="{Binding IsExpanded, FallbackValue=False}"
+                                               Background="White" ZIndex="100">
+                                            <idc:DockToolChrome IsActive="{Binding IsActive}" Content="{Binding ActiveDockable}"/>
+                                        </Panel>
+                                        <Grid Background="Transparent">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition>
+                                                    <RowDefinition.Height>
+                                                        <MultiBinding Converter="{StaticResource PinDockToGridLengthConverter}">
+                                                            <Binding Path="#TopPanel.Bounds.Height"/>
+                                                            <Binding Path="Top.IsExpanded"/>
+                                                            <Binding Path="Top.AutoHide"/>
+                                                        </MultiBinding>
+                                                    </RowDefinition.Height>
+                                                </RowDefinition>
+                                                <RowDefinition Height="*"/>
+                                                <RowDefinition>
+                                                    <RowDefinition.Height>
+                                                        <MultiBinding Converter="{StaticResource PinDockToGridLengthConverter}">
+                                                            <Binding Path="#BottomPanel.Bounds.Height"/>
+                                                            <Binding Path="Bottom.IsExpanded"/>
+                                                            <Binding Path="Bottom.AutoHide"/>
+                                                        </MultiBinding>
+                                                    </RowDefinition.Height>
+                                                </RowDefinition>
+                                            </Grid.RowDefinitions>
+                                            <Panel Name="ContentRoot" Grid.Row="1">
+                                                <ContentPresenter
+                                                                  Name="PART_ContentPresenter"
+                                                                  Background="{DynamicResource ThemeBackgroundBrush}"
+                                                                  BorderBrush="{TemplateBinding BorderBrush}"
+                                                                  BorderThickness="{TemplateBinding BorderThickness}"
+                                                                  Content="{TemplateBinding Content}"
+                                                                  Padding="{TemplateBinding Padding}" />
+                                            </Panel>
+                                        </Grid>
+                                    </Grid>
+                                </DockPanel>
+                            </Panel>
+                        </Grid>
+                    </Grid>
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/src/Dock.Avalonia.Themes.Default/ProportionalStackPanelSplitter.xaml
+++ b/src/Dock.Avalonia.Themes.Default/ProportionalStackPanelSplitter.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
     <Style Selector="idc|ProportionalStackPanelSplitter">

--- a/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
@@ -4,11 +4,12 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
-        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model"
+        xmlns:Controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model">
     <Style Selector="idc|ToolControl">
         <Setter Property="Template">
             <ControlTemplate>
-                <DockPanel Name="DropToolDock" id:DockProperties.IsDropArea="True" Background="Transparent" Grid.Row="1" ZIndex="1">
+                <DockPanel Name="DropToolDock" id:DockProperties.IsDropArea="True" Background="Transparent" Grid.Row="1" ZIndex="1" x:DataType="Controls:IToolDock" x:CompileBindings="True">
                     <DockPanel.Styles>
                         <Style Selector="TextBlock.drag">
                             <Setter Property="Background" Value="Transparent" />

--- a/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/ToolControl.xaml
@@ -37,7 +37,6 @@
                                         <WrapPanel ClipToBounds="False" />
                                     </ItemsPanelTemplate>
                                 </Setter>
-                                <Setter Property="MaxHeight" Value="24" />
                             </Style>
                             <Style Selector="TabStripItem">
                                 <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />

--- a/src/Dock.Avalonia.Themes.Metro/DefaultTheme.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/DefaultTheme.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Dock.Avalonia.Themes.Metro.DefaultTheme">
     <StyleInclude Source="avares://Dock.Avalonia.Themes.Metro/HostWindow.xaml"/>

--- a/src/Dock.Avalonia.Themes.Metro/DefaultTheme.xaml.cs
+++ b/src/Dock.Avalonia.Themes.Metro/DefaultTheme.xaml.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Avalonia.Styling;
 
 namespace Dock.Avalonia.Themes.Metro

--- a/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
@@ -9,6 +9,7 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
         <Setter Property="FontFamily" Value="{TemplateBinding FontFamily}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="HasSystemDecorations" Value="False" />
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="WindowState" Value="Normal" />

--- a/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:id="clr-namespace:Dock.Avalonia;assembly=Dock.Avalonia"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"

--- a/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
@@ -17,7 +17,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" x:CompileBindings="True">
+                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" x:DataType="Dock:IHostWindow" x:CompileBindings="True">
                     <VisualLayerManager>
                         <Grid ColumnDefinitions="Auto, *, Auto" RowDefinitions="Auto,Auto,*,Auto,Auto" Background="Transparent">
                             <Grid Grid.RowSpan="5" Grid.ColumnSpan="3">
@@ -97,10 +97,10 @@
         <Setter Property="Margin" Value="0" />
     </Style>
     <Style Selector="idc|HostWindow">
-        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" x:CompileBindings="True"/>
+        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" x:CompileBindings="False"/>
         <Setter Property="Content">
             <Template>
-                <idc:DockControl Layout="{Binding}" x:CompileBindings="True"/>
+                <idc:DockControl Layout="{Binding}" x:DataType="Dock:IHostWindow" x:CompileBindings="True"/>
             </Template>
         </Setter>
     </Style>

--- a/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/HostWindow.xaml
@@ -17,7 +17,7 @@
         <Setter Property="BorderBrush" Value="{DynamicResource ThemeBorderLowBrush}" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" x:CompileBindings="True">
                     <VisualLayerManager>
                         <Grid ColumnDefinitions="Auto, *, Auto" RowDefinitions="Auto,Auto,*,Auto,Auto" Background="Transparent">
                             <Grid Grid.RowSpan="5" Grid.ColumnSpan="3">
@@ -97,10 +97,10 @@
         <Setter Property="Margin" Value="0" />
     </Style>
     <Style Selector="idc|HostWindow">
-        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" />
+        <Setter Property="Title" Value="{Binding ActiveDockable.Title}" x:CompileBindings="True"/>
         <Setter Property="Content">
             <Template>
-                <idc:DockControl Layout="{Binding}"/>
+                <idc:DockControl Layout="{Binding}" x:CompileBindings="True"/>
             </Template>
         </Setter>
     </Style>

--- a/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
@@ -1,6 +1,4 @@
-﻿<!-- Copyright (c) Wiesław Šoltés. All rights reserved. -->
-<!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
-<Styles xmlns="https://github.com/avaloniaui"
+﻿<Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
         xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">

--- a/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
@@ -7,6 +7,7 @@
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
         <Setter Property="FontFamily" Value="{TemplateBinding FontFamily}" />
+        <Setter Property="TextBlock.Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
         <Setter Property="HasSystemDecorations" Value="False" />
         <Setter Property="Template">
             <ControlTemplate>

--- a/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
+++ b/src/Dock.Avalonia.Themes.Metro/MetroWindow.xaml
@@ -2,7 +2,8 @@
 <!-- Licensed under the MIT license. See LICENSE file in the project root for full license information. -->
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia">
+        xmlns:idc="clr-namespace:Dock.Avalonia.Controls;assembly=Dock.Avalonia"
+        xmlns:Dock="clr-namespace:Dock.Model;assembly=Dock.Model">
     <Style Selector="idc|MetroWindow">
         <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
         <Setter Property="FontSize" Value="{DynamicResource FontSizeNormal}" />
@@ -11,7 +12,7 @@
         <Setter Property="HasSystemDecorations" Value="False" />
         <Setter Property="Template">
             <ControlTemplate>
-                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}">
+                <Border BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" x:DataType="Dock:IHostWindow" x:CompileBindings="True">
                     <VisualLayerManager>
                         <Grid ColumnDefinitions="Auto, *, Auto" RowDefinitions="Auto,Auto,*,Auto,Auto" Background="Transparent">
                             <Grid Grid.RowSpan="5" Grid.ColumnSpan="3">

--- a/src/Dock.Avalonia/AdornerHelper.cs
+++ b/src/Dock.Avalonia/AdornerHelper.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.LogicalTree;
 using Avalonia.VisualTree;

--- a/src/Dock.Avalonia/Controls/DockControl.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls.Primitives;

--- a/src/Dock.Avalonia/Controls/DockPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/DockPanelSplitter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;

--- a/src/Dock.Avalonia/Controls/DockTarget.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;

--- a/src/Dock.Avalonia/Controls/DockTarget.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.cs
@@ -33,9 +33,9 @@ namespace Dock.Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
-            base.OnTemplateApplied(e);
+            base.OnApplyTemplate(e);
 
             _topIndicator = e.NameScope.Find<Grid>("PART_TopIndicator");
             _bottomIndicator = e.NameScope.Find<Grid>("PART_BottomIndicator");

--- a/src/Dock.Avalonia/Controls/DockToolChrome.cs
+++ b/src/Dock.Avalonia/Controls/DockToolChrome.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Dock.Model;
@@ -17,22 +18,25 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DockToolChrome : ContentControl
     {
-        static DockToolChrome()
-        {
-            PseudoClass<DockToolChrome>(IsActiveProperty, ":active");
-        }
-
         /// <summary>
         /// Define <see cref="Title"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<string> TitleProprty =
+        public static readonly StyledProperty<string> TitleProprty =
             AvaloniaProperty.Register<DockToolChrome, string>(nameof(Title));
 
         /// <summary>
         /// Define the <see cref="IsActive"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<bool> IsActiveProperty =
+        public static readonly StyledProperty<bool> IsActiveProperty =
             AvaloniaProperty.Register<DockToolChrome, bool>(nameof(IsActive));
+
+        /// <summary>
+        /// Initialize the new instance of the <see cref="DockToolChrome"/>.
+        /// </summary>
+        public DockToolChrome()
+        {
+            UpdatePseudoClasses(IsActive);
+        }
 
         /// <summary>
         /// Gets or sets chrome tool title.
@@ -56,20 +60,17 @@ namespace Dock.Avalonia.Controls
 
         internal Button? CloseButton { get; private set; }
 
-        private IDisposable? _disposable;
-
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            _disposable = AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
         }
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)
@@ -101,6 +102,26 @@ namespace Dock.Avalonia.Controls
 
                 this.PseudoClasses.Set(":floating", true);
             }
+        }
+
+        /// <inheritdoc/>
+        protected override void OnPropertyChanged<T>(
+            AvaloniaProperty<T> property,
+            Optional<T> oldValue,
+            BindingValue<T> newValue,
+            BindingPriority priority)
+        {
+            base.OnPropertyChanged(property, oldValue, newValue, priority);
+
+            if (property == IsActiveProperty)
+            {
+                UpdatePseudoClasses(newValue.GetValueOrDefault<bool>());
+            }
+        }
+
+        private void UpdatePseudoClasses(bool isActive)
+        {
+            PseudoClasses.Set(":active", isActive);
         }
     }
 }

--- a/src/Dock.Avalonia/Controls/DockToolChrome.cs
+++ b/src/Dock.Avalonia/Controls/DockToolChrome.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Diagnostics;
 using Avalonia;

--- a/src/Dock.Avalonia/Controls/DockToolChrome.cs
+++ b/src/Dock.Avalonia/Controls/DockToolChrome.cs
@@ -89,9 +89,9 @@ namespace Dock.Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
-            base.OnTemplateApplied(e);
+            base.OnApplyTemplate(e);
 
             if (VisualRoot is HostWindow window)
             {
@@ -105,17 +105,13 @@ namespace Dock.Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnPropertyChanged<T>(
-            AvaloniaProperty<T> property,
-            Optional<T> oldValue,
-            BindingValue<T> newValue,
-            BindingPriority priority)
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
         {
-            base.OnPropertyChanged(property, oldValue, newValue, priority);
+            base.OnPropertyChanged(change);
 
-            if (property == IsActiveProperty)
+            if (change.Property == IsActiveProperty)
             {
-                UpdatePseudoClasses(newValue.GetValueOrDefault<bool>());
+                UpdatePseudoClasses(change.NewValue.GetValueOrDefault<bool>());
             }
         }
 

--- a/src/Dock.Avalonia/Controls/DocumentControl.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Diagnostics;
 using Avalonia;

--- a/src/Dock.Avalonia/Controls/DocumentControl.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.cs
@@ -16,20 +16,17 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DocumentControl : TemplatedControl
     {
-        private IDisposable? _disposable;
-
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            _disposable = AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
         }
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)

--- a/src/Dock.Avalonia/Controls/HostWindow.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Reactive.Linq;
 using Avalonia;

--- a/src/Dock.Avalonia/Controls/HostWindow.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.cs
@@ -265,9 +265,9 @@ namespace Dock.Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
-            base.OnTemplateApplied(e);
+            base.OnApplyTemplate(e);
 
             _titleBar = e.NameScope.Find<Control>("PART_TitleBar");
             _minimiseButton = e.NameScope.Find<Button>("PART_MinimiseButton");

--- a/src/Dock.Avalonia/Controls/HostWindow.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.cs
@@ -23,13 +23,13 @@ namespace Dock.Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="IsChromeVisible"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<bool> IsChromeVisibleProperty =
+        public static readonly StyledProperty<bool> IsChromeVisibleProperty =
             AvaloniaProperty.Register<HostWindow, bool>(nameof(IsChromeVisible), true);
 
         /// <summary>
         /// Defines the <see cref="TitleBarContent"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<Control> TitleBarContentProperty =
+        public static readonly StyledProperty<Control> TitleBarContentProperty =
             AvaloniaProperty.Register<HostWindow, Control>(nameof(TitleBarContent));
 
         /// <summary>
@@ -81,8 +81,6 @@ namespace Dock.Avalonia.Controls
         /// </summary>
         public HostWindow()
         {
-            this.AttachDevTools();
-
             AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
             AddHandler(InputElement.PointerReleasedEvent, Released, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
             AddHandler(InputElement.PointerMovedEvent, Moved, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);

--- a/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
+++ b/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls

--- a/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
+++ b/src/Dock.Avalonia/Controls/MarkupExtensions/LoadExtension.cs
@@ -36,8 +36,7 @@ namespace Dock.Avalonia.Controls
             if (serviceProvider.GetService(typeof(IUriContext)) is IUriContext uriContext)
             {
                 var baseUri = uriContext.BaseUri;
-                var loader = new AvaloniaXamlLoader();
-                var obj = loader.Load(Source, baseUri);
+                var obj = AvaloniaXamlLoader.Load(Source, baseUri);
                 return obj;
             }
             return default;

--- a/src/Dock.Avalonia/Controls/MarkupExtensions/ReferenceExtension.cs
+++ b/src/Dock.Avalonia/Controls/MarkupExtensions/ReferenceExtension.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 

--- a/src/Dock.Avalonia/Controls/MetroWindow.cs
+++ b/src/Dock.Avalonia/Controls/MetroWindow.cs
@@ -26,8 +26,8 @@ namespace Dock.Avalonia.Controls
         private Button? _closeButton;
         private Button? _minimiseButton;
         private Button? _restoreButton;
-        private Image? _icon;
-        private bool _mouseDown;
+        //private Image? _icon;
+        //private bool _mouseDown;
 
         /// <summary>
         /// Defines the <see cref="IsChromeVisible"/> property.
@@ -111,17 +111,17 @@ namespace Dock.Avalonia.Controls
             }
             else if (_titleBar != null && _titleBar.IsPointerOver)
             {
-                _mouseDown = true;
+                //_mouseDown = true;
 
                 if(e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
                 {
                     BeginMoveDrag(e);
-                    _mouseDown = false;
+                    //_mouseDown = false;
                 }
             }
             else
             {
-                _mouseDown = false;
+                //_mouseDown = false;
             }
 
             base.OnPointerPressed(e);
@@ -130,7 +130,7 @@ namespace Dock.Avalonia.Controls
         /// <inheritdoc/>
         protected override void OnPointerReleased(PointerReleasedEventArgs e)
         {
-            _mouseDown = false;
+            //_mouseDown = false;
             base.OnPointerReleased(e);
         }
 
@@ -143,7 +143,7 @@ namespace Dock.Avalonia.Controls
             _minimiseButton = e.NameScope.Find<Button>("PART_MinimiseButton");
             _restoreButton = e.NameScope.Find<Button>("PART_RestoreButton");
             _closeButton = e.NameScope.Find<Button>("PART_CloseButton");
-            _icon = e.NameScope.Find<Image>("PART_Icon");
+            //_icon = e.NameScope.Find<Image>("PART_Icon");
 
             _topHorizontalGrip = e.NameScope.Find<Grid>("PART_TopHorizontalGrip");
             _bottomHorizontalGrip = e.NameScope.Find<Grid>("PART_BottomHorizontalGrip");

--- a/src/Dock.Avalonia/Controls/MetroWindow.cs
+++ b/src/Dock.Avalonia/Controls/MetroWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;

--- a/src/Dock.Avalonia/Controls/MetroWindow.cs
+++ b/src/Dock.Avalonia/Controls/MetroWindow.cs
@@ -135,9 +135,9 @@ namespace Dock.Avalonia.Controls
         }
 
         /// <inheritdoc/>
-        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
-            base.OnTemplateApplied(e);
+            base.OnApplyTemplate(e);
 
             _titleBar = e.NameScope.Find<Grid>("PART_TitleBar");
             _minimiseButton = e.NameScope.Find<Button>("PART_MinimiseButton");

--- a/src/Dock.Avalonia/Controls/MetroWindow.cs
+++ b/src/Dock.Avalonia/Controls/MetroWindow.cs
@@ -32,13 +32,13 @@ namespace Dock.Avalonia.Controls
         /// <summary>
         /// Defines the <see cref="IsChromeVisible"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<bool> IsChromeVisibleProperty =
+        public static readonly StyledProperty<bool> IsChromeVisibleProperty =
             AvaloniaProperty.Register<MetroWindow, bool>(nameof(IsChromeVisible), true);
 
         /// <summary>
         /// Defines the <see cref="TitleBarContent"/> property.
         /// </summary>
-        public static readonly AvaloniaProperty<Control> TitleBarContentProperty =
+        public static readonly StyledProperty<Control> TitleBarContentProperty =
             AvaloniaProperty.Register<MetroWindow, Control>(nameof(TitleBarContent));
 
         /// <summary>

--- a/src/Dock.Avalonia/Controls/NavigationControl.cs
+++ b/src/Dock.Avalonia/Controls/NavigationControl.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Avalonia.Controls.Primitives;
 
 namespace Dock.Avalonia.Controls

--- a/src/Dock.Avalonia/Controls/PinDockControl.cs
+++ b/src/Dock.Avalonia/Controls/PinDockControl.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Dock.Model;
+using Dock.Model.Controls;
+
+namespace Dock.Avalonia.Controls
+{
+    /// <summary>
+    /// Represents a pin attached to side of dock, which can expand and collapse
+    /// </summary>
+    public class PinDockControl : ContentControl
+    {
+        private IDisposable? _disposable;
+
+        /// <inheritdoc/>
+        protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnAttachedToVisualTree(e);        
+            _disposable = this.AddDisposableHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            _disposable?.Dispose();
+        }
+
+        private void Pressed(object sender, PointerPressedEventArgs e)
+        {
+            if (this.DataContext is IDock dock && dock.Factory is IFactory factory)
+            {
+                if (dock.ActiveDockable != null)
+                {
+                    if (factory.FindRoot(dock.ActiveDockable) is IRootDock root)
+                    {
+                        Debug.WriteLine($"{nameof(PinDockControl)} SetFocusedDockable {dock.ActiveDockable.GetType().Name}, owner: {dock.Title}");
+                        factory.SetFocusedDockable(root, dock.ActiveDockable);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Dock.Avalonia/Controls/PinHostControl.cs
+++ b/src/Dock.Avalonia/Controls/PinHostControl.cs
@@ -1,0 +1,12 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls
+{
+    /// <summary>
+    /// Adds pin docking capabilities to other docks
+    /// </summary>
+    public class PinHostControl : ContentControl
+    {
+    }
+}

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -140,6 +140,10 @@ namespace Dock.Avalonia.Controls
                 {
                     element.Measure(Size.Infinity);
                 }
+                else
+                {
+                    element.Measure(constraint);
+                }
             }
 
             return new Size();

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -132,17 +132,88 @@ namespace Dock.Avalonia.Controls
         /// <inheritdoc/>
         protected override Size MeasureOverride(Size constraint)
         {
+            var horizontal = Orientation == Orientation.Horizontal;
+
+            if (constraint == Size.Infinity 
+                || (horizontal && double.IsInfinity(constraint.Width)) 
+                || (!horizontal && double.IsInfinity(constraint.Height)))
+            {
+                throw new Exception("Proportional StackPanel cannot be inside a control that offers infinite space.");                
+            }
+
+            double usedWidth = 0.0;
+            double usedHeight = 0.0;
+            double maximumWidth = 0.0;
+            double maximumHeight = 0.0;
+
+            var splitterThickness = GetTotalSplitterThickness();
+
             AssignProportions();
 
+            // Measure each of the Children
             foreach (Control element in GetChildren())
             {
-                if (element is ProportionalStackPanelSplitter)
+                // Get the child's desired size
+                Size remainingSize = new Size(
+                    Math.Max(0.0, constraint.Width - usedWidth - splitterThickness),
+                    Math.Max(0.0, constraint.Height - usedHeight - splitterThickness));
+
+                var proportion = ProportionalStackPanelSplitter.GetProportion(element);
+
+                if (!(element is ProportionalStackPanelSplitter))
                 {
-                    element.Measure(Size.Infinity);
+                    switch (Orientation)
+                    {
+                        case Orientation.Horizontal:
+                            element.Measure(constraint.WithWidth(Math.Max(0, (constraint.Width - splitterThickness) * proportion)));
+                            break;
+
+                        case Orientation.Vertical:
+                            element.Measure(constraint.WithHeight(Math.Max(0, (constraint.Height - splitterThickness) * proportion)));
+                            break;
+                    }
+                }
+                else
+                {
+                    element.Measure(remainingSize);
+                }
+
+                var desiredSize = element.DesiredSize;
+
+                // Decrease the remaining space for the rest of the children
+                switch (Orientation)
+                {
+                    case Orientation.Horizontal:
+                        maximumHeight = Math.Max(maximumHeight, usedHeight + desiredSize.Height);
+
+                        if (element is ProportionalStackPanelSplitter)
+                        {
+                            usedWidth += desiredSize.Width;
+                        }
+                        else
+                        {
+                            usedWidth += Math.Max(0, (constraint.Width - splitterThickness) * proportion);
+                        }
+                        break;
+                    case Orientation.Vertical:
+                        maximumWidth = Math.Max(maximumWidth, usedWidth + desiredSize.Width);
+
+                        if (element is ProportionalStackPanelSplitter)
+                        {
+                            usedHeight += desiredSize.Height;
+                        }
+                        else
+                        {
+                            usedHeight += Math.Max(0, (constraint.Height - splitterThickness) * proportion);
+                        }
+                        break;
                 }
             }
 
-            return new Size();
+            maximumWidth = Math.Max(maximumWidth, usedWidth);
+            maximumHeight = Math.Max(maximumHeight, usedHeight);
+
+            return new Size(maximumWidth, maximumHeight);
         }
 
         /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -37,6 +37,7 @@ namespace Dock.Avalonia.Controls
             {
                 if (c is ContentPresenter cp)
                 {
+                    cp.UpdateChild();
                     return cp.Child;
                 }
                 else

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -140,10 +140,6 @@ namespace Dock.Avalonia.Controls
                 {
                     element.Measure(Size.Infinity);
                 }
-                else
-                {
-                    element.Measure(constraint);
-                }
             }
 
             return new Size();

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanelSplitter.cs
@@ -83,6 +83,7 @@ namespace Dock.Avalonia.Controls
             }
         }
 
+        /// <inheritdoc/>
         protected override Size MeasureOverride(Size availableSize)
         {
             if (GetPanel() is ProportionalStackPanel panel)

--- a/src/Dock.Avalonia/Controls/ToolControl.cs
+++ b/src/Dock.Avalonia/Controls/ToolControl.cs
@@ -16,20 +16,17 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class ToolControl : TemplatedControl
     {
-        private IDisposable? _disposable;
-
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
-            _disposable = AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
+            AddHandler(InputElement.PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
         }
 
         /// <inheritdoc/>
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnDetachedFromVisualTree(e);
-            _disposable?.Dispose();
         }
 
         private void Pressed(object sender, PointerPressedEventArgs e)

--- a/src/Dock.Avalonia/Controls/ToolControl.cs
+++ b/src/Dock.Avalonia/Controls/ToolControl.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Diagnostics;
 using Avalonia;

--- a/src/Dock.Avalonia/Converters/AlignmentConverter.cs
+++ b/src/Dock.Avalonia/Converters/AlignmentConverter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Data.Converters;

--- a/src/Dock.Avalonia/Converters/OrientationConverter.cs
+++ b/src/Dock.Avalonia/Converters/OrientationConverter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Data.Converters;

--- a/src/Dock.Avalonia/Converters/PinDockToGridLengthConverter.cs
+++ b/src/Dock.Avalonia/Converters/PinDockToGridLengthConverter.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+
+namespace Dock.Avalonia.Converters
+{
+    /// <summary>
+    /// Converter used by PinHostControl to position PinDocks around rock docks
+    /// </summary>
+    public class PinDockToGridLengthConverter : IMultiValueConverter
+    {
+        /// <summary>
+        /// Converts 3 bindings into <see cref="GridLength"/>
+        /// This is used to puppeter RootDock content when there are PinDocks without AutoHide
+        /// </summary>
+        /// <param name="values">3 objects from binding are expected in exact order-</param>
+        /// <param name="targetType"></param>
+        /// <param name="parameter"></param>
+        /// <param name="culture"></param>
+        /// <returns></returns>
+        public object Convert(IList<object> values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values.Count == 3 && values[0] is double panelWidth && values[1] is bool isExpanded && values[2] is bool autoHide)
+            {
+                if (autoHide || isExpanded == false)
+                {
+                    return new GridLength(0);
+                }
+                else
+                {
+                    return new GridLength(panelWidth);
+                }
+
+            }
+            return new GridLength(0);
+        }
+    }
+}

--- a/src/Dock.Avalonia/DockControlState.cs
+++ b/src/Dock.Avalonia/DockControlState.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Avalonia;

--- a/src/Dock.Avalonia/DockHelpers.cs
+++ b/src/Dock.Avalonia/DockHelpers.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/Dock.Avalonia/DockProperties.cs
+++ b/src/Dock.Avalonia/DockProperties.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Avalonia;
+﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 

--- a/src/Dock.Avalonia/DockProperties.cs
+++ b/src/Dock.Avalonia/DockProperties.cs
@@ -26,13 +26,13 @@ namespace Dock.Avalonia
         /// <summary>
         /// Define IsDragEnabled attached property.
         /// </summary>
-        public static readonly AvaloniaProperty<bool> IsDragEnabledProperty =
+        public static readonly StyledProperty<bool> IsDragEnabledProperty =
             AvaloniaProperty.RegisterAttached<DockProperties, IControl, bool>("IsDragEnabled", true, true, BindingMode.TwoWay);
 
         /// <summary>
         /// Define IsDropEnabled attached property.
         /// </summary>
-        public static readonly AvaloniaProperty<bool> IsDropEnabledProperty =
+        public static readonly StyledProperty<bool> IsDropEnabledProperty =
             AvaloniaProperty.RegisterAttached<DockProperties, IControl, bool>("IsDropEnabled", true, true, BindingMode.TwoWay);
 
         /// <summary>

--- a/src/Dock.Avalonia/DockSettings.cs
+++ b/src/Dock.Avalonia/DockSettings.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Avalonia
 {
     /// <summary>

--- a/src/Dock.Avalonia/EventType.cs
+++ b/src/Dock.Avalonia/EventType.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Avalonia
 {
     /// <summary>

--- a/src/Dock.Avalonia/HostWindowState.cs
+++ b/src/Dock.Avalonia/HostWindowState.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;

--- a/src/Dock.Model.Avalonia/Controls/Document.cs
+++ b/src/Dock.Model.Avalonia/Controls/Document.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.Avalonia/Controls/PinDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/PinDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Avalonia;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model.Avalonia/Controls/PinDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/PinDock.cs
@@ -62,6 +62,30 @@ namespace Dock.Model.Controls
         {
             Id = nameof(IPinDock);
             Title = nameof(IPinDock);
+
+            PropertyChanged += PinDock_PropertyChanged;
+        }
+
+        private void PinDock_PropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            switch (e.Property.Name)
+            {
+                case nameof(IsActive):
+                    if (AutoHide)
+                    {
+                        IsExpanded = IsActive;
+                    }
+                    break;
+                case nameof(AutoHide):
+                    IsExpanded = true;
+                    break;
+                case nameof(ActiveDockable):
+                    if (VisibleDockables?.Count == 0)
+                    {
+                        IsActive = false;
+                    }
+                    break;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Dock.Model.Avalonia/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/ProportionalDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Avalonia;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model.Avalonia/Controls/RootDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/RootDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Avalonia;
 using Avalonia.Collections;

--- a/src/Dock.Model.Avalonia/Controls/SplitterDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/SplitterDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.Avalonia/Controls/Tool.cs
+++ b/src/Dock.Model.Avalonia/Controls/Tool.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.Avalonia/Controls/ToolDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/ToolDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Avalonia;

--- a/src/Dock.Model.Avalonia/Core/DockWindow.cs
+++ b/src/Dock.Model.Avalonia/Core/DockWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Avalonia;
 using Avalonia.Metadata;
 using Dock.Model.Controls;

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Avalonia;
 
 namespace Dock.Model

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Avalonia.Collections;
 using Dock.Model.Controls;
 

--- a/src/Dock.Model.INPC/Controls/Document.cs
+++ b/src/Dock.Model.INPC/Controls/Document.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/DocumentDock.cs
+++ b/src/Dock.Model.INPC/Controls/DocumentDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/PinDock.cs
+++ b/src/Dock.Model.INPC/Controls/PinDock.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.ComponentModel;
+using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {
@@ -17,7 +18,7 @@ namespace Dock.Model.Controls
         public Alignment Alignment
         {
             get => _alignment;
-            set => this.RaiseAndSetIfChanged(ref _alignment, value);
+            set => RaiseAndSetIfChanged(ref _alignment, value);
         }
 
         /// <inheritdoc/>
@@ -25,7 +26,7 @@ namespace Dock.Model.Controls
         public bool IsExpanded
         {
             get => _isExpanded;
-            set => this.RaiseAndSetIfChanged(ref _isExpanded, value);
+            set => RaiseAndSetIfChanged(ref _isExpanded, value);
         }
 
         /// <inheritdoc/>
@@ -33,7 +34,7 @@ namespace Dock.Model.Controls
         public bool AutoHide
         {
             get => _autoHide;
-            set => this.RaiseAndSetIfChanged(ref _autoHide, value);
+            set => RaiseAndSetIfChanged(ref _autoHide, value);
         }
 
         /// <summary>
@@ -43,6 +44,30 @@ namespace Dock.Model.Controls
         {
             Id = nameof(IPinDock);
             Title = nameof(IPinDock);
+
+            PropertyChanged += PinDock_PropertyChanged;
+        }
+
+        private void PinDock_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            switch (e.PropertyName)
+            {
+                case nameof(IsActive):
+                    if (AutoHide)
+                    {
+                        IsExpanded = IsActive;
+                    }
+                    break;
+                case nameof(AutoHide):
+                    IsExpanded = true;
+                    break;
+                case nameof(ActiveDockable):
+                    if (VisibleDockables?.Count == 0)
+                    {
+                        IsActive = false;
+                    }
+                    break;
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Dock.Model.INPC/Controls/PinDock.cs
+++ b/src/Dock.Model.INPC/Controls/PinDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.INPC/Controls/ProportionalDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/RootDock.cs
+++ b/src/Dock.Model.INPC/Controls/RootDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model.INPC/Controls/SplitterDock.cs
+++ b/src/Dock.Model.INPC/Controls/SplitterDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/Tool.cs
+++ b/src/Dock.Model.INPC/Controls/Tool.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Controls/ToolDock.cs
+++ b/src/Dock.Model.INPC/Controls/ToolDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.INPC/Core/DockBase.cs
+++ b/src/Dock.Model.INPC/Core/DockBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Dock.Model

--- a/src/Dock.Model.INPC/Core/DockWindow.cs
+++ b/src/Dock.Model.INPC/Core/DockWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Dock.Model.Controls;
 
 namespace Dock.Model

--- a/src/Dock.Model.INPC/Core/DockableBase.cs
+++ b/src/Dock.Model.INPC/Core/DockableBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model
 {

--- a/src/Dock.Model.INPC/Factory.cs
+++ b/src/Dock.Model.INPC/Factory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Dock.Model.Controls;
 

--- a/src/Dock.Model.INPC/ObservableObject.cs
+++ b/src/Dock.Model.INPC/ObservableObject.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace Dock.Model

--- a/src/Dock.Model.ReactiveUI/Controls/Document.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/Document.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using ReactiveUI;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/PinDock.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using ReactiveUI;
+using System;
 
 namespace Dock.Model.Controls
 {
@@ -44,6 +45,28 @@ namespace Dock.Model.Controls
         {
             Id = nameof(IPinDock);
             Title = nameof(IPinDock);
+
+            this.ObservableForProperty(n => n.IsActive)
+                .Subscribe(isActive =>
+                {
+                    if(AutoHide)
+                    {
+                        IsExpanded = isActive.Value;
+                    }
+                });
+            this.ObservableForProperty(n => n.AutoHide)
+                .Subscribe(autoHide =>
+                {
+                    IsExpanded = true;
+                });
+            this.ObservableForProperty(n => n.ActiveDockable)
+                .Subscribe(activeDockable =>
+                {
+                    if(VisibleDockables?.Count == 0)
+                    {
+                        IsActive = false;
+                    }
+                });
         }
 
         /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Controls/ProportionalDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ProportionalDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using ReactiveUI;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using ReactiveUI;
 

--- a/src/Dock.Model.ReactiveUI/Controls/SplitterDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/SplitterDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.ReactiveUI/Controls/Tool.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/Tool.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.ReactiveUI/Controls/ToolDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ToolDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 
 namespace Dock.Model.Controls
 {

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
 using ReactiveUI;
 

--- a/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using Dock.Model.Controls;
 using ReactiveUI;
 

--- a/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Runtime.Serialization;
+﻿using System.Runtime.Serialization;
 using ReactiveUI;
 
 namespace Dock.Model

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Dock.Model.Controls;
 using ReactiveUI.Legacy;

--- a/src/Dock.Model/Adapters/HostAdapter.cs
+++ b/src/Dock.Model/Adapters/HostAdapter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Adapters/NavigateAdapter.cs
+++ b/src/Dock.Model/Adapters/NavigateAdapter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dock.Model.Controls;

--- a/src/Dock.Model/CloneHelper.cs
+++ b/src/Dock.Model/CloneHelper.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Dock.Model.Controls;
 
 namespace Dock.Model

--- a/src/Dock.Model/Controls/IDocument.cs
+++ b/src/Dock.Model/Controls/IDocument.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/IDocumentDock.cs
+++ b/src/Dock.Model/Controls/IDocumentDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/IPinDock.cs
+++ b/src/Dock.Model/Controls/IPinDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/IProportionalDock.cs
+++ b/src/Dock.Model/Controls/IProportionalDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/IRootDock.cs
+++ b/src/Dock.Model/Controls/IRootDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System.Collections.Generic;
 
 namespace Dock.Model.Controls

--- a/src/Dock.Model/Controls/ISplitterDock.cs
+++ b/src/Dock.Model/Controls/ISplitterDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/ITool.cs
+++ b/src/Dock.Model/Controls/ITool.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Controls/IToolDock.cs
+++ b/src/Dock.Model/Controls/IToolDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     /// <summary>

--- a/src/Dock.Model/Core/Alignment.cs
+++ b/src/Dock.Model/Core/Alignment.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Core/DockOperation.cs
+++ b/src/Dock.Model/Core/DockOperation.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Core/DockPoint.cs
+++ b/src/Dock.Model/Core/DockPoint.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Globalization;
+﻿using System.Globalization;
 
 namespace Dock.Model
 {

--- a/src/Dock.Model/Core/DragAction.cs
+++ b/src/Dock.Model/Core/DragAction.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 
 namespace Dock.Model
 {

--- a/src/Dock.Model/Core/IDock.cs
+++ b/src/Dock.Model/Core/IDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System.Collections.Generic;
 
 namespace Dock.Model

--- a/src/Dock.Model/Core/IDockManager.cs
+++ b/src/Dock.Model/Core/IDockManager.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 
 namespace Dock.Model
 {

--- a/src/Dock.Model/Core/IDockWindow.cs
+++ b/src/Dock.Model/Core/IDockWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using Dock.Model.Controls;
 
 namespace Dock.Model

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Dock.Model.Controls;
 

--- a/src/Dock.Model/Core/IHostAdapter.cs
+++ b/src/Dock.Model/Core/IHostAdapter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Core/IHostWindow.cs
+++ b/src/Dock.Model/Core/IHostWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/Core/INavigateAdapter.cs
+++ b/src/Dock.Model/Core/INavigateAdapter.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using Dock.Model.Controls;
 
 namespace Dock.Model

--- a/src/Dock.Model/Core/Orientation.cs
+++ b/src/Dock.Model/Core/Orientation.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     /// <summary>

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Linq;
+﻿using System.Linq;
 using Dock.Model.Controls;
 
 namespace Dock.Model

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Dock.Serializer/DockSerializer.cs
+++ b/src/Dock.Serializer/DockSerializer.cs
@@ -63,7 +63,7 @@ namespace Dock.Serializer
 
         public T Deserialize<T>(string text)
         {
-            return JsonConvert.DeserializeObject<T>(text, _settings);
+            return JsonConvert.DeserializeObject<T>(text, _settings)!;
         }
 
         public T Load<T>(string path)

--- a/src/Dock.Serializer/DockSerializer.cs
+++ b/src/Dock.Serializer/DockSerializer.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/Dock.Serializer/IDockSerializer.cs
+++ b/src/Dock.Serializer/IDockSerializer.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Serializer
 {
     public interface IDockSerializer

--- a/tests/Dock.Avalonia.UnitTests/Controls/DockControlTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/DockControlTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/DockPanelSplitterTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/DockPanelSplitterTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/DockTargetTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/DockTargetTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/DockToolChromeTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/DockToolChromeTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/DocumentControlTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/DocumentControlTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/HostWindowTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/HostWindowTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/MetroWindowTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/MetroWindowTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/NavigationControlTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/NavigationControlTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelSplitterTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelSplitterTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Avalonia.Controls;
+﻿using Dock.Avalonia.Controls;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -153,8 +153,8 @@ namespace Dock.Avalonia.UnitTests.Controls
 
             Assert.Equal(new Size(1000, 500), target.Bounds.Size);
             Assert.Equal(new Rect(0, 0, 331, 500), target.Children[0].Bounds);
-            Assert.Equal(new Rect(330, 0, 4, 500), target.Children[1].Bounds);
-            Assert.Equal(new Rect(334, 0, 331, 500), target.Children[2].Bounds);
+            Assert.Equal(new Rect(331, 0, 4, 500), target.Children[1].Bounds);
+            Assert.Equal(new Rect(335, 0, 331, 500), target.Children[2].Bounds);
             Assert.Equal(new Rect(665, 0, 4, 500), target.Children[3].Bounds);
             Assert.Equal(new Rect(669, 0, 331, 500), target.Children[4].Bounds);
         }

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;

--- a/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Avalonia.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Avalonia.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using Xunit;
 

--- a/tests/Dock.Model.Avalonia.UnitTests/CloneHelperTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/CloneHelperTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Dock.Model.Controls;
 using Xunit;
 

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/DocumentDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/DocumentDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/PinDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/PinDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/ProportionalDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/ProportionalDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/RootDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/RootDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/SplitterDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/SplitterDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/ToolDockTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/ToolDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests.Controls

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockWindowTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockWindowTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests
 {

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/DockableBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.Avalonia.UnitTests

--- a/tests/Dock.Model.Avalonia.UnitTests/Core/StyledElementTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Core/StyledElementTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 using Avalonia;
 
 namespace Dock.Model.Avalonia.UnitTests

--- a/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Model.Avalonia.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/FactoryTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Avalonia.Collections;
 using Dock.Model.Controls;
 using Xunit;

--- a/tests/Dock.Model.Avalonia.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using Xunit;
 

--- a/tests/Dock.Model.INPC.UnitTests/CloneHelperTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/CloneHelperTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Dock.Model.Controls;
 using Xunit;
 

--- a/tests/Dock.Model.INPC.UnitTests/Controls/DocumentDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/DocumentDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Controls/PinDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/PinDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Controls/ProportionalDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/ProportionalDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Controls/RootDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/RootDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Controls/SplitterDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/SplitterDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Controls/ToolDockTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Controls/ToolDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests.Controls

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockWindowTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockWindowTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.INPC.UnitTests
 {

--- a/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Core/DockableBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.INPC.UnitTests

--- a/tests/Dock.Model.INPC.UnitTests/Dock.Model.INPC.UnitTests.csproj
+++ b/tests/Dock.Model.INPC.UnitTests/Dock.Model.INPC.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Model.INPC.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/FactoryTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using Dock.Model.Controls;
 using Xunit;

--- a/tests/Dock.Model.INPC.UnitTests/ObservableObjectTests.cs
+++ b/tests/Dock.Model.INPC.UnitTests/ObservableObjectTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.INPC.UnitTests
 {

--- a/tests/Dock.Model.INPC.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Model.INPC.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using Xunit;
 

--- a/tests/Dock.Model.ReactiveUI.UnitTests/CloneHelperTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/CloneHelperTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Dock.Model.Controls;
 using Xunit;
 

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DocumentDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DocumentDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/PinDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/PinDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/ProportionalDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/ProportionalDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/RootDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/RootDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/SplitterDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/SplitterDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/ToolDockTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/ToolDockTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Dock.Model.Controls;
+﻿using Dock.Model.Controls;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests.Controls

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockBaseTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockWindowTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockWindowTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests
 {

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Core/DockableBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using Xunit;
 
 namespace Dock.Model.ReactiveUI.UnitTests

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Model.ReactiveUI.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/FactoryTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.ObjectModel;
 using Dock.Model.Controls;
 using ReactiveUI.Legacy;

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using Xunit;
 

--- a/tests/Dock.Model.Test/Controls/Document.cs
+++ b/tests/Dock.Model.Test/Controls/Document.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     public class Document : DockableBase, IDocument

--- a/tests/Dock.Model.Test/Controls/DocumentDock.cs
+++ b/tests/Dock.Model.Test/Controls/DocumentDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.Controls

--- a/tests/Dock.Model.Test/Controls/PinDock.cs
+++ b/tests/Dock.Model.Test/Controls/PinDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.Controls

--- a/tests/Dock.Model.Test/Controls/ProportionalDock.cs
+++ b/tests/Dock.Model.Test/Controls/ProportionalDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.Controls

--- a/tests/Dock.Model.Test/Controls/RootDock.cs
+++ b/tests/Dock.Model.Test/Controls/RootDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 using System.Collections.Generic;
 

--- a/tests/Dock.Model.Test/Controls/SplitterDock.cs
+++ b/tests/Dock.Model.Test/Controls/SplitterDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.Controls

--- a/tests/Dock.Model.Test/Controls/Tool.cs
+++ b/tests/Dock.Model.Test/Controls/Tool.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.Controls
 {
     public class Tool : DockableBase, ITool, IDocument

--- a/tests/Dock.Model.Test/Controls/ToolDock.cs
+++ b/tests/Dock.Model.Test/Controls/ToolDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.Controls

--- a/tests/Dock.Model.Test/Core/DockBase.cs
+++ b/tests/Dock.Model.Test/Core/DockBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace Dock.Model
 {

--- a/tests/Dock.Model.Test/Core/DockWindow.cs
+++ b/tests/Dock.Model.Test/Core/DockWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 using Dock.Model.Controls;
 

--- a/tests/Dock.Model.Test/Core/DockableBase.cs
+++ b/tests/Dock.Model.Test/Core/DockableBase.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model
 {
     public abstract class DockableBase : IDockable

--- a/tests/Dock.Model.Test/Factory.cs
+++ b/tests/Dock.Model.Test/Factory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Dock.Model.Controls;
 

--- a/tests/Dock.Model.Test/HostWindow.cs
+++ b/tests/Dock.Model.Test/HostWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 
 namespace Dock.Model
 {

--- a/tests/Dock.Model.Test/TestDockFactory.cs
+++ b/tests/Dock.Model.Test/TestDockFactory.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Dock.Model.Controls;
 

--- a/tests/Dock.Model.UnitTests/Adapters/HostAdapterTests.cs
+++ b/tests/Dock.Model.UnitTests/Adapters/HostAdapterTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.UnitTests
 {

--- a/tests/Dock.Model.UnitTests/Adapters/NavigateAdapterTests.cs
+++ b/tests/Dock.Model.UnitTests/Adapters/NavigateAdapterTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.UnitTests
 {

--- a/tests/Dock.Model.UnitTests/Core/DockPointTests.cs
+++ b/tests/Dock.Model.UnitTests/Core/DockPointTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.UnitTests
 {

--- a/tests/Dock.Model.UnitTests/Core/TestDock.cs
+++ b/tests/Dock.Model.UnitTests/Core/TestDock.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 using System;
 
 namespace Dock.Model.UnitTests

--- a/tests/Dock.Model.UnitTests/Core/TestWindow.cs
+++ b/tests/Dock.Model.UnitTests/Core/TestWindow.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
+﻿
 namespace Dock.Model.UnitTests
 {
     public class TestWindow : DockWindow

--- a/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
+++ b/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>

--- a/tests/Dock.Model.UnitTests/DockManagerTests.cs
+++ b/tests/Dock.Model.UnitTests/DockManagerTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 
 namespace Dock.Model.UnitTests
 {

--- a/tests/Dock.Model.UnitTests/FactoryBaseTests.cs
+++ b/tests/Dock.Model.UnitTests/FactoryBaseTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Xunit;
 using Dock.Model.Controls;
 

--- a/tests/Dock.Model.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Model.UnitTests/Properties/AssemblyInfo.cs
@@ -1,5 +1,3 @@
-// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Reflection;
 using Xunit;
 

--- a/tests/Dock.Model.UnitTests/TestFactoryTests.cs
+++ b/tests/Dock.Model.UnitTests/TestFactoryTests.cs
@@ -1,6 +1,4 @@
-﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using Xunit;
+﻿using Xunit;
 using Dock.Model.Controls;
 
 namespace Dock.Model.UnitTests


### PR DESCRIPTION
Support for pinning and unpinning dockables to pindocks. #73


Currently `IsExapanded` is tied to `IsActive`, so it tracks docks automatically (`PinDockControl` focuses pindock when clicked).

Potential problems:
Reused `DockToolChrome`, I do not understand what is purpose of this control - maybe there is need to separate it (especially do edit pin image). Also because of this logic of changing autohide is in `Factory.PinDockable`.
When `Auto-Hide` mode panel expands and still occupies space (unlike visual studio, where panel "overlaps" on top of content. This is really bad when you want close dock by clicking on something else, your click is lost, because whole window moves (in case of left or top panel).

@wieslawsoltes what you think?