### PR TITLE
Possibility to hide document close button

### DIFF
--- a/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
+++ b/src/Dock.Avalonia.Themes.Default/DocumentControl.xaml
@@ -82,7 +82,7 @@
                                         <TextBlock Text="{Binding Title}" />
                                         <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" x:CompileBindings="False"/>
                                     </StackPanel>
-                                    <Button Height="14" Width="14" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding}" Classes="documentTabButton" x:CompileBindings="False">
+                                    <Button Height="14" Width="14" IsVisible="{Binding CanClose, FallbackValue=True}" Command="{Binding Owner.Factory.CloseDockable}" CommandParameter="{Binding}" Classes="documentTabButton" x:CompileBindings="False">
                                         <Button.Styles>
                                             <Style Selector="Button">
                                                 <Setter Property="BorderThickness" Value="0"/>


### PR DESCRIPTION
Hi!

I need possibility to hide the close button for some documents.
I added binding for the close button and tested changed in the sample projects.

Possibly it would be better also to add CanClose (and IsDirty) properties to the Document class. Should I do that?
