### PR TITLE
Fixed binding Proportion in DocumentDock and ToolDock

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -30,12 +30,12 @@
                             <idc:ProportionalStackPanelSplitter Background="Transparent"/>
                         </DataTemplate>
                         <DataTemplate DataType="dmc:IDocumentDock">
-                            <idc:DockableControl TrackingMode="Visible">
-                                <idc:DocumentControl idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}"/>
+                            <idc:DockableControl TrackingMode="Visible" idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
+                                <idc:DocumentControl/>
                             </idc:DockableControl>
                         </DataTemplate>
                         <DataTemplate DataType="dmc:IToolDock">
-                                <DockPanel>
+                                <DockPanel idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
                                     <ItemsControl Items="{Binding PinnedDockables}"
                                                   DockPanel.Dock="{Binding Alignment, Converter={x:Static converters:AlignmentConverter.Instance}}">
                                         <ItemsControl.ItemsPanel>
@@ -90,8 +90,7 @@
                                     </ItemsControl>
                                     <idc:DockableControl TrackingMode="Visible">
                                         <idc:ToolChromeControl IsActive="{Binding IsActive}" 
-                                                               IsVisible="{Binding !!VisibleDockables.Count}"
-                                                               idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
+                                                               IsVisible="{Binding !!VisibleDockables.Count}">
                                             <idc:ToolControl/>
                                         </idc:ToolChromeControl>
                                     </idc:DockableControl>


### PR DESCRIPTION
Because of the way how ProportionalStackPanelSplitter works, Proportion attached property is supposed to be bound to the root control in data template.