### PR TITLE
Bind IsActive to DocumentControl and update styles accordingly

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -31,7 +31,7 @@
                         </DataTemplate>
                         <DataTemplate DataType="dmc:IDocumentDock">
                             <idc:DockableControl TrackingMode="Visible" idc:ProportionalStackPanelSplitter.Proportion="{Binding Proportion}">
-                                <idc:DocumentControl/>
+                                <idc:DocumentControl IsActive="{Binding IsActive}" />
                             </idc:DockableControl>
                         </DataTemplate>
                         <DataTemplate DataType="dmc:IToolDock">

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -159,18 +159,6 @@
                                     </ControlTemplate>
                                 </Setter>
                             </Style>
-                            <Style Selector="TabStripItem:pointerover">
-                                <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
-                                <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
-                            </Style>
-                            <Style Selector="TabStripItem:selected">
-                                <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
-                                <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
-                            </Style>
-                            <Style Selector="TabStripItem:selected:pointerover">
-                                <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
-                                <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
-                            </Style>
                         </TabStrip.Styles>
                         <TabStrip.DataTemplates>
                             <DataTemplate DataType="core:IDockable">
@@ -209,13 +197,12 @@
                         </TabStrip.DataTemplates>
                     </TabStrip>
                     <Grid  x:Name="PART_Grid"
-                           Background="{DynamicResource DockApplicationAccentBrushLow}" 
                            Height="2" 
                            IsVisible="{Binding #PART_TabStrip.IsVisible}" 
                            DockPanel.Dock="Top" 
                            x:CompileBindings="False" />
                     <Border x:Name="PART_Border"
-                            BorderThickness="1" 
+                            BorderThickness="1,0,1,1" 
                             BorderBrush="{DynamicResource DockThemeBorderLowBrush}">
                         <idc:DockableControl DataContext="{Binding ActiveDockable}"
                                              TrackingMode="Visible">
@@ -228,5 +215,29 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+    </Style>
+
+    <Style Selector="idc|DocumentControl /template/ Grid#PART_Grid">
+        <Setter Property="Background" Value="{DynamicResource DockThemeBorderLowBrush}"/>
+    </Style>
+    <Style Selector="idc|DocumentControl:active /template/ Grid#PART_Grid">
+        <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
+    </Style>
+    
+    <Style Selector="idc|DocumentControl /template/ TabStrip#PART_TabStrip TabStripItem:pointerover">
+        <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
+    </Style>
+    <Style Selector="idc|DocumentControl:not(:active) /template/ TabStrip#PART_TabStrip TabStripItem:selected">
+        <Setter Property="Background" Value="{DynamicResource DockThemeBorderLowBrush}" />
+        <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}" />
+    </Style>
+    <Style Selector="idc|DocumentControl:active /template/ TabStrip#PART_TabStrip TabStripItem:selected">
+        <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
+    </Style>
+    <Style Selector="idc|DocumentControl /template/ TabStrip#PART_TabStrip TabStripItem:selected:pointerover">
+        <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}"/>
+        <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
     </Style>
 </Styles>

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -11,6 +12,21 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class DocumentControl : TemplatedControl
     {
+        /// <summary>
+        /// Define the <see cref="IsActive"/> property.
+        /// </summary>
+        public static readonly StyledProperty<bool> IsActiveProperty =
+            AvaloniaProperty.Register<DocumentControl, bool>(nameof(IsActive));
+        
+        /// <summary>
+        /// Gets or sets if this is the currently active dockable.
+        /// </summary>
+        public bool IsActive
+        {
+            get => GetValue(IsActiveProperty);
+            set => SetValue(IsActiveProperty, value);
+        }
+        
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
@@ -28,6 +44,22 @@ namespace Dock.Avalonia.Controls
                     factory.SetFocusedDockable(root, dock.ActiveDockable);
                 }
             }
+        }
+        
+        /// <inheritdoc/>
+        protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == IsActiveProperty)
+            {
+                UpdatePseudoClasses(change.NewValue.GetValueOrDefault<bool>());
+            }
+        }
+
+        private void UpdatePseudoClasses(bool isActive)
+        {
+            PseudoClasses.Set(":active", isActive);
         }
     }
 }


### PR DESCRIPTION
Currently `DocumentControl` doesn't have `IsActive` property, even though `IDocumentDock` implements `IDock`, which has `IsActive` property. Because of that, document dock style doesn't indicate if the dock is active or not, so you can't tell where is the user focus.

This PR adds IsActive property to `DocumentControl` and changes style so that there is a difference between active selected document and non-active selected document.

Before (notice that two documents have the same blue color, so you can't tell where is the focus):
![image](https://user-images.githubusercontent.com/5689666/114111037-40f42780-98d9-11eb-8ddb-e76c8e9d27b2.png)

After (notice that bottom document is grayed-out, that means the upper one has focus):
![image](https://user-images.githubusercontent.com/5689666/114110988-20c46880-98d9-11eb-892d-c5459a47297e.png)