### PR TITLE
Styleable tab item header

### DIFF
--- a/samples/AvaloniaDemo/App.axaml
+++ b/samples/AvaloniaDemo/App.axaml
@@ -11,7 +11,22 @@
         <Style Selector="idc|DocumentControl">
             <Setter Property="HeaderTemplate">
                 <DataTemplate DataType="core:IDockable">
-                    <TextBlock Text="{Binding Title}" Foreground="Red" Padding="2" />
+                    <StackPanel Orientation="Horizontal">
+                        <PathIcon Data="M5 1C3.89543 1 3 1.89543 3 3V13C3 14.1046 3.89543 15 5 15H11C12.1046 15 13 14.1046 13 13V5.41421C13 5.01639 12.842 4.63486 12.5607 4.35355L9.64645 1.43934C9.36514 1.15804 8.98361 1 8.58579 1H5ZM4 3C4 2.44772 4.44772 2 5 2H8V4.5C8 5.32843 8.67157 6 9.5 6H12V13C12 13.5523 11.5523 14 11 14H5C4.44772 14 4 13.5523 4 13V3ZM11.7929 5H9.5C9.22386 5 9 4.77614 9 4.5V2.20711L11.7929 5Z"
+                                  Width="16"
+                                  Height="16"
+                                  Margin="0"/>
+                        <TextBlock Text="{Binding Title}" 
+                                   VerticalAlignment="Center"
+                                   Padding="4,0,0,0" />
+                    </StackPanel>
+                </DataTemplate>
+            </Setter>
+        </Style>
+        <Style Selector="idc|ToolControl">
+            <Setter Property="HeaderTemplate">
+                <DataTemplate DataType="core:IDockable">
+                    <TextBlock Text="{Binding Title}" Padding="2" />
                 </DataTemplate>
             </Setter>
         </Style>

--- a/samples/AvaloniaDemo/App.axaml
+++ b/samples/AvaloniaDemo/App.axaml
@@ -1,8 +1,19 @@
 ﻿<Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:AvaloniaDemo"
+             xmlns:idc="using:Dock.Avalonia.Controls"
+             xmlns:core="using:Dock.Model.Core"
              x:Class="AvaloniaDemo.App">
     <Application.DataTemplates>
         <local:ViewLocator/>
     </Application.DataTemplates>
+    <Application.Styles>
+        <Style Selector="idc|DocumentControl">
+            <Setter Property="HeaderTemplate">
+                <DataTemplate DataType="core:IDockable">
+                    <TextBlock Text="{Binding Title}" Foreground="Red" Padding="2" />
+                </DataTemplate>
+            </Setter>
+        </Style>
+    </Application.Styles>
 </Application>

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -9,11 +9,6 @@
         <idc:DockControl Width="600" Height="400"/>
     </Design.PreviewWith>
     <Style Selector="idc|DockControl">
-        <Setter Property="TabHeaderTemplate">
-            <DataTemplate>
-                <TextBlock Text="{Binding Title}" Padding="2" />
-            </DataTemplate>
-        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <ContentControl x:Name="PART_ContentControl"

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -9,6 +9,11 @@
         <idc:DockControl Width="600" Height="400"/>
     </Design.PreviewWith>
     <Style Selector="idc|DockControl">
+        <Setter Property="TabHeaderTemplate">
+            <DataTemplate>
+                <TextBlock Text="{Binding Title}" Padding="2" />
+            </DataTemplate>
+        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <ContentControl x:Name="PART_ContentControl"

--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -39,12 +39,6 @@ namespace Dock.Avalonia.Controls
         public static readonly StyledProperty<bool> InitializeFactoryProperty =
             AvaloniaProperty.Register<DockControl, bool>(nameof(InitializeFactory));
 
-        /// <summary>
-        /// Defines the <see cref="TabHeaderTemplate"/> property.
-        /// </summary>
-        public static readonly StyledProperty<IDataTemplate> TabHeaderTemplateProperty =
-            AvaloniaProperty.Register<DockControl, IDataTemplate>(nameof(TabHeaderTemplate));
-        
         /// <inheritdoc/>
         public IDockManager DockManager => _dockManager;
 
@@ -71,15 +65,6 @@ namespace Dock.Avalonia.Controls
         {
             get => GetValue(InitializeFactoryProperty);
             set => SetValue(InitializeFactoryProperty, value);
-        }
-
-        /// <summary>
-        /// Gets or sets the template of tab item header
-        /// </summary>
-        public IDataTemplate TabHeaderTemplate
-        {
-            get { return GetValue(TabHeaderTemplateProperty); }
-            set { SetValue(TabHeaderTemplateProperty, value); }
         }
 
         /// <summary>

--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Metadata;
@@ -38,6 +39,12 @@ namespace Dock.Avalonia.Controls
         public static readonly StyledProperty<bool> InitializeFactoryProperty =
             AvaloniaProperty.Register<DockControl, bool>(nameof(InitializeFactory));
 
+        /// <summary>
+        /// Defines the <see cref="TabHeaderTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> TabHeaderTemplateProperty =
+            AvaloniaProperty.Register<DockControl, IDataTemplate>(nameof(TabHeaderTemplate));
+        
         /// <inheritdoc/>
         public IDockManager DockManager => _dockManager;
 
@@ -64,6 +71,15 @@ namespace Dock.Avalonia.Controls
         {
             get => GetValue(InitializeFactoryProperty);
             set => SetValue(InitializeFactoryProperty, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the template of tab item header
+        /// </summary>
+        public IDataTemplate TabHeaderTemplate
+        {
+            get { return GetValue(TabHeaderTemplateProperty); }
+            set { SetValue(TabHeaderTemplateProperty, value); }
         }
 
         /// <summary>

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -8,6 +8,11 @@
         <idc:DocumentControl Width="300" Height="400"/>
     </Design.PreviewWith>
     <Style Selector="idc|DocumentControl">
+        <Setter Property="HeaderTemplate">
+            <DataTemplate DataType="core:IDockable">
+                <TextBlock Text="{Binding Title}" Padding="2" />
+            </DataTemplate>
+        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel x:Name="PART_DockPanel" 
@@ -170,8 +175,9 @@
                                                 id:DockProperties.IsDropArea="True" >
                                         <Panel Margin="2" 
                                                TextBlock.FontSize="{DynamicResource DockFontSizeNormal}">
-                                            <ContentPresenter ContentTemplate="{Binding $parent[idc:DockControl].TabHeaderTemplate}" 
-                                                              Content="{Binding}" />
+                                            <ContentPresenter ContentTemplate="{Binding $parent[idc:DocumentControl].HeaderTemplate}" 
+                                                              Content="{Binding}"
+                                                              x:CompileBindings="False" />
                                         </Panel>
                                         <Button Height="14" 
                                                 Width="14" 

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -23,11 +23,6 @@
                            x:DataType="dmc:IDocumentDock" 
                            x:CompileBindings="True">
                     <DockPanel.Styles>
-                        <Style Selector="TextBlock.drag">
-                            <Setter Property="Background" Value="Transparent"/>
-                            <Setter Property="VerticalAlignment" Value="Stretch"/>
-                            <Setter Property="HorizontalAlignment" Value="Stretch"/>
-                        </Style>
                         <Style Selector="Border.panel">
                             <Setter Property="Margin" Value="0"/>
                             <Setter Property="Padding" Value="4"/>
@@ -172,12 +167,10 @@
                                                 Orientation="Horizontal" 
                                                 Spacing="2"
                                                 id:DockProperties.IsDragArea="True" 
-                                                id:DockProperties.IsDropArea="True" >
-                                        <Panel Margin="2" 
-                                               TextBlock.FontSize="{DynamicResource DockFontSizeNormal}">
+                                                id:DockProperties.IsDropArea="True">
+                                        <Panel Margin="2">
                                             <ContentPresenter ContentTemplate="{Binding $parent[idc:DocumentControl].HeaderTemplate}" 
-                                                              Content="{Binding}"
-                                                              x:CompileBindings="False" />
+                                                              Content="{Binding}" />
                                         </Panel>
                                         <Button Height="14" 
                                                 Width="14" 
@@ -219,6 +212,10 @@
                 </DockPanel>
             </ControlTemplate>
         </Setter>
+    </Style>
+    <Style Selector="idc|DocumentControl /template/ TabStrip#PART_TabStrip TabStripItem">
+        <Setter Property="FontSize" Value="{DynamicResource DockFontSizeNormal}" />
+        <Setter Property="FontWeight" Value="Normal" />
     </Style>
     <Style Selector="idc|DocumentControl /template/ TabStrip#PART_TabStrip TabStripItem:pointerover">
         <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}"/>

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -168,11 +168,11 @@
                                                 Spacing="2"
                                                 id:DockProperties.IsDragArea="True" 
                                                 id:DockProperties.IsDropArea="True" >
-                                        <StackPanel Orientation="Horizontal" 
-                                                    Margin="2" 
-                                                    TextBlock.FontSize="{DynamicResource DockFontSizeNormal}">
-                                            <TextBlock Text="{Binding Title}" Padding="2" />
-                                        </StackPanel>
+                                        <Panel Margin="2" 
+                                               TextBlock.FontSize="{DynamicResource DockFontSizeNormal}">
+                                            <ContentPresenter ContentTemplate="{Binding $parent[idc:DockControl].TabHeaderTemplate}" 
+                                                              Content="{Binding}" />
+                                        </Panel>
                                         <Button Height="14" 
                                                 Width="14" 
                                                 Command="{Binding Owner.Factory.CloseDockable}" 

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
@@ -16,10 +16,10 @@ namespace Dock.Avalonia.Controls
     public class DocumentControl : TemplatedControl
     {
         /// <summary>
-        /// Define the HeaderTemplate property.
+        /// Define the <see cref="HeaderTemplate"/> property.
         /// </summary>
-        public static readonly AttachedProperty<IDataTemplate> HeaderTemplateProperty =
-            AvaloniaProperty.RegisterAttached<DocumentControl, DocumentControl, IDataTemplate>("HeaderTemplate");
+        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty = 
+            AvaloniaProperty.Register<DocumentControl, IDataTemplate>(nameof(HeaderTemplate));
 
         /// <summary>
         /// Define the <see cref="IsActive"/> property.
@@ -28,23 +28,12 @@ namespace Dock.Avalonia.Controls
             AvaloniaProperty.Register<DocumentControl, bool>(nameof(IsActive));
 
         /// <summary>
-        /// Gets the value of the HeaderTemplate attached property on the specified document control.
+        /// Gets or sets tab header template.
         /// </summary>
-        /// <param name="documentControl">The document control.</param>
-        /// <returns>The HeaderTemplate attached property.</returns>
-        public static IDataTemplate GetHeaderTemplate(DocumentControl documentControl)
+        public IDataTemplate HeaderTemplate
         {
-            return documentControl.GetValue(HeaderTemplateProperty);
-        }
-
-        /// <summary>
-        /// Sets the value of the HeaderTemplate attached property on the specified document control.
-        /// </summary>
-        /// <param name="documentControl">The control.</param>
-        /// <param name="value">The value of the HeaderTemplate property.</param>
-        public static void SetHeaderTemplate(DocumentControl documentControl, IDataTemplate value)
-        {
-            documentControl.SetValue(HeaderTemplateProperty, value);
+            get => GetValue(HeaderTemplateProperty);
+            set => SetValue(HeaderTemplateProperty, value);
         }
 
         /// <summary>

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
@@ -18,7 +18,7 @@ namespace Dock.Avalonia.Controls
         /// <summary>
         /// Define the HeaderTemplate property.
         /// </summary>
-        public static readonly AttachedProperty<IDataTemplate> HeaderTemplateProperty = 
+        public static readonly AttachedProperty<IDataTemplate> HeaderTemplateProperty =
             AvaloniaProperty.RegisterAttached<DocumentControl, DocumentControl, IDataTemplate>("HeaderTemplate");
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Dock.Avalonia.Controls
                 }
             }
         }
-        
+
         /// <inheritdoc/>
         protected override void OnPropertyChanged<T>(AvaloniaPropertyChangedEventArgs<T> change)
         {

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Dock.Model.Core;
@@ -15,11 +16,37 @@ namespace Dock.Avalonia.Controls
     public class DocumentControl : TemplatedControl
     {
         /// <summary>
+        /// Define the HeaderTemplate property.
+        /// </summary>
+        public static readonly AttachedProperty<IDataTemplate> HeaderTemplateProperty = 
+            AvaloniaProperty.RegisterAttached<DocumentControl, DocumentControl, IDataTemplate>("HeaderTemplate");
+
+        /// <summary>
         /// Define the <see cref="IsActive"/> property.
         /// </summary>
         public static readonly StyledProperty<bool> IsActiveProperty =
             AvaloniaProperty.Register<DocumentControl, bool>(nameof(IsActive));
-        
+
+        /// <summary>
+        /// Gets the value of the HeaderTemplate attached property on the specified document control.
+        /// </summary>
+        /// <param name="documentControl">The document control.</param>
+        /// <returns>The HeaderTemplate attached property.</returns>
+        public static IDataTemplate GetHeaderTemplate(DocumentControl documentControl)
+        {
+            return documentControl.GetValue(HeaderTemplateProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the HeaderTemplate attached property on the specified document control.
+        /// </summary>
+        /// <param name="documentControl">The control.</param>
+        /// <param name="value">The value of the HeaderTemplate property.</param>
+        public static void SetHeaderTemplate(DocumentControl documentControl, IDataTemplate value)
+        {
+            documentControl.SetValue(HeaderTemplateProperty, value);
+        }
+
         /// <summary>
         /// Gets or sets if this is the currently active dockable.
         /// </summary>

--- a/src/Dock.Avalonia/Controls/ToolControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolControl.axaml
@@ -8,6 +8,11 @@
         <idc:ToolControl Width="300" Height="400"/>
     </Design.PreviewWith>
     <Style Selector="idc|ToolControl">
+        <Setter Property="HeaderTemplate">
+            <DataTemplate DataType="core:IDockable">
+                <TextBlock Text="{Binding Title}" Padding="2" />
+            </DataTemplate>
+        </Setter>
         <Setter Property="Template">
             <ControlTemplate>
                 <DockPanel x:Name="PART_DockPanel" 
@@ -27,7 +32,6 @@
                             <Setter Property="BorderBrush" Value="{DynamicResource DockThemeBorderLowBrush}" />
                             <Setter Property="BorderThickness" Value="1 0 1 0" />
                         </Style>
-                        
                         <Style Selector="Separator.separator">
                             <Setter Property="Background" Value="{DynamicResource DockThemeBorderLowBrush}" />
                             <Setter Property="Height" Value="1" />
@@ -105,15 +109,15 @@
                             <DataTemplate DataType="core:IDockable">
                                 <idc:DockableControl TrackingMode="Tab">
                                     <StackPanel x:Name="DragTool" 
-                                                id:DockProperties.IsDragArea="True" 
-                                                id:DockProperties.IsDropArea="True" 
                                                 Background="Transparent" 
                                                 Orientation="Horizontal" 
-                                                Spacing="2">
-                                        <TextBlock Text="{Binding Title}" 
-                                                   Classes="drag" 
-                                                   Padding="2" 
-                                                   Margin="2" />
+                                                Spacing="2"
+                                                id:DockProperties.IsDragArea="True" 
+                                                id:DockProperties.IsDropArea="True">
+                                        <Panel Margin="2">
+                                            <ContentPresenter ContentTemplate="{Binding $parent[idc:ToolControl].HeaderTemplate}" 
+                                                              Content="{Binding}" />
+                                        </Panel>
                                     </StackPanel>
                                 </idc:DockableControl>
                             </DataTemplate>

--- a/src/Dock.Avalonia/Controls/ToolControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolControl.axaml.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Dock.Model.Core;
@@ -11,6 +12,21 @@ namespace Dock.Avalonia.Controls
     /// </summary>
     public class ToolControl : TemplatedControl
     {
+        /// <summary>
+        /// Define the <see cref="HeaderTemplate"/> property.
+        /// </summary>
+        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty = 
+            AvaloniaProperty.Register<ToolControl, IDataTemplate>(nameof(HeaderTemplate));
+
+        /// <summary>
+        /// Gets or sets tab header template.
+        /// </summary>
+        public IDataTemplate HeaderTemplate
+        {
+            get => GetValue(HeaderTemplateProperty);
+            set => SetValue(HeaderTemplateProperty, value);
+        }
+
         /// <inheritdoc/>
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {

--- a/src/Dock.Avalonia/Controls/ToolControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolControl.axaml.cs
@@ -15,7 +15,7 @@ namespace Dock.Avalonia.Controls
         /// <summary>
         /// Define the <see cref="HeaderTemplate"/> property.
         /// </summary>
-        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty = 
+        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty =
             AvaloniaProperty.Register<ToolControl, IDataTemplate>(nameof(HeaderTemplate));
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace Dock.Avalonia.Controls
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             base.OnAttachedToVisualTree(e);
- 
+
             AddHandler(PointerPressedEvent, Pressed, RoutingStrategies.Tunnel);
         }
 


### PR DESCRIPTION
**Why:**
In my app I have a need to add icons to document tab headers. 

**How:**
Therefore I came up with this implementation - to add "TabHeaderProperty" so that user can redefine his own chosen template of header item (but close button is still handled by Dock).

It does work, but I am not sure if this is best way to achieve that result, especially that it requires $parent selector