### PR TITLE
DockDockableIntoWindow will respect CanFloat property

### DIFF
--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -151,6 +151,11 @@ namespace Dock.Model
                         return false;
                     }
 
+                    if (!sourceDockable.CanFloat)
+                    {
+                        return false;
+                    }
+
                     if (sourceDockable.Owner is not IDock sourceDockableOwner)
                     {
                         return false;


### PR DESCRIPTION
After https://github.com/wieslawsoltes/Dock/commit/f5b80533e94db136edf8042648a6b557acaf230e dragging a tab can open a new window, however as of now it doesn't respect CanFloat dockable property. This PR fixes that