### PR TITLE
Fixes #232

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTabStripItem.cs
+++ b/src/Dock.Avalonia/Controls/DockTabStripItem.cs
@@ -27,7 +27,7 @@ public class DockTabStripItem : TabStripItem, IStyleable
     {
         if (e.GetCurrentPoint(this).Properties.IsMiddleButtonPressed)
         {
-            if (DataContext is IDockable { Owner: IDock { Factory: { } factory } } dockable)
+            if (DataContext is IDockable { Owner: IDock { Factory: { } factory } } dockable && dockable.CanClose)
             {
                 factory.CloseDockable(dockable);
             }


### PR DESCRIPTION
This fix prevents a document/tool with their `CanClose` property set to `false` from being closed when middle-clicking a tab. This does not prevent it from being closed through the factory API though.