### PR TITLE
Fix Bindings

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -38,33 +38,27 @@
                 <MenuItem Header="_Float"
                           Command="{Binding Owner.Factory.FloatDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanFloat}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanFloat}"/>
                 <MenuItem Header="_Close"
                           Command="{Binding Owner.Factory.CloseDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
                 <MenuItem Header="Close other tabs"
                           Command="{Binding Owner.Factory.CloseOtherDockables}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
                 <MenuItem Header="Close all tabs"
                           Command="{Binding Owner.Factory.CloseAllDockables}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
                 <MenuItem Header="_Close tabs to the left"
                           Command="{Binding Owner.Factory.CloseLeftDockables}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
                 <MenuItem Header="_Close tabs to the right"
                           Command="{Binding Owner.Factory.CloseRightDockables}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
               </ContextMenu>
             </Border.ContextMenu>
             <DockableControl TrackingMode="Tab">
@@ -80,8 +74,7 @@
                 <Button x:Name="PART_CloseButton"
                         Command="{Binding Owner.Factory.CloseDockable}"
                         CommandParameter="{Binding}"
-                        IsVisible="{Binding CanClose}"
-                        x:CompileBindings="False">
+                        IsVisible="{Binding CanClose}">
                   <Button.Styles>
                     <Style Selector="Button">
                       <Setter Property="BorderThickness" Value="0" />

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -31,18 +31,15 @@
                 <MenuItem Header="_Float"
                           Command="{Binding Owner.Factory.FloatDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}"/>
                 <MenuItem Header="_Hide"
                           Command="{Binding Owner.Factory.PinDockable}"
                           CommandParameter="{Binding ActiveDockable}"
-                          IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"/>
                 <MenuItem Header="_Close"
                           Command="{Binding Owner.Factory.CloseDockable}"
                           CommandParameter="{Binding ActiveDockable}"
-                          IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"/>
               </ContextMenu>
             </Border.ContextMenu>
             <Grid x:Name="PART_Grip">
@@ -55,8 +52,7 @@
                         Command="{Binding Owner.Factory.CloseDockable}"
                         CommandParameter="{Binding ActiveDockable}"
                         IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"
-                        DockPanel.Dock="Right"
-                        x:CompileBindings="False">
+                        DockPanel.Dock="Right">
                   <Viewbox>
                     <Path x:Name="PART_ClosePath" />
                   </Viewbox>
@@ -65,8 +61,7 @@
                         Command="{Binding Owner.Factory.PinDockable}"
                         CommandParameter="{Binding ActiveDockable}"
                         IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"
-                        DockPanel.Dock="Right"
-                        x:CompileBindings="False">
+                        DockPanel.Dock="Right">
                   <Viewbox>
                     <Path x:Name="PART_PinPath" />
                   </Viewbox>

--- a/src/Dock.Avalonia/Controls/ToolPinnedControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinnedControl.axaml
@@ -30,8 +30,7 @@
                           BorderThickness="0"
                           Command="{Binding Owner.Factory.PinDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanPin}"
-                          x:CompileBindings="False">
+                          IsVisible="{Binding CanPin}">
                     <TextBlock Text="{Binding Title}"
                                VerticalAlignment="Center"
                                HorizontalAlignment="Left">
@@ -40,18 +39,15 @@
                           <MenuItem Header="_Float"
                                     Command="{Binding Owner.Factory.FloatDockable}"
                                     CommandParameter="{Binding}"
-                                    IsVisible="{Binding CanFloat}"
-                                    x:CompileBindings="False" />
+                                    IsVisible="{Binding CanFloat}"/>
                           <MenuItem Header="_Show"
                                     Command="{Binding Owner.Factory.PinDockable}"
                                     CommandParameter="{Binding}"
-                                    IsVisible="{Binding CanPin}"
-                                    x:CompileBindings="False" />
+                                    IsVisible="{Binding CanPin}"/>
                           <MenuItem Header="_Close"
                                     Command="{Binding Owner.Factory.CloseDockable}"
                                     CommandParameter="{Binding}"
-                                    IsVisible="{Binding CanClose}"
-                                    x:CompileBindings="False" />
+                                    IsVisible="{Binding CanClose}"/>
                         </ContextMenu>
                       </TextBlock.ContextMenu>
                     </TextBlock>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -42,18 +42,15 @@
                 <MenuItem Header="_Float"
                           Command="{Binding Owner.Factory.FloatDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanFloat}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanFloat}"/>
                 <MenuItem Header="_Hide"
                           Command="{Binding Owner.Factory.PinDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanPin}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanPin}"/>
                 <MenuItem Header="_Close"
                           Command="{Binding Owner.Factory.CloseDockable}"
                           CommandParameter="{Binding}"
-                          IsVisible="{Binding CanClose}"
-                          x:CompileBindings="False" />
+                          IsVisible="{Binding CanClose}"/>
               </ContextMenu>
             </Border.ContextMenu>
             <DockableControl TrackingMode="Tab">


### PR DESCRIPTION
Since Avalonia 11 preview 2 the bindings are broken. This might be an Avalonia bug.
<img width="314" alt="image" src="https://user-images.githubusercontent.com/25281882/195341427-d968012f-b21b-4d33-a32e-c04abab898e4.png">

Interestingly, this can be fixed easily by using compiled bindings.
