### PR TITLE
fix: prevent closing dockables which should not be closable

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -259,7 +259,7 @@ public abstract partial class FactoryBase
             var originalTargetDockable = targetDock.VisibleDockables[targetIndex];
             sourceDock.VisibleDockables[sourceIndex] = originalTargetDockable;
             targetDock.VisibleDockables[targetIndex] = originalSourceDockable;
-                
+
             InitDockable(originalSourceDockable, targetDock);
             InitDockable(originalTargetDockable, sourceDock);
 
@@ -320,7 +320,7 @@ public abstract partial class FactoryBase
                 {
                     return;
                 }
-                
+
                 var isVisible = false;
 
                 if (toolDock.VisibleDockables is not null)
@@ -360,7 +360,7 @@ public abstract partial class FactoryBase
                             break;
                         }
                     }
-                    
+
                     if (toolDock.VisibleDockables is not null)
                     {
                         toolDock.VisibleDockables.Remove(dockable);
@@ -471,7 +471,7 @@ public abstract partial class FactoryBase
                     toolDock.VisibleDockables.Add(dockable);
                     toolDock.IsEmpty = toolDock.VisibleDockables.Count == 0;
                     OnDockableAdded(dockable);
-                    
+
                     // TODO: Handle ActiveDockable state.
                     // TODO: Handle IsExpanded property of IToolDock.
                     // TODO: Handle AutoHide property of IToolDock.
@@ -532,7 +532,7 @@ public abstract partial class FactoryBase
     /// <inheritdoc/>
     public virtual void CloseDockable(IDockable dockable)
     {
-        if (dockable.OnClose())
+        if (dockable.CanClose && dockable.OnClose())
         {
             RemoveDockable(dockable, true);
             OnDockableClosed(dockable);
@@ -590,7 +590,7 @@ public abstract partial class FactoryBase
         {
             return;
         }
-            
+
         CloseDockablesRange(dock, 0, indexOf - 1);
     }
 
@@ -607,7 +607,7 @@ public abstract partial class FactoryBase
         {
             return;
         }
-            
+
         CloseDockablesRange(dock, indexOf + 1, dock.VisibleDockables.Count - 1);
     }
 }


### PR DESCRIPTION
Prevents the following commands from closing dockables which have CanClose = false

![image](https://github.com/wieslawsoltes/Dock/assets/9521987/613911cb-4f6c-4795-9409-08a47b8514bc)

Let me know if you want me to undo the whitespace changes, VS decided to sneak that in :)