### PR TITLE
Fix typo in SplitToDock

### DIFF
--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -246,7 +246,7 @@ public abstract partial class FactoryBase : IFactory
                         ownerDock.IsEmpty = ownerDock.VisibleDockables.Count == 0;
                         OnDockableRemoved(dockable);
                         ownerDock.VisibleDockables.Insert(index, layout);
-                        layout.IsEmpty = layout.VisibleDockables?.Count == 0;
+                        ownerDock.IsEmpty = ownerDock.VisibleDockables?.Count == 0;
                         OnDockableAdded(dockable);
                         InitDockable(layout, ownerDock);
                         ownerDock.ActiveDockable = layout;


### PR DESCRIPTION
Before the fix:


https://github.com/wieslawsoltes/Dock/assets/5689666/e580b348-edc9-4e89-8226-d574e777cb00

After the fix:


https://github.com/wieslawsoltes/Dock/assets/5689666/b131400d-6e1a-44bc-b33a-6498f3c24204

