### PR TITLE
Corrected the logic for updating IsEmpty

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -1,4 +1,5 @@
-﻿using Dock.Model.Controls;
+﻿using System.Linq;
+using Dock.Model.Controls;
 using Dock.Model.Core;
 
 namespace Dock.Model;
@@ -13,8 +14,7 @@ public abstract partial class FactoryBase
     {
         InitDockable(dockable, dock);
         dock.VisibleDockables ??= CreateList<IDockable>();
-        dock.VisibleDockables.Add(dockable);
-        dock.IsEmpty = dock.VisibleDockables.Count == 0;
+        AddVisibleDockable(dock, dockable);
         OnDockableAdded(dockable);
     }
 
@@ -25,8 +25,7 @@ public abstract partial class FactoryBase
         {
             InitDockable(dockable, dock);
             dock.VisibleDockables ??= CreateList<IDockable>();
-            dock.VisibleDockables.Insert(index, dockable);
-            dock.IsEmpty = dock.VisibleDockables.Count == 0;
+            InsertVisibleDockable(dock, index, dockable);
             OnDockableAdded(dockable);
         }
     }
@@ -45,8 +44,7 @@ public abstract partial class FactoryBase
             return;
         }
 
-        dock.VisibleDockables.Remove(dockable);
-        dock.IsEmpty = dock.VisibleDockables.Count == 0;
+        RemoveVisibleDockable(dock, dockable);
         OnDockableRemoved(dockable);
 
         var indexActiveDockable = index > 0 ? index - 1 : 0;
@@ -102,11 +100,9 @@ public abstract partial class FactoryBase
 
         if (sourceIndex >= 0 && targetIndex >= 0 && sourceIndex != targetIndex)
         {
-            dock.VisibleDockables.RemoveAt(sourceIndex);
-            dock.IsEmpty = dock.VisibleDockables.Count == 0;
+            RemoveVisibleDockableAt(dock, sourceIndex);
             OnDockableRemoved(sourceDockable);
-            dock.VisibleDockables.Insert(targetIndex, sourceDockable);
-            dock.IsEmpty = dock.VisibleDockables.Count == 0;
+            InsertVisibleDockable(dock, targetIndex, sourceDockable);
             OnDockableAdded(sourceDockable);
             OnDockableMoved(sourceDockable);
             dock.ActiveDockable = sourceDockable;
@@ -177,11 +173,9 @@ public abstract partial class FactoryBase
                 var sourceIndex = sourceDock.VisibleDockables.IndexOf(sourceDockable);
                 if (sourceIndex < targetIndex)
                 {
-                    targetDock.VisibleDockables.Insert(targetIndex + 1, sourceDockable);
-                    targetDock.IsEmpty = targetDock.VisibleDockables.Count == 0;
+                    InsertVisibleDockable(targetDock, targetIndex + 1, sourceDockable);
                     OnDockableAdded(sourceDockable);
-                    targetDock.VisibleDockables.RemoveAt(sourceIndex);
-                    targetDock.IsEmpty = targetDock.VisibleDockables.Count == 0;
+                    RemoveVisibleDockableAt(targetDock, sourceIndex);
                     OnDockableRemoved(sourceDockable);
                     OnDockableMoved(sourceDockable);
                 }
@@ -190,11 +184,9 @@ public abstract partial class FactoryBase
                     var removeIndex = sourceIndex + 1;
                     if (targetDock.VisibleDockables.Count + 1 > removeIndex)
                     {
-                        targetDock.VisibleDockables.Insert(targetIndex, sourceDockable);
-                        targetDock.IsEmpty = targetDock.VisibleDockables.Count == 0;
+                        InsertVisibleDockable(targetDock, targetIndex, sourceDockable);
                         OnDockableAdded(sourceDockable);
-                        targetDock.VisibleDockables.RemoveAt(removeIndex);
-                        targetDock.IsEmpty = targetDock.VisibleDockables.Count == 0;
+                        RemoveVisibleDockableAt(targetDock, removeIndex);
                         OnDockableRemoved(sourceDockable);
                         OnDockableMoved(sourceDockable);
                     }
@@ -203,8 +195,7 @@ public abstract partial class FactoryBase
             else
             {
                 RemoveDockable(sourceDockable, true);
-                targetDock.VisibleDockables.Insert(targetIndex, sourceDockable);
-                targetDock.IsEmpty = targetDock.VisibleDockables.Count == 0;
+                InsertVisibleDockable(targetDock, targetIndex, sourceDockable);
                 OnDockableAdded(sourceDockable);
                 OnDockableMoved(sourceDockable);
                 InitDockable(sourceDockable, targetDock);
@@ -230,11 +221,9 @@ public abstract partial class FactoryBase
             var originalTargetDockable = dock.VisibleDockables[targetIndex];
 
             dock.VisibleDockables[targetIndex] = originalSourceDockable;
-            dock.IsEmpty = dock.VisibleDockables.Count == 0;
             OnDockableRemoved(originalTargetDockable);
             OnDockableAdded(originalSourceDockable);
             dock.VisibleDockables[sourceIndex] = originalTargetDockable;
-            dock.IsEmpty = dock.VisibleDockables.Count == 0;
             OnDockableAdded(originalTargetDockable);
             OnDockableSwapped(originalSourceDockable);
             OnDockableSwapped(originalTargetDockable);
@@ -363,8 +352,7 @@ public abstract partial class FactoryBase
                     
                     if (toolDock.VisibleDockables is not null)
                     {
-                        toolDock.VisibleDockables.Remove(dockable);
-                        toolDock.IsEmpty = toolDock.VisibleDockables.Count == 0;
+                        RemoveVisibleDockable(toolDock, dockable);
                         OnDockableRemoved(dockable);
                     }
 
@@ -468,8 +456,7 @@ public abstract partial class FactoryBase
                         }
                     }
 
-                    toolDock.VisibleDockables.Add(dockable);
-                    toolDock.IsEmpty = toolDock.VisibleDockables.Count == 0;
+                    AddVisibleDockable(toolDock, dockable);
                     OnDockableAdded(dockable);
                     
                     // TODO: Handle ActiveDockable state.
@@ -609,5 +596,71 @@ public abstract partial class FactoryBase
         }
             
         CloseDockablesRange(dock, indexOf + 1, dock.VisibleDockables.Count - 1);
+    }
+
+    /// <summary>
+    /// Adds the dockable to the visible dockables list of the dock.
+    /// </summary>
+    protected void AddVisibleDockable(IDock dock, IDockable dockable)
+    {
+        if (dock.VisibleDockables == null)
+        {
+            dock.VisibleDockables = CreateList<IDockable>();
+        }
+        dock.VisibleDockables.Add(dockable);
+        UpdateIsEmpty(dock);
+    }
+
+    /// <summary>
+    /// Inserts the dockable to the visible dockables list of the dock at the specified index.
+    /// </summary>
+    protected void InsertVisibleDockable(IDock dock, int index, IDockable dockable)
+    {
+        if (dock.VisibleDockables == null)
+        {
+            dock.VisibleDockables = CreateList<IDockable>();
+        }
+        dock.VisibleDockables.Insert(index, dockable);
+        UpdateIsEmpty(dock);
+    }
+
+    /// <summary>
+    /// Removes the dockable from the visible dockables list of the dock.
+    /// </summary>
+    protected void RemoveVisibleDockable(IDock dock, IDockable dockable)
+    {
+        if (dock.VisibleDockables != null)
+        {
+            dock.VisibleDockables.Remove(dockable);
+            UpdateIsEmpty(dock);
+        }
+    }
+
+    /// <summary>
+    /// Removes the dockable at the specified index from the visible dockables list of the dock.
+    /// </summary>
+    protected void RemoveVisibleDockableAt(IDock dock, int index)
+    {
+        if (dock.VisibleDockables != null)
+        {
+            dock.VisibleDockables.RemoveAt(index);
+            UpdateIsEmpty(dock);
+        }
+    }
+
+    private void UpdateIsEmpty(IDock dock)
+    {
+        bool oldIsEmpty = dock.IsEmpty;
+
+        var newIsEmpty = dock.VisibleDockables == null
+                         || dock.VisibleDockables?.Count == 0
+                         || dock.VisibleDockables!.All(x => x is IDock { IsEmpty: true } or IProportionalDockSplitter);
+
+        if (oldIsEmpty != newIsEmpty)
+        {
+            dock.IsEmpty = newIsEmpty;
+            if (dock.Owner is IDock parent)
+                UpdateIsEmpty(parent);
+        }
     }
 }

--- a/src/Dock.Model/FactoryBase.Init.cs
+++ b/src/Dock.Model/FactoryBase.Init.cs
@@ -54,7 +54,7 @@ public abstract partial class FactoryBase
                     InitDockable(child, dockable);
                 }
 
-                dock.IsEmpty = dock.VisibleDockables.Count == 0;
+                UpdateIsEmpty(dock);
             }
         }
 

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -125,8 +125,7 @@ public abstract partial class FactoryBase : IFactory
             split.VisibleDockables = CreateList<IDockable>();
             if (split.VisibleDockables is not null)
             {
-                split.VisibleDockables.Add(dockable);
-                split.IsEmpty = split.VisibleDockables.Count == 0;
+                AddVisibleDockable(split, dockable);
                 OnDockableAdded(dockable);
                 split.ActiveDockable = dockable;
             }
@@ -166,8 +165,7 @@ public abstract partial class FactoryBase : IFactory
             {
                 if (layout.VisibleDockables is not null)
                 {
-                    layout.VisibleDockables.Add(split);
-                    layout.IsEmpty = layout.VisibleDockables.Count == 0;
+                    AddVisibleDockable(layout, split);
                     OnDockableAdded(split);
                     layout.ActiveDockable = split;
                 }
@@ -179,8 +177,7 @@ public abstract partial class FactoryBase : IFactory
             {
                 if (layout.VisibleDockables is not null)
                 {
-                    layout.VisibleDockables.Add(dock);
-                    layout.IsEmpty = layout.VisibleDockables.Count == 0;
+                    AddVisibleDockable(layout, dock);
                     OnDockableAdded(dock);
                     layout.ActiveDockable = dock;
                 }
@@ -189,8 +186,7 @@ public abstract partial class FactoryBase : IFactory
             }
         }
 
-        layout.VisibleDockables?.Add(splitter);
-        layout.IsEmpty = layout.VisibleDockables?.Count == 0;
+        AddVisibleDockable(layout, splitter);
         OnDockableAdded(splitter);
 
         switch (operation)
@@ -200,8 +196,7 @@ public abstract partial class FactoryBase : IFactory
             {
                 if (layout.VisibleDockables is not null)
                 {
-                    layout.VisibleDockables.Add(dock);
-                    layout.IsEmpty = layout.VisibleDockables.Count == 0;
+                    AddVisibleDockable(layout, dock);
                     OnDockableAdded(dock);
                     layout.ActiveDockable = dock;
                 }
@@ -213,8 +208,7 @@ public abstract partial class FactoryBase : IFactory
             {
                 if (layout.VisibleDockables is not null)
                 {
-                    layout.VisibleDockables.Add(split);
-                    layout.IsEmpty = layout.VisibleDockables.Count == 0;
+                    AddVisibleDockable(layout, split);
                     OnDockableAdded(split);
                     layout.ActiveDockable = split;
                 }
@@ -242,11 +236,9 @@ public abstract partial class FactoryBase : IFactory
                     if (index >= 0)
                     {
                         var layout = CreateSplitLayout(dock, dockable, operation);
-                        ownerDock.VisibleDockables.RemoveAt(index);
-                        ownerDock.IsEmpty = ownerDock.VisibleDockables.Count == 0;
+                        RemoveVisibleDockableAt(ownerDock, index);
                         OnDockableRemoved(dockable);
-                        ownerDock.VisibleDockables.Insert(index, layout);
-                        layout.IsEmpty = layout.VisibleDockables?.Count == 0;
+                        InsertVisibleDockable(ownerDock, index, layout);
                         OnDockableAdded(dockable);
                         InitDockable(layout, ownerDock);
                         ownerDock.ActiveDockable = layout;
@@ -276,8 +268,7 @@ public abstract partial class FactoryBase : IFactory
                     dock.VisibleDockables = CreateList<IDockable>();
                     if (dock.VisibleDockables is not null)
                     {
-                        dock.VisibleDockables.Add(dockable);
-                        dock.IsEmpty = dock.VisibleDockables.Count == 0;
+                        AddVisibleDockable(dock, dockable);
                         OnDockableAdded(dockable);
                         dock.ActiveDockable = dockable;
                     }
@@ -309,8 +300,7 @@ public abstract partial class FactoryBase : IFactory
                     }
                     if (dock.VisibleDockables is not null)
                     {
-                        dock.VisibleDockables.Add(dockable);
-                        dock.IsEmpty = dock.VisibleDockables.Count == 0;
+                        AddVisibleDockable(dock, dockable);
                         OnDockableAdded(dockable);
                         dock.ActiveDockable = dockable;
                     }
@@ -359,8 +349,7 @@ public abstract partial class FactoryBase : IFactory
         root.VisibleDockables = CreateList<IDockable>();
         if (root.VisibleDockables is not null && target is not null)
         {
-            root.VisibleDockables.Add(target);
-            root.IsEmpty = root.VisibleDockables.Count == 0;
+            AddVisibleDockable(root, target);
             OnDockableAdded(target);
             root.ActiveDockable = target;
             root.DefaultDockable = target;


### PR DESCRIPTION
Unifies the logic for managing the VisibleDockables. The previous code was error prone and in fact there was one typo which caused dockables to randomly disappear (https://github.com/wieslawsoltes/Dock/pull/323). Additionally, the IsEmpty should be also set if there are dockables in the VisibleDockables list, but they are empty. This can happen if all dockables are pinned 

Before the fix:

https://github.com/wieslawsoltes/Dock/assets/5689666/3e43a0ca-e6f4-4a7b-9d5d-5d0b90af8ab4

After the fix:

https://github.com/wieslawsoltes/Dock/assets/5689666/841189b5-1357-4a03-bcac-72005f033561

Before the fix:

https://github.com/wieslawsoltes/Dock/assets/5689666/b9c65ec8-92fa-43fb-9b30-92691a271432

After the fix (with https://github.com/wieslawsoltes/Dock/pull/322):

https://github.com/wieslawsoltes/Dock/assets/5689666/78c72fa6-266d-4bf8-a657-deb2dfc62a63


