### PR TITLE
Correctly set host window's parent

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:core="using:Dock.Model.Core">
+                    xmlns:core="using:Dock.Model.Core"
+                    xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model">
   <Design.PreviewWith>
     <HostWindow IsToolWindow="False" Width="300" Height="400" />
   </Design.PreviewWith>
@@ -14,6 +15,7 @@
     <Setter Property="WindowState" Value="Normal" />
     <Setter Property="UseLayoutRounding" Value="True" />
     <Setter Property="Title" Value="{Binding ActiveDockable.Title}" />
+    <Setter Property="Topmost" Value="{Binding Window.Topmost}" x:DataType="controls:IRootDock" />
     <Setter Property="SystemDecorations" Value="Full" />
     <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
     <Setter Property="ExtendClientAreaChromeHints" Value="PreferSystemChrome" />

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
@@ -6,6 +7,7 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Styling;
+using Avalonia.VisualTree;
 using Dock.Avalonia.Internal;
 using Dock.Model;
 using Dock.Model.Core;
@@ -276,7 +278,15 @@ public class HostWindow : Window, IHostWindow
                     Window.Factory?.OnWindowOpened(Window);
                 }
 
-                Show();
+                var ownerDockControl = Window?.Layout?.Factory?.DockControls.FirstOrDefault();
+                if (ownerDockControl is Control control && control.GetVisualRoot() is Window parentWindow)
+                {
+                    Show(parentWindow);
+                }
+                else
+                {
+                    Show();
+                }
             }
         }
     }
@@ -332,12 +342,6 @@ public class HostWindow : Window, IHostWindow
     {
         width = Width;
         height = Height;
-    }
-
-    /// <inheritdoc/>
-    public void SetTopmost(bool topmost)
-    {
-        Topmost = topmost;
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Adapters/HostAdapter.cs
+++ b/src/Dock.Model/Adapters/HostAdapter.cs
@@ -56,7 +56,6 @@ public class HostAdapter : IHostAdapter
             _window.Host.Present(isDialog);
             _window.Host.SetPosition(_window.X, _window.Y);
             _window.Host.SetSize(_window.Width, _window.Height);
-            _window.Host.SetTopmost(_window.Topmost);
             _window.Host.SetTitle(_window.Title);
             _window.Host.SetLayout(_window.Layout);
             _window.Host.IsTracked = true;

--- a/src/Dock.Model/Core/IHostWindow.cs
+++ b/src/Dock.Model/Core/IHostWindow.cs
@@ -65,12 +65,6 @@ public interface IHostWindow
     void GetSize(out double width, out double height);
 
     /// <summary>
-    /// Sets host topmost.
-    /// </summary>
-    /// <param name="topmost">The host topmost.</param>
-    void SetTopmost(bool topmost);
-
-    /// <summary>
     /// Sets host title.
     /// </summary>
     /// <param name="title">The host title.</param>

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -263,7 +263,6 @@ public abstract partial class FactoryBase : IFactory
     public virtual IDockWindow? CreateWindowFrom(IDockable dockable)
     {
         IDockable? target;
-        bool topmost;
 
         switch (dockable)
         {
@@ -282,7 +281,6 @@ public abstract partial class FactoryBase : IFactory
                         dock.ActiveDockable = dockable;
                     }
                 }
-                topmost = true;
                 break;
             }
             case IDocument:
@@ -315,37 +313,31 @@ public abstract partial class FactoryBase : IFactory
                         dock.ActiveDockable = dockable;
                     }
                 }
-                topmost = false;
                 break;
             }
             case IToolDock:
             {
                 target = dockable;
-                topmost = true;
                 break;
             }
             case IDocumentDock:
             {
                 target = dockable;
-                topmost = false;
                 break;
             }
             case IProportionalDock proportionalDock:
             {
                 target = proportionalDock;
-                topmost = false;
                 break;
             }
             case IDockDock dockDock:
             {
                 target = dockDock;
-                topmost = false;
                 break;
             }
             case IRootDock rootDock:
             {
                 target = rootDock.ActiveDockable;
-                topmost = false;
                 break;
             }
             default:
@@ -372,7 +364,6 @@ public abstract partial class FactoryBase : IFactory
         window.Title = "";
         window.Width = double.NaN;
         window.Height = double.NaN;
-        window.Topmost = topmost;
         window.Layout = root;
 
         root.Window = window;


### PR DESCRIPTION
## What is the current behavior?
Host windows (additional dock windows) are always Topmost and don't have parent.


## What is the updated/expected behavior with this PR?
Host windows have correctly set parent - the main dock control window. They also no longer have top most flag. Instead, in most platforms (checked Windows and Mac), if the parent is correctly set, the children windows are always on top of the parent, but don't have to be on top of other windows, which is muuuuch more useful than the old behaviour.