### PR TITLE
Fix host windows dragging on Windows

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -100,11 +100,6 @@ public class HostWindow : Window, IHostWindow
         PseudoClasses.Set(":dragging", true);
         _draggingWindow = true;
         BeginMoveDrag(e);
-            
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            EndDrag(e);
-        }
     }
 
     private void EndDrag(PointerEventArgs e)
@@ -148,9 +143,7 @@ public class HostWindow : Window, IHostWindow
         {
             Window.Save();
 
-            if ((_chromeGrip is { } && _chromeGrip.IsPointerOver)
-                || (_hostWindowTitleBar?.BackgroundControl is { } && (_hostWindowTitleBar?.BackgroundControl?.IsPointerOver ?? false))
-                && _mouseDown)
+            if (_mouseDown)
             {
                 Window.Factory?.OnWindowMoveDrag(Window);
                 _hostWindowState.Process(Position.ToPoint(1.0), EventType.Moved);


### PR DESCRIPTION
I am not sure why this `EndDrag(e);` was there in the first place, it looks like it doesn't serve any purpose. Tested on Windows and macOS and everything works good. The `IsPointerOver` check is also very wonky in Avalonia - when you drag a host window out of the screen (and keep dragging) and drag the window back - the `IsPointerOver` state is lost, even though the mouse is still over the chrome. I don't think the check is needed - the window position changed AND mouseDown conditions are only met if the user is dragging the window, right?


Fixes: https://github.com/wieslawsoltes/Dock/issues/319