### PR TITLE
Fixed mixed screen/client position usage

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -87,6 +87,14 @@ public class HostWindow : Window, IHostWindow
         }
     }
 
+    private PixelPoint ClientPointToScreenRelativeToWindow(Point clientPoint)
+    {
+        var absScreenPoint = this.PointToScreen(clientPoint);
+        var absScreenWindowPoint = this.PointToScreen(new Point(0, 0));
+        var relativeScreenDiff = absScreenPoint - absScreenWindowPoint;
+        return relativeScreenDiff;
+    }
+
     private void MoveDrag(PointerPressedEventArgs e)
     {
         if (Window?.Factory?.OnWindowMoveDragBegin(Window) != true)
@@ -95,7 +103,7 @@ public class HostWindow : Window, IHostWindow
         }
 
         _mouseDown = true;
-        _hostWindowState.Process(e.GetPosition(this), EventType.Pressed);
+        _hostWindowState.Process(ClientPointToScreenRelativeToWindow(e.GetPosition(this)), EventType.Pressed);
 
         PseudoClasses.Set(":dragging", true);
         _draggingWindow = true;
@@ -112,7 +120,7 @@ public class HostWindow : Window, IHostWindow
         PseudoClasses.Set(":dragging", false);
 
         Window?.Factory?.OnWindowMoveDragEnd(Window);
-        _hostWindowState.Process(e.GetPosition(this), EventType.Released);
+        _hostWindowState.Process(ClientPointToScreenRelativeToWindow(e.GetPosition(this)), EventType.Released);
         _mouseDown = false;
         _draggingWindow = false;
     }
@@ -153,7 +161,7 @@ public class HostWindow : Window, IHostWindow
                 && _mouseDown)
             {
                 Window.Factory?.OnWindowMoveDrag(Window);
-                _hostWindowState.Process(Position.ToPoint(1.0), EventType.Moved);
+                _hostWindowState.Process(Position, EventType.Moved);
             }
         }
     }

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -10,7 +10,7 @@ namespace Dock.Avalonia.Internal;
 
 internal class WindowDragState
 {
-    public Point DragStartPoint { get; set; }
+    public PixelPoint DragStartPoint { get; set; }
     public bool PointerPressed { get; set; }
     public bool DoDragDrop { get; set; }
     public DockControl? TargetDockControl { get; set; }
@@ -18,7 +18,7 @@ internal class WindowDragState
     public Control? TargetDropControl { get; set; }
     public DragAction DragAction { get; set; }
 
-    public void Start(Point point)
+    public void Start(PixelPoint point)
     {
         DragStartPoint = point;
         PointerPressed = true;
@@ -162,7 +162,7 @@ internal class HostWindowState : IHostWindowState
         }
     }
 
-    private bool IsMinimumDragDistance(Vector diff)
+    private bool IsMinimumDragDistance(PixelPoint diff)
     {
         return (Math.Abs(diff.X) > DockSettings.MinimumHorizontalDragDistance
                 || Math.Abs(diff.Y) > DockSettings.MinimumVerticalDragDistance);
@@ -173,7 +173,7 @@ internal class HostWindowState : IHostWindowState
     /// </summary>
     /// <param name="point">The pointer position.</param>
     /// <param name="eventType">The pointer event type.</param>
-    public void Process(Point point, EventType eventType)
+    public void Process(PixelPoint point, EventType eventType)
     {
         switch (eventType)
         {
@@ -219,7 +219,7 @@ internal class HostWindowState : IHostWindowState
 
                 if (_state.DoDragDrop == false)
                 {
-                    Vector diff = _state.DragStartPoint - point;
+                    var diff = _state.DragStartPoint - point;
                     var haveMinimumDragDistance = IsMinimumDragDistance(diff);
                     if (haveMinimumDragDistance)
                     {


### PR DESCRIPTION
In this code, screen and client position were mixed. The screen and client positions are equal when the screen scaling is 100%, but when the DPI is not standard, then they are not. Because of that there was an offset when dragging a window, see the vids: 

Before:

https://github.com/wieslawsoltes/Dock/assets/5689666/b99976ee-c3f3-4ab8-b84d-0f2ff76c8e49

After:

https://github.com/wieslawsoltes/Dock/assets/5689666/3881da92-3460-45c0-b71e-90d842c350d9

