### PR TITLE
Border issue #343

### DIFF
--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -404,7 +404,8 @@ public class ProportionalStackPanel : Panel
                         else
                         {
                             Debug.Assert(!double.IsNaN(proportion));
-                            var width = CalculateDimension(arrangeSize.Width - splitterThickness, proportion, ref sumOfFractions);
+                            var width = CalculateDimension(arrangeSize.Width - splitterThickness, proportion,
+                                ref sumOfFractions);
                             remainingRect = remainingRect.WithWidth(width);
                             left += width;
                         }
@@ -421,7 +422,8 @@ public class ProportionalStackPanel : Panel
                         else
                         {
                             Debug.Assert(!double.IsNaN(proportion));
-                            var height = CalculateDimension(arrangeSize.Height - splitterThickness, proportion, ref sumOfFractions);
+                            var height = CalculateDimension(arrangeSize.Height - splitterThickness, proportion,
+                                ref sumOfFractions);
                             remainingRect = remainingRect.WithHeight(height);
                             top += height;
                         }
@@ -439,13 +441,13 @@ public class ProportionalStackPanel : Panel
     }
 
     private double CalculateDimension(
-        double dimension, 
-        double proportion, 
+        double dimension,
+        double proportion,
         ref double sumOfFractions)
     {
         var childDimension = dimension * proportion;
         var flooredChildDimension = Math.Floor(childDimension);
-       
+
         // sums fractions from the division
         sumOfFractions += childDimension - flooredChildDimension;
 
@@ -455,7 +457,7 @@ public class ProportionalStackPanel : Panel
             sumOfFractions -= Math.Round(sumOfFractions);
             return Math.Max(0, flooredChildDimension + 1);
         }
-        
+
         return Math.Max(0, flooredChildDimension);
     }
 

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -441,7 +441,7 @@ public class ProportionalStackPanel : Panel
             return Math.Max(0, flooredChildDimension);
         else
         {
-            // if so, it assigns the divided pixel to the first control in proportional split
+            // if it leaves, it assigns the divided pixel to the first control in proportional split
             int isFirst = childIndex == 0 ? 1 : 0;
             return Math.Max(0, flooredChildDimension + isFirst);
         }

--- a/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalStackPanel.cs
@@ -255,14 +255,14 @@ public class ProportionalStackPanel : Panel
                 {
                     case Orientation.Horizontal:
                     {
-                        var width = Math.Max(0, (constraint.Width - splitterThickness) * proportion);
+                        var width = CalculateDimension(constraint.Width - splitterThickness, proportion, i);
                         var size = constraint.WithWidth(width);
                         control.Measure(size);
                         break;
                     }
                     case Orientation.Vertical:
                     {
-                        var height = Math.Max(0, (constraint.Height - splitterThickness) * proportion);
+                        var height = CalculateDimension(constraint.Height - splitterThickness, proportion, i);
                         var size = constraint.WithHeight(height);
                         control.Measure(size);
                         break;
@@ -299,7 +299,7 @@ public class ProportionalStackPanel : Panel
                     }
                     else
                     {
-                        usedWidth += Math.Max(0, (constraint.Width - splitterThickness) * proportion);
+                        usedWidth += CalculateDimension(constraint.Width - splitterThickness, proportion, i);
                     }
 
                     break;
@@ -314,7 +314,7 @@ public class ProportionalStackPanel : Panel
                     }
                     else
                     {
-                        usedHeight += Math.Max(0, (constraint.Height - splitterThickness) * proportion);
+                        usedHeight += CalculateDimension(constraint.Height - splitterThickness, proportion, i);
                     }
 
                     break;
@@ -397,7 +397,7 @@ public class ProportionalStackPanel : Panel
                         else
                         {
                             Debug.Assert(!double.IsNaN(proportion));
-                            var width = Math.Max(0, (arrangeSize.Width - splitterThickness) * proportion);
+                            var width = CalculateDimension(arrangeSize.Width - splitterThickness, proportion, i);
                             remainingRect = remainingRect.WithWidth(width);
                             left += width;
                         }
@@ -414,7 +414,7 @@ public class ProportionalStackPanel : Panel
                         else
                         {
                             Debug.Assert(!double.IsNaN(proportion));
-                            var height = Math.Max(0, (arrangeSize.Height - splitterThickness) * proportion);
+                            var height = CalculateDimension(arrangeSize.Height - splitterThickness, proportion, i);
                             remainingRect = remainingRect.WithHeight(height);
                             top += height;
                         }
@@ -429,6 +429,22 @@ public class ProportionalStackPanel : Panel
         }
 
         return arrangeSize;
+    }
+    
+    private double CalculateDimension(double dimension, double proportion, int childIndex)
+    {
+        var childDimension = dimension * proportion;
+        var flooredChildDimension = Math.Floor(childDimension);
+    
+        // checks whether division doesn't leave a fraction
+        if (childDimension == flooredChildDimension)
+            return Math.Max(0, flooredChildDimension);
+        else
+        {
+            // if so, it assigns the divided pixel to the first control in proportional split
+            int isFirst = childIndex == 0 ? 1 : 0;
+            return Math.Max(0, flooredChildDimension + isFirst);
+        }
     }
 
     /// <inheritdoc/>

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -65,7 +65,7 @@ public class ProportionalStackPanelTests
         yield return [0.5, 604, 300, 300];
         yield return [0.25, 604, 150, 450];
         yield return [0.6283185307179586476925286766559, 604, 377, 223];
-        yield return [0.3141592653589793238462643383279, 604, 189, 411];
+        yield return [0.3141592653589793238462643383279, 604, 188, 412];
     }
 
     [Theory]
@@ -187,10 +187,11 @@ public class ProportionalStackPanelTests
         target.Measure(Size.Infinity);
         target.Arrange(new Rect(target.DesiredSize));
 
+        // values have to add up to width/height of the parent control
         Assert.Equal(new Size(1000, 500), target.Bounds.Size);
-        Assert.Equal(new Rect(0, 0, 331, 500), target.Children[0].Bounds);
-        Assert.Equal(new Rect(331, 0, 4, 500), target.Children[1].Bounds);
-        Assert.Equal(new Rect(335, 0, 331, 500), target.Children[2].Bounds);
+        Assert.Equal(new Rect(0, 0, 330, 500), target.Children[0].Bounds);
+        Assert.Equal(new Rect(330, 0, 4, 500), target.Children[1].Bounds);
+        Assert.Equal(new Rect(334, 0, 331, 500), target.Children[2].Bounds);
         Assert.Equal(new Rect(665, 0, 4, 500), target.Children[3].Bounds);
         Assert.Equal(new Rect(669, 0, 331, 500), target.Children[4].Bounds);
     }

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
@@ -26,12 +28,7 @@ public class ProportionalStackPanelTests
             Width = 300,
             Height = 100,
             Orientation = Orientation.Horizontal,
-            Children =
-            {
-                new Border(),
-                new ProportionalStackPanelSplitter(),
-                new Border()
-            }
+            Children = { new Border(), new ProportionalStackPanelSplitter(), new Border() }
         };
 
         target.Measure(Size.Infinity);
@@ -51,12 +48,7 @@ public class ProportionalStackPanelTests
             Width = 100,
             Height = 300,
             Orientation = Orientation.Vertical,
-            Children =
-            {
-                new Border(),
-                new ProportionalStackPanelSplitter(),
-                new Border()
-            }
+            Children = { new Border(), new ProportionalStackPanelSplitter(), new Border() }
         };
 
         target.Measure(Size.Infinity);
@@ -66,6 +58,76 @@ public class ProportionalStackPanelTests
         Assert.Equal(new Rect(0, 0, 100, 148), target.Children[0].Bounds);
         Assert.Equal(new Rect(0, 148, 100, 4), target.Children[1].Bounds);
         Assert.Equal(new Rect(0, 152, 100, 148), target.Children[2].Bounds);
+    }
+
+    private static IEnumerable<object[]> GetBorderTestsData()
+    {
+        yield return [0.5, 604, 300, 300];
+        yield return [0.25, 604, 150, 450];
+        yield return [0.6283185307179586476925286766559, 604, 377, 223];
+        yield return [0.3141592653589793238462643383279, 604, 189, 411];
+    }
+
+    [Theory]
+    [MemberData(nameof(GetBorderTestsData))]
+    public void Should_Not_Trim_Borders_Horizontal(
+        double proportion,
+        double expectedWidth,
+        double expectedFirstChildHeight,
+        double expectedSecondChildHeight)
+    {
+        var target = new ProportionalStackPanel()
+        {
+            Width = expectedWidth,
+            Height = 100,
+            Orientation = Orientation.Horizontal,
+            Children =
+            {
+                new Border { [ProportionalStackPanel.ProportionProperty] = proportion },
+                new ProportionalStackPanelSplitter(),
+                new Border { [ProportionalStackPanel.ProportionProperty] = 1 - proportion }
+            }
+        };
+
+        target.Measure(Size.Infinity);
+        target.Arrange(new Rect(target.DesiredSize));
+
+        var width = target.Children.Sum(c => c.Bounds.Width);
+
+        Assert.Equal(expectedFirstChildHeight, target.Children[0].Bounds.Width);
+        Assert.Equal(expectedSecondChildHeight, target.Children[2].Bounds.Width);
+        Assert.Equal(expectedWidth, width);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetBorderTestsData))]
+    public void Should_Not_Trim_Borders_Vertical(
+        double proportion,
+        double expectedHeight,
+        double expectedFirstChildHeight,
+        double expectedSecondChildHeight)
+    {
+        var target = new ProportionalStackPanel()
+        {
+            Width = 100,
+            Height = expectedHeight,
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                new Border { [ProportionalStackPanel.ProportionProperty] = proportion },
+                new ProportionalStackPanelSplitter(),
+                new Border { [ProportionalStackPanel.ProportionProperty] = 1 - proportion }
+            }
+        };
+
+        target.Measure(Size.Infinity);
+        target.Arrange(new Rect(target.DesiredSize));
+
+        var height = target.Children.Sum(c => c.Bounds.Height);
+
+        Assert.Equal(expectedFirstChildHeight, target.Children[0].Bounds.Height);
+        Assert.Equal(expectedSecondChildHeight, target.Children[2].Bounds.Height);
+        Assert.Equal(expectedHeight, height);
     }
 
     [Fact]
@@ -84,19 +146,12 @@ public class ProportionalStackPanelTests
                     {
                         new Border()
                         {
-                            Background = Brushes.Red,
-                            [ProportionalStackPanel.ProportionProperty] = 0.5
+                            Background = Brushes.Red, [ProportionalStackPanel.ProportionProperty] = 0.5
                         },
                         new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background = Brushes.Green
-                        },
+                        new Border() { Background = Brushes.Green },
                         new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background = Brushes.Blue
-                        }
+                        new Border() { Background = Brushes.Blue }
                     }
                 },
                 new ProportionalStackPanelSplitter(),
@@ -104,20 +159,11 @@ public class ProportionalStackPanelTests
                 {
                     Children =
                     {
-                        new Border()
-                        {
-                            Background = Brushes.Blue,
-                        },
+                        new Border() { Background = Brushes.Blue, },
                         new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background = Brushes.Red
-                        },
+                        new Border() { Background = Brushes.Red },
                         new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background=Brushes.Green
-                        }
+                        new Border() { Background = Brushes.Green }
                     }
                 },
                 new ProportionalStackPanelSplitter(),
@@ -125,20 +171,13 @@ public class ProportionalStackPanelTests
                 {
                     Children =
                     {
-                        new Border()
-                        {
-                            Background = Brushes.Green,
-                        },
+                        new Border() { Background = Brushes.Green, },
+                        new ProportionalStackPanelSplitter(),
+                        new Border() { Background = Brushes.Blue },
                         new ProportionalStackPanelSplitter(),
                         new Border()
                         {
-                            Background = Brushes.Blue
-                        },
-                        new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background=Brushes.Red,
-                            [ProportionalStackPanel.ProportionProperty] = 0.5
+                            Background = Brushes.Red, [ProportionalStackPanel.ProportionProperty] = 0.5
                         }
                     }
                 },
@@ -163,49 +202,30 @@ public class ProportionalStackPanelTests
         {
             Width = 1000,
             Height = 500,
-            ItemsPanel = new ItemsPanelTemplate()
-            {
-                Content = new ProportionalStackPanel()
+            ItemsPanel =
+                new ItemsPanelTemplate()
                 {
-                    Orientation = Orientation.Horizontal
-                }
-            },
+                    Content = new ProportionalStackPanel() { Orientation = Orientation.Horizontal }
+                },
             ItemsSource = new List<Control>()
             {
-                new Border()
-                {
-                    Background = Brushes.Green
-                },
+                new Border() { Background = Brushes.Green },
                 new ProportionalStackPanelSplitter(),
-                new Border()
-                {
-                    Background = Brushes.Blue
-                },
+                new Border() { Background = Brushes.Blue },
                 new ProportionalStackPanelSplitter(),
                 new ItemsControl()
                 {
-                    ItemsPanel = new ItemsPanelTemplate()
-                    {
-                        Content = new ProportionalStackPanel()
+                    ItemsPanel =
+                        new ItemsPanelTemplate()
                         {
-                            Orientation = Orientation.Vertical,
-                        }
-                    },
+                            Content = new ProportionalStackPanel() { Orientation = Orientation.Vertical, }
+                        },
                     ItemsSource = new List<Control>()
                     {
-                        new Border()
-                        {
-                            Background = Brushes.Green
-                        },
+                        new Border() { Background = Brushes.Green },
                         new ProportionalStackPanelSplitter(),
-                        new Border()
-                        {
-                            Background = Brushes.Blue
-                        },
-                        new Border()
-                        {
-                            Background = Brushes.Red
-                        }
+                        new Border() { Background = Brushes.Blue },
+                        new Border() { Background = Brushes.Red }
                     }
                 }
             }


### PR DESCRIPTION
A fix of #343 , caused by multiplying by proportion variable and supposedly wrong rounding.

It adds private method to properly calculate the dimension of children and unit tests to check whether the sum of the children adds up to the dimensions of the parent.

![border-issue](https://github.com/user-attachments/assets/55738c15-3ed0-454d-bc31-cc8097febbce)

Fixes #343 