### PR TITLE
Add DropAdornerShape as DockTarget Selector

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTarget.axaml
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml
@@ -35,22 +35,18 @@
           <Panel x:Name="PART_RightIndicator" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2" />
           <Panel x:Name="PART_CenterIndicator" Grid.ColumnSpan="2" Grid.Column="0" Grid.Row="0" Grid.RowSpan="2" />
           <Panel x:Name="PART_SelectorPanel" Grid.Row="0" Grid.RowSpan="2" Grid.ColumnSpan="2" Grid.Column="0">
-            <Grid x:Name="PART_SelectorGrid" RowDefinitions="*,*,*" ColumnDefinitions="*,*,*">
-              <Image x:Name="PART_TopSelector" Grid.Row="0" Grid.Column="1" />
-              <Image x:Name="PART_BottomSelector" Grid.Row="2" Grid.Column="1" />
-              <Image x:Name="PART_LeftSelector" Grid.Row="1" Grid.Column="0" />
-              <Image x:Name="PART_RightSelector" Grid.Row="1" Grid.Column="2" />
-              <Image x:Name="PART_CenterSelector" Grid.Row="1" Grid.Column="1" />
+            <Grid x:Name="PART_SelectorGrid" RowDefinitions="*,*,*" ColumnDefinitions="*,*,*"
+                  HorizontalAlignment="Center" VerticalAlignment="Center">
+              <DropAdornerShape x:Name="PART_TopSelector" DockPosition="Top" Grid.Row="0" Grid.Column="1" />
+              <DropAdornerShape x:Name="PART_BottomSelector" DockPosition="Bottom" Grid.Row="2" Grid.Column="1" />
+              <DropAdornerShape x:Name="PART_LeftSelector" DockPosition="Left" Grid.Row="1" Grid.Column="0" />
+              <DropAdornerShape x:Name="PART_RightSelector" DockPosition="Right" Grid.Row="1" Grid.Column="2" />
+              <DropAdornerShape x:Name="PART_CenterSelector" DockPosition="{x:Null}" Grid.Row="1" Grid.Column="1" />
             </Grid>
           </Panel>
         </Grid>
       </ControlTemplate>
     </Setter>
-
-    <Style Selector="^/template/ Grid#PART_SelectorGrid">
-      <Setter Property="MaxWidth" Value="125" />
-      <Setter Property="MaxHeight" Value="125" />
-    </Style>
 
     <Style Selector="^/template/ Panel#PART_TopIndicator">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
@@ -75,36 +71,6 @@
     <Style Selector="^/template/ Panel#PART_CenterIndicator">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
       <Setter Property="Opacity" Value="0" />
-    </Style>
-
-    <Style Selector="^/template/ Image#PART_TopSelector">
-      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableTop.png" />
-      <Setter Property="Width" Value="40" />
-      <Setter Property="Height" Value="40" />
-    </Style>
-
-    <Style Selector="^/template/ Image#PART_BottomSelector">
-      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableBottom.png" />
-      <Setter Property="Width" Value="40" />
-      <Setter Property="Height" Value="40" />
-    </Style>
-
-    <Style Selector="^/template/ Image#PART_LeftSelector">
-      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableLeft.png" />
-      <Setter Property="Width" Value="40" />
-      <Setter Property="Height" Value="40" />
-    </Style>
-
-    <Style Selector="^/template/ Image#PART_RightSelector">
-      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableRight.png" />
-      <Setter Property="Width" Value="40" />
-      <Setter Property="Height" Value="40" />
-    </Style>
-
-    <Style Selector="^/template/ Image#PART_CenterSelector">
-      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockDocumentInside.png" />
-      <Setter Property="Width" Value="40" />
-      <Setter Property="Height" Value="40" />
     </Style>
 
   </ControlTheme>

--- a/src/Dock.Avalonia/Controls/DropAdornerShape.axaml
+++ b/src/Dock.Avalonia/Controls/DropAdornerShape.axaml
@@ -1,0 +1,17 @@
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <Border Padding="20">
+      <StackPanel>
+        <DropAdornerShape />
+      </StackPanel>
+    </Border>
+  </Design.PreviewWith>
+  <ControlTheme x:Key="{x:Type DropAdornerShape}" TargetType="DropAdornerShape">
+    <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}" />
+    <Setter Property="Background" Value="{DynamicResource DockThemeBorderLowBrush}" />
+    <Setter Property="BorderBrush" Value="{DynamicResource DockThemeForegroundBrush}" />
+    <Setter Property="Margin" Value="4" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DropAdornerShape.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DropAdornerShape.axaml.cs
@@ -1,0 +1,164 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using AvaloniaDock = Avalonia.Controls.Dock;
+
+namespace Dock.Avalonia.Controls;
+
+public class DropAdornerShape : Control
+{
+    public static readonly StyledProperty<IBrush?> ForegroundProperty = 
+        AvaloniaProperty.Register<DropAdornerShape, IBrush?>(nameof(Foreground));
+
+    public static readonly StyledProperty<IBrush?> BorderBrushProperty = 
+        AvaloniaProperty.Register<DropAdornerShape, IBrush?>(nameof(BorderBrush));
+
+    public static readonly StyledProperty<IBrush?> BackgroundProperty = 
+        AvaloniaProperty.Register<DropAdornerShape, IBrush?>(nameof(Background));
+
+    public static readonly StyledProperty<AvaloniaDock?> DockPositionProperty = 
+        AvaloniaProperty.Register<DropAdornerShape, AvaloniaDock?>(nameof(DockPosition));
+
+    public IBrush? Foreground
+    {
+        get => GetValue(ForegroundProperty);
+        set => SetValue(ForegroundProperty, value);
+    }
+
+    public IBrush? BorderBrush
+    {
+        get => GetValue(BorderBrushProperty);
+        set => SetValue(BorderBrushProperty, value);
+    }
+
+    public IBrush? Background
+    {
+        get => GetValue(BackgroundProperty);
+        set => SetValue(BackgroundProperty, value);
+    }
+
+    public AvaloniaDock? DockPosition
+    {
+        get => GetValue(DockPositionProperty);
+        set => SetValue(DockPositionProperty, value);
+    }
+
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        return new Size(40, 40);
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        context.DrawRectangle(Brushes.Transparent, null, new Rect(this.Bounds.Size));
+        context.DrawRectangle(Background, new Pen(BorderBrush, 1), new Rect(new Size(40, 40)), 3, 3);
+        context.DrawGeometry(Foreground, null, CreateGeometry(DockPosition, 40));
+    }
+
+    private Geometry CreateGeometry(AvaloniaDock? dock, double size)
+    {
+        var streamGeometry = new StreamGeometry();
+        using (var context = streamGeometry.Open())
+        {
+            // Draw a triangle. 
+            if (dock is not null)
+            {
+                Point[] dots = dock switch
+                {
+                    AvaloniaDock.Right => [new Point(10, 16), new Point(14, 20), new Point(10, 24)],
+                    AvaloniaDock.Left => [new Point(30, 16), new Point(26, 20), new Point(30, 24)],
+                    AvaloniaDock.Top => [new Point(16, 30), new Point(20, 26), new Point(24, 30)],
+                    AvaloniaDock.Bottom => [new Point(16, 10), new Point(20, 14), new Point(24, 10)],
+                    _ => throw new ArgumentOutOfRangeException(nameof(dock), dock, null)
+                };
+                context.BeginFigure(dots[0], true);
+                context.LineTo(dots[1]);
+                context.LineTo(dots[2]);
+                context.EndFigure(true);
+            }
+
+            Point[] outerDots = dock switch
+            {
+                AvaloniaDock.Right =>
+                [
+                    new Point(20, 6), new Point(34, 6), new Point(34, 31), new Point(31, 34), new Point(23, 34),
+                    new Point(20, 31), new Point(20, 6)
+                ],
+                AvaloniaDock.Left =>
+                [
+                    new Point(6, 6), new Point(20, 6), new Point(20, 31), new Point(17, 34), new Point(9, 34),
+                    new Point(6, 31), new Point(6, 6)
+                ],
+                AvaloniaDock.Top =>
+                [
+                    new Point(6, 6), new Point(34, 6), new Point(34, 17), new Point(31, 20), new Point(9, 20),
+                    new Point(6, 17), new Point(6, 6)
+                ],
+                AvaloniaDock.Bottom =>
+                [
+                    new Point(6, 20), new Point(34, 20), new Point(34, 31), new Point(31, 34), new Point(9, 34),
+                    new Point(6, 31), new Point(6, 6)
+                ],
+                _ =>
+                [
+                    new Point(6, 6), new Point(34, 6), new Point(34, 31), new Point(31, 34), new Point(9, 34),
+                    new Point(6, 31), new Point(6, 6)
+                ]
+            };
+
+            context.BeginFigure(outerDots[0], true);
+            context.LineTo(outerDots[1]);
+            context.LineTo(outerDots[2]);
+            context.ArcTo(outerDots[3], new Size(3, 3), 45, false, SweepDirection.Clockwise);
+            context.LineTo(outerDots[4]);
+            context.ArcTo(outerDots[5], new Size(3, 3), 45, false, SweepDirection.Clockwise);
+            context.LineTo(outerDots[6]);
+            context.EndFigure(true);
+        }
+
+        var innerStreamGeometry = new StreamGeometry();
+        using (var innerContext = innerStreamGeometry.Open())
+        {
+            Point[] outerDots = dock switch
+            {
+                AvaloniaDock.Right =>
+                [
+                    new Point(21, 10), new Point(33, 10), new Point(33, 31), new Point(31, 33), new Point(23, 33),
+                    new Point(21, 31), new Point(21, 10)
+                ],
+                AvaloniaDock.Left =>
+                [
+                    new Point(7, 10), new Point(19, 10), new Point(19, 31), new Point(17, 33), new Point(9, 33),
+                    new Point(7, 31), new Point(7, 10)
+                ],
+                AvaloniaDock.Top =>
+                [
+                    new Point(7, 10), new Point(33, 10), new Point(33, 17), new Point(31, 19), new Point(9, 19),
+                    new Point(7, 17), new Point(7, 10)
+                ],
+                AvaloniaDock.Bottom =>
+                [
+                    new Point(7, 24), new Point(33, 24), new Point(33, 31), new Point(31, 33), new Point(9, 33),
+                    new Point(7, 31), new Point(7, 24)
+                ],
+                _ =>
+                [
+                    new Point(7, 10), new Point(33, 10), new Point(33, 31), new Point(31, 33), new Point(9, 33),
+                    new Point(7, 31), new Point(7, 10)
+                ]
+            };
+            innerContext.BeginFigure(outerDots[0], true);
+            innerContext.LineTo(outerDots[1]);
+            innerContext.LineTo(outerDots[2]);
+            innerContext.ArcTo(outerDots[3], new Size(2, 2), 45, false, SweepDirection.Clockwise);
+            innerContext.LineTo(outerDots[4]);
+            innerContext.ArcTo(outerDots[5], new Size(2, 2), 45, false, SweepDirection.Clockwise);
+            innerContext.LineTo(outerDots[6]);
+            innerContext.EndFigure(true);
+        }
+
+        return new CombinedGeometry(GeometryCombineMode.Exclude, streamGeometry, innerStreamGeometry);
+    }
+}

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -5,6 +5,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Avalonia.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml" />
+        <ResourceInclude Source="/Controls/DropAdornerShape.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStripItem.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStrip.axaml" />
         <ResourceInclude Source="/Controls/ToolTabStripItem.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -5,6 +5,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Avalonia.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml" />
+        <ResourceInclude Source="/Controls/DropAdornerShape.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStripItem.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStrip.axaml" />
         <ResourceInclude Source="/Controls/ToolTabStripItem.axaml" />


### PR DESCRIPTION
DropAdornerShape is a selector shape that allows customization of `Foreground`, `Background`&`BorderBrush`.

It looks like this using FluentTheme:
![image](https://github.com/user-attachments/assets/5695ba51-92cf-4221-adb1-b3ed58d460b3)
![image](https://github.com/user-attachments/assets/2ef2386b-057c-4288-aa0d-a035c74affd4)

Do the [Images from Assets](https://github.com/wieslawsoltes/Dock/tree/master/src/Dock.Avalonia/Assets) should be deleted?