### PR TITLE
Fix deep dive code block refs

### DIFF
--- a/docs/dock-deep-dive.md
+++ b/docs/dock-deep-dive.md
@@ -6,43 +6,38 @@ This document explains the internals of `DockControl` and the docking pipeline u
 
 `DockControl` is the main Avalonia control that hosts a layout. The constructor registers pointer handlers and creates both a `DockManager` and a `DockControlState` instance:
 
-```csharp
-// DockControl.axaml.cs
-```
+The
+[constructor implementation](../src/Dock.Avalonia/Controls/DockControl.axaml.cs#L115-L126)
+shows how the control registers pointer handlers and initializes the docking state.
 
-When the `Layout` property changes `OnPropertyChanged` reinitializes the control with the new root dock:
-
-```csharp
-// DockControl.axaml.cs
-```
+When the `Layout` property changes `OnPropertyChanged` reinitializes the control
+with the new root dock. You can inspect the logic in the
+[source file](../src/Dock.Avalonia/Controls/DockControl.axaml.cs#L128-L142).
 
 The private `Initialize` method wires up the factory and optionally calls `InitLayout`:
 
-```csharp
-// DockControl.axaml.cs
-```
+Initialization configures factories and optionally creates the default layout.
+Refer to the
+[Initialize method](../src/Dock.Avalonia/Controls/DockControl.axaml.cs#L144-L186)
+for a full walkthrough.
 
-Pointer events are forwarded to `DockControlState.Process` which performs hit testing and drag logic:
-
-```csharp
-// DockControl.axaml.cs
-```
+Pointer events are delegated to `DockControlState.Process`. See
+[PressedHandler and ReleasedHandler](../src/Dock.Avalonia/Controls/DockControl.axaml.cs#L253-L272)
+for how the events are forwarded.
 
 ## DockControlState
 
-`DockControlState` keeps track of the drag state. It validates potential drop targets using `DockManager` and displays `DockTarget` adorners when appropriate. Once the user releases the pointer the state object calls `DockManager.ValidateDockable` with execution enabled.
-
-```csharp
-// DockControlState.cs
-```
+`DockControlState` keeps track of the drag state. It validates potential drop targets using `DockManager` and displays `DockTarget` adorners when appropriate. Once the user releases the pointer the state object calls
+[`DockManager.ValidateDockable`](../src/Dock.Avalonia/Internal/DockControlState.cs#L124-L166)
+to execute the operation.
 
 ## DockManager
 
 `DockManager` implements the algorithms that move, swap or split dockables. Methods such as `MoveDockable`, `SwapDockable` and `SplitToolDockable` call back into the factory to modify the view models.
 
-```csharp
-// DockManager.cs
-```
+The
+[MoveDockable method](../src/Dock.Model/DockManager.cs#L18-L50)
+shows how `DockManager` coordinates with the factory to move a dockable into a new dock.
 
 ## Putting it together
 


### PR DESCRIPTION
## Summary
- insert links to actual DockControl constructor and helpers
- reference OnPropertyChanged and Initialize method source
- link to event handlers, DockControlState call, and DockManager logic

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685becc24364832191f54f36b44fd919