### PR TITLE
Improve doc navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Install-Package Dock.Model.Mvvm -Pre
 ```
 
 ## Resources
-* [Documentation](docs/dock-mvvm.md) - MVVM guide
+* [Documentation index](docs/README.md)
+* [MVVM Guide](docs/dock-mvvm.md)
 * [ReactiveUI Guide](docs/dock-reactiveui.md)
 * [XAML Guide](docs/dock-xaml.md)
 * [Reference Guide](docs/dock-reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Dock Documentation
+
+Welcome to the Dock documentation. This directory contains all official guides for using the library.
+
+## Guides
+
+- [MVVM Guide](dock-mvvm.md) – Build layouts using MVVM view models.
+- [ReactiveUI Guide](dock-reactiveui.md) – ReactiveUI equivalent of the MVVM guide.
+- [XAML Guide](dock-xaml.md) – Declare layouts purely in XAML.
+- [Reference Guide](dock-reference.md) – Overview of the core APIs.
+- [Advanced Guide](dock-advanced.md) – Custom factories and runtime features.
+- [Events Guide](dock-events.md) – Subscribing to dock and window events.
+- [API Scenarios](dock-api-scenarios.md) – Common coding patterns.
+- [Deep Dive](dock-deep-dive.md) – Internals of `DockControl`.
+
+See the sample applications under the [samples](../samples/) directory for real-world usage.

--- a/docs/dock-advanced.md
+++ b/docs/dock-advanced.md
@@ -101,3 +101,5 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
 ## Conclusion
 
 Explore the samples under `samples/` for complete implementations. Mixing these techniques with the basics lets you build complex layouts that can be persisted and restored.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-api-scenarios.md
+++ b/docs/dock-api-scenarios.md
@@ -58,3 +58,5 @@ These factories expose methods such as `AddDockable`, `MoveDockable` or `FloatDo
 
 Use the MVVM, ReactiveUI or XAML samples as references for complete implementations.
 
+For an overview of all guides see the [documentation index](README.md).
+

--- a/docs/dock-deep-dive.md
+++ b/docs/dock-deep-dive.md
@@ -64,3 +64,5 @@ _dockManager.MoveDockable(document, targetDock, index);
 ## Putting it together
 
 When the user drags a tab or tool the pointer handlers in `DockControl` delegate the event stream to `DockControlState`. The state object determines the target area and executes the appropriate operation through `DockManager`. The manager calls the factory which updates collections on the dock view models, completing the layout update.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-events.md
+++ b/docs/dock-events.md
@@ -48,3 +48,5 @@ Events are useful for:
 - Implementing custom logic when new documents are created at runtime.
 
 Consult the samples for practical examples where events are wired to view models and commands.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -128,3 +128,5 @@ _factory.DockableAdded += (_, e) => Console.WriteLine($"Added {e.Dockable?.Id}")
 ## Next steps
 
 Use the MVVM sample as a starting point for your application. You can extend the factory to create custom docks, documents and tools.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-reactiveui.md
+++ b/docs/dock-reactiveui.md
@@ -118,3 +118,5 @@ OpenDocument = ReactiveCommand.Create(() =>
 All the events shown in the MVVM guide are present here as well. Subscribe to them in the same way using ReactiveUI commands or observables.
 
 Use the ReactiveUI sample as a template when building your own layouts.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -55,3 +55,5 @@ The XAML sample shows that a layout can be declared entirely in markup using `Do
 - `samples/DockMvvmSample` – full MVVM example.
 - `samples/DockReactiveUISample` – ReactiveUI variant.
 - `samples/DockXamlSample` – XAML-only layout with serialization.
+
+For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-xaml.md
+++ b/docs/dock-xaml.md
@@ -101,3 +101,5 @@ Use `SaveFilePickerAsync` and `OpenFilePickerAsync` from Avalonia to choose the 
 ## Next steps
 
 Use the XAML sample as a template if you prefer declaring layouts in markup rather than creating them via a factory. You can combine this approach with MVVM or ReactiveUI view models for additional logic.
+
+For an overview of all guides see the [documentation index](README.md).


### PR DESCRIPTION
## Summary
- add docs index under `docs/README.md`
- link to docs index from main README
- cross reference docs to the index

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685bf2110da0832181f5f3dcdc482f23