### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Target framework `netstandard2.0`:
 dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release -f netstandard2.0
 ```
 
+Alternatively execute the repository build script which restores,
+builds and tests all projects. The scripts work on Windows and Unix
+like systems:
+
+```bash
+./build.sh       # or .\build.cmd on Windows
+```
+
 ## NuGet
 
 Dock is delivered as a NuGet package.
@@ -66,6 +74,8 @@ Install-Package Dock.Model.Mvvm -Pre
 * [Events Guide](docs/dock-events.md)
 * [API Scenarios](docs/dock-api-scenarios.md)
 * [Deep Dive](docs/dock-deep-dive.md)
+* Sample applications can be found under the [samples](samples/) directory
+  which illustrate each approach in a working project.
 
 * [GitHub source code repository.](https://github.com/wieslawsoltes/Dock)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,10 @@
 # Dock Documentation
 
-Welcome to the Dock documentation. This directory contains all official guides for using the library.
+Welcome to the Dock documentation.  The files in this folder describe how to
+use the Dock layout system from simple getting started examples to
+advanced customization scenarios.  The documents assume you have an
+Avalonia application created with the .NET SDK.  If you are new to Dock
+start with the MVVM guide and work your way towards the deep dive.
 
 ## Guides
 
@@ -14,3 +18,5 @@ Welcome to the Dock documentation. This directory contains all official guides f
 - [Deep Dive](dock-deep-dive.md) – Internals of `DockControl`.
 
 See the sample applications under the [samples](../samples/) directory for real-world usage.
+The [project README](../README.md) also lists the available guides and provides
+basic build instructions.

--- a/docs/dock-advanced.md
+++ b/docs/dock-advanced.md
@@ -11,7 +11,11 @@ All samples derive from `Factory` and override methods to configure the layout. 
 - `CreateDocumentDock` to provide a custom `IDocumentDock` implementation
 - `InitLayout` to wire up `ContextLocator`, `DockableLocator` and `HostWindowLocator`
 
-The MVVM and ReactiveUI samples use these hooks to register view models and window factories:
+The MVVM and ReactiveUI samples use these hooks to register view models,
+window factories and other services required at runtime. By overriding the
+factory methods you can control how floating windows are created, inject your
+own tool or document types and tie into application specific services such as
+dependency injection containers.
 
 ```csharp
 public override void InitLayout(IDockable layout)
@@ -35,6 +39,10 @@ public override void InitLayout(IDockable layout)
 ## Handling events
 
 `FactoryBase` exposes events for virtually every docking action. The samples subscribe to them to trace runtime changes:
+
+Events are useful for hooking into your application's own logging or
+analytics system. For example you might record when documents are opened
+or closed so that the next run can restore them.
 
 ```csharp
 factory.ActiveDockableChanged += (_, args) =>

--- a/docs/dock-api-scenarios.md
+++ b/docs/dock-api-scenarios.md
@@ -58,5 +58,24 @@ These factories expose methods such as `AddDockable`, `MoveDockable` or `FloatDo
 
 Use the MVVM, ReactiveUI or XAML samples as references for complete implementations.
 
+### Saving and restoring a layout
+
+Layouts can be persisted using `DockSerializer` from the `Dock.Serializer` package.
+This allows users to keep their preferred window arrangement between sessions.
+
+```csharp
+await using var stream = File.Create(path);
+_serializer.Save(layout, stream);
+```
+
+Likewise you can restore a saved layout and reinitialise the factory:
+
+```csharp
+await using var stream = File.OpenRead(path);
+var layout = _serializer.Load<IDock>(stream);
+factory.InitLayout(layout);
+dockControl.Layout = layout;
+```
+
 For an overview of all guides see the [documentation index](README.md).
 

--- a/docs/dock-deep-dive.md
+++ b/docs/dock-deep-dive.md
@@ -2,6 +2,10 @@
 
 This document explains how `DockControl` routes pointer input through the docking pipeline. Reading this guide together with the source code will help you understand how layout changes are performed.
 
+While the high level guides focus on using the provided factories this section
+dives into the low level mechanics. Understanding these classes is useful when
+you need behaviour not covered by the default implementation.
+
 ## DockControl
 
 `DockControl` is the main Avalonia control that hosts a layout. Its constructor registers pointer handlers and creates both a `DockManager` and a `DockControlState`:
@@ -64,5 +68,9 @@ _dockManager.MoveDockable(document, targetDock, index);
 ## Putting it together
 
 When the user drags a tab or tool the pointer handlers in `DockControl` delegate the event stream to `DockControlState`. The state object determines the target area and executes the appropriate operation through `DockManager`. The manager calls the factory which updates collections on the dock view models, completing the layout update.
+
+If you wish to extend this pipeline—for example to implement custom drag
+restrictions—you can subclass `DockManager` and override its methods before
+assigning it to the `DockControl` instance.
 
 For an overview of all guides see the [documentation index](README.md).

--- a/docs/dock-events.md
+++ b/docs/dock-events.md
@@ -2,6 +2,10 @@
 
 Dock exposes a large set of runtime events through `FactoryBase` so that applications can react to changes in the layout. The other guides only briefly mention these hooks. This document lists the most commonly used events and shows how to subscribe to them.
 
+Each event uses a dedicated arguments type that exposes the affected
+dockable or window along with optional cancelation tokens. This makes it
+possible to intercept an operation before it completes.
+
 ## Common events
 
 `FactoryBase` publishes events via the `IFactory` interface. Each event passes an arguments object containing the affected dockable or window.

--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -2,6 +2,11 @@
 
 This guide explains how to get started with the MVVM version of Dock and describes the available features. It assumes you already have a basic Avalonia application.
 
+The MVVM helpers provided by `Dock.Model.Mvvm` add `INotifyPropertyChanged`
+support to the core interfaces and expose a `Factory` base class that wires up
+commands and events for you.  The sample project `DockMvvmSample` in the
+repository shows a full implementation.
+
 ## Step-by-step tutorial
 
 The following steps walk you through creating a very small application that uses Dock with the MVVM helpers.
@@ -49,6 +54,11 @@ The following steps walk you through creating a very small application that uses
    Layout = _factory.CreateLayout();
    _factory.InitLayout(Layout);
    ```
+
+   `InitLayout` configures services such as `ContextLocator` and
+   `DockableLocator` which the view models use to resolve their
+   corresponding views. Override this method in your factory if you need
+   to register additional mappings or perform custom initialization logic.
 
 5. **Add `DockControl` to `MainWindow.axaml`**
 

--- a/docs/dock-reactiveui.md
+++ b/docs/dock-reactiveui.md
@@ -1,6 +1,9 @@
 # Dock ReactiveUI Guide
 
-This document mirrors the MVVM instructions for projects that use ReactiveUI. The API surface is the same but the view models derive from ReactiveUI types.
+This document mirrors the MVVM instructions for projects that use ReactiveUI.
+The API surface is the same but the view models derive from ReactiveUI types and
+commands are implemented using `ReactiveCommand`. The sample project
+`DockReactiveUISample` demonstrates these concepts in a working application.
 
 ## Step-by-step tutorial
 

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -50,6 +50,10 @@ The MVVM sample demonstrates how to subscribe to factory events and update the U
 
 The XAML sample shows that a layout can be declared entirely in markup using `DockControl` and the various dock types. The `Dock.Serializer` package can persist these layouts to disk. In XAML you place `RootDock`, `ProportionalDock`, `ToolDock` or `DocumentDock` elements inside a `DockControl`, optionally providing a factory for runtime behaviour.
 
+`DockSerializer` from the same package can save or load layouts as JSON. The
+samples register an instance of this serializer through dependency injection so
+commands can call `SaveAsync` and `LoadAsync` to persist user changes.
+
 ## Further reading
 
 - `samples/DockMvvmSample` – full MVVM example.

--- a/docs/dock-xaml.md
+++ b/docs/dock-xaml.md
@@ -1,6 +1,9 @@
 # Dock XAML Guide
 
-This guide shows how to create Dock layouts entirely in XAML. The [DockXamlSample](../samples/DockXamlSample) demonstrates these techniques.
+This guide shows how to create Dock layouts entirely in XAML.  Using XAML can be
+convenient when the layout rarely changes or when you wish to edit it without
+recompiling. The [DockXamlSample](../samples/DockXamlSample) demonstrates these
+techniques.
 
 ## Step-by-step tutorial
 
@@ -40,7 +43,12 @@ These steps outline how to set up a small Dock application that defines its layo
 
 4. **Save and load layouts**
 
-   Use `DockSerializer` from code-behind to persist or restore the layout.
+Use `DockSerializer` from code-behind to persist or restore the layout.
+
+When declaring layouts this way you typically still provide a small
+`Factory` implementation. The factory allows you to resolve your view
+models and hook into runtime events while keeping the layout defined in
+markup.
 
 5. **Run the application**
 


### PR DESCRIPTION
## Summary
- clarify build instructions and link to sample directory
- expand docs index introduction
- note MVVM helper usage and `InitLayout` purpose
- add ReactiveUI tips and XAML factory explanation
- detail advanced factory customization and event logging
- document DockSerializer usage and deep dive notes

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685bf4548f08832189e20ba587b58b7d