### PR TITLE
Add Quick Start guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,12 @@ Welcome to the Dock documentation.  The files in this folder describe how to
 use the Dock layout system from simple getting started examples to
 advanced customization scenarios.  The documents assume you have an
 Avalonia application created with the .NET SDK.  If you are new to Dock
-start with the MVVM guide and work your way towards the deep dive.
+start with the MVVM guide and work your way towards the deep dive. If you
+just want to see Dock running quickly, check out the Quick Start below.
 
 ## Guides
 
+- [Quick Start](quick-start.md) – Install the packages and run a simple layout.
 - [MVVM Guide](dock-mvvm.md) – Build layouts using MVVM view models.
 - [ReactiveUI Guide](dock-reactiveui.md) – ReactiveUI equivalent of the MVVM guide.
 - [XAML Guide](dock-xaml.md) – Declare layouts purely in XAML.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,76 @@
+# Quick Start
+
+This short guide shows how to set up Dock in a new Avalonia application. You will install the NuGet packages, create a minimal layout and run it.
+
+## Step-by-step tutorial
+
+1. **Create a new Avalonia project**
+
+   ```bash
+   dotnet new avalonia.app -o DockQuickStart
+   cd DockQuickStart
+   ```
+
+2. **Install the Dock packages**
+
+   ```powershell
+   dotnet add package Dock.Avalonia
+   dotnet add package Dock.Model.Mvvm
+   ```
+
+3. **Add a simple layout**
+
+   Create a `DockFactory` that derives from `Dock.Model.Mvvm.Factory` and returns a basic layout:
+
+   ```csharp
+   using Dock.Model.Core;
+   using Dock.Model.Mvvm;
+   using Dock.Model.Mvvm.Controls;
+
+   public class DockFactory : Factory
+   {
+       public override IRootDock CreateLayout()
+       {
+           var document = new Document { Id = "Doc1", Title = "Document" };
+
+           return CreateRootDock().With(root =>
+           {
+               root.VisibleDockables = CreateList<IDockable>(
+                   new DocumentDock { VisibleDockables = CreateList<IDockable>(document), ActiveDockable = document }
+               );
+               root.DefaultDockable = root.VisibleDockables[0];
+           });
+       }
+   }
+   ```
+
+   Initialize this layout in `MainWindow.axaml.cs`:
+
+   ```csharp
+   public partial class MainWindow : Window
+   {
+       private readonly DockFactory _factory = new();
+
+       public MainWindow()
+       {
+           InitializeComponent();
+           var layout = _factory.CreateLayout();
+           _factory.InitLayout(layout);
+           Dock.Layout = layout;
+       }
+   }
+   ```
+
+   Add a `DockControl` placeholder to `MainWindow.axaml`:
+
+   ```xaml
+   <DockControl x:Name="Dock" />
+   ```
+
+4. **Run the application**
+
+   ```bash
+   dotnet run
+   ```
+
+The window should show a single document hosted by `DockControl`. See the other guides for more advanced layouts.


### PR DESCRIPTION
## Summary
- add a Quick Start document for installing Dock and running a sample layout
- link the guide from the documentation index

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685c520b479c8321a2cce81a0848e62d