### PR TITLE
Add FAQ on intercepting dock events

### DIFF
--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -57,4 +57,24 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
 }
 ```
 
+**Can I cancel switching the active dockable or closing a dock?**
+
+Dock currently raises `ActiveDockableChanged` only *after* the active dockable
+has been updated, so the change cannot be cancelled. Likewise there is no
+pre-close event for dockables. The only cancellable closing hook is
+`WindowClosing`, which is fired when a host window is about to close. Set the
+`Cancel` property on the event arguments to keep the window open:
+
+```csharp
+factory.WindowClosing += (_, args) =>
+{
+    if (!CanShutdown())
+    {
+        args.Cancel = true; // prevents the window from closing
+    }
+};
+```
+
+Cancelling individual dockables is not supported.
+
 For a general overview of Dock see the [documentation index](README.md).


### PR DESCRIPTION
## Summary
- document that `ActiveDockableChanged` and dockable closing can't be cancelled
- show how to cancel `WindowClosing`

## Testing
- `./build.sh --target Test`

------
https://chatgpt.com/codex/tasks/task_e_685c5cd04d708321b5876e962418b298