### PR TITLE
Clarify dock IDs

### DIFF
--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -49,6 +49,14 @@ objects that become the `DataContext` of the views. Populate both dictionaries
 when initializing your factory so that Dock can resolve your custom documents
 and tools.
 
+**Are dock `Id`s unique?**
+
+No. The `Id` string on a dockable acts as a lookup key for `DockSerializer`.
+When a document dock is split or cloned the factory copies the source `Id` so
+that both docks resolve to the same view model type when a layout is
+deserialized. If you need to distinguish individual document docks, store a
+separate unique identifier on your view models.
+
 ## Other questions
 
 **Floating windows appear in the wrong place**

--- a/docs/dock-serialization.md
+++ b/docs/dock-serialization.md
@@ -40,4 +40,13 @@ Before calling `Load` ensure that custom dockables are registered with `Dockable
 
 Following this pattern keeps the window arrangement consistent across sessions.
 
+## Dockable identifiers
+
+Every dockable stores an `Id` string that is written to the layout file. During
+deserialization `DockableLocator` receives this identifier and returns the view
+model to instantiate. The value is a type key, not a unique runtime ID. When a
+document dock is split or cloned the framework copies the original `Id` so each
+section resolves to the same view model type. Track your own unique identifier
+if your application must distinguish individual document docks.
+
 For an overview of all guides see the [documentation index](README.md).


### PR DESCRIPTION
## Summary
- document why dock `Id`s are reused when splitting
- explain how `Id` values are used by `DockSerializer`

## Testing
- `dotnet test -v minimal` *(fails: No test is available / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685c5d3d0a1c83218a9858152ba01857