### PR TITLE
Add active document helper

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ just want to see Dock running quickly, check out the Quick Start below.
 - [Glossary](dock-glossary.md) – Definitions of common Dock terms.
 - [Advanced Guide](dock-advanced.md) – Custom factories and runtime features.
 - [Events Guide](dock-events.md) – Subscribing to dock and window events.
+- [Active Document](dock-active-document.md) – Retrieve the currently focused document.
 - [API Scenarios](dock-api-scenarios.md) – Common coding patterns.
 - [Serialization and Persistence](dock-serialization.md) – Saving and restoring layouts.
 - [Architecture Overview](dock-architecture.md) – High level design of the docking system.

--- a/docs/dock-active-document.md
+++ b/docs/dock-active-document.md
@@ -1,0 +1,17 @@
+# Finding the Active Document
+
+Only one document or tool can have focus at a time, even when multiple
+`IDocumentDock` instances or floating windows are present.  The
+`IRootDock` that is currently active exposes its focused dockable via the
+`FocusedDockable` property.  You can subscribe to the
+`IFactory.FocusedDockableChanged` event or query the property directly.
+
+```csharp
+factory.FocusedDockableChanged += (_, e) =>
+    Console.WriteLine($"Current document: {e.Dockable?.Title}");
+
+var current = factory.GetCurrentDocument();
+```
+
+The helper `GetCurrentDocument` extension returns the focused document
+for the active root dock or `null` if no document is selected.

--- a/src/Dock.Model/Core/FactoryExtensions.cs
+++ b/src/Dock.Model/Core/FactoryExtensions.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Core;
+
+/// <summary>
+/// Helper methods for <see cref="IFactory"/>.
+/// </summary>
+internal static class FactoryExtensions
+{
+    /// <summary>
+    /// Finds the root dock that currently has focus.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <returns>The active <see cref="IRootDock"/> if found, otherwise <c>null</c>.</returns>
+    public static IRootDock? GetActiveRoot(this IFactory factory)
+    {
+        return factory
+            .Find(d => d is IRootDock root && root.IsActive)
+            .OfType<IRootDock>()
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Gets the document that is currently focused across all docks and windows.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <returns>The active <see cref="IDocument"/> or <c>null</c> if no document is focused.</returns>
+    public static IDocument? GetCurrentDocument(this IFactory factory)
+    {
+        return factory.GetActiveRoot()?.FocusedDockable as IDocument;
+    }
+}


### PR DESCRIPTION
## Summary
- add `FactoryExtensions` with methods to retrieve the active root and current document
- document how to get the active document
- link the new guide from the docs index

## Testing
- `dotnet test` *(fails: No test is available message, but 13 tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_685c5f8b49088321810eeab8c38443cd