### PR TITLE
Add PixelDock sample

### DIFF
--- a/samples/DockMvvmSample/ViewModels/DockFactory.cs
+++ b/samples/DockMvvmSample/ViewModels/DockFactory.cs
@@ -41,7 +41,7 @@ public class DockFactory : Factory
         var tool7 = new Tool7ViewModel {Id = "Tool7", Title = "Tool7", CanClose = false, CanPin = false};
         var tool8 = new Tool8ViewModel {Id = "Tool8", Title = "Tool8", CanClose = false, CanPin = true};
 
-        var leftDock = new ProportionalDock
+        var leftDock = new PixelDock
         {
             Proportion = 0.25,
             Orientation = Orientation.Vertical,
@@ -50,13 +50,15 @@ public class DockFactory : Factory
             (
                 new ToolDock
                 {
+                    Proportion = 150,
                     ActiveDockable = tool1,
                     VisibleDockables = CreateList<IDockable>(tool1, tool2),
                     Alignment = Alignment.Left
                 },
-                new ProportionalDockSplitter(),
+                new PixelDockSplitter(),
                 new ToolDock
                 {
+                    Proportion = 150,
                     ActiveDockable = tool3,
                     VisibleDockables = CreateList<IDockable>(tool3, tool4),
                     Alignment = Alignment.Bottom

--- a/samples/DockMvvmSample/ViewModels/DockFactory.cs
+++ b/samples/DockMvvmSample/ViewModels/DockFactory.cs
@@ -6,11 +6,11 @@ using DockMvvmSample.ViewModels.Docks;
 using DockMvvmSample.ViewModels.Documents;
 using DockMvvmSample.ViewModels.Tools;
 using DockMvvmSample.ViewModels.Views;
-using Dock.Avalonia.Controls;
+using AvaloniaControls = Dock.Avalonia.Controls;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Model.Mvvm;
-using Dock.Model.Mvvm.Controls;
+using ModelControls = Dock.Model.Mvvm.Controls;
 
 namespace DockMvvmSample.ViewModels;
 
@@ -41,22 +41,22 @@ public class DockFactory : Factory
         var tool7 = new Tool7ViewModel {Id = "Tool7", Title = "Tool7", CanClose = false, CanPin = false};
         var tool8 = new Tool8ViewModel {Id = "Tool8", Title = "Tool8", CanClose = false, CanPin = true};
 
-        var leftDock = new PixelDock
+        var leftDock = new ModelControls.PixelDock
         {
             Proportion = 0.25,
             Orientation = Orientation.Vertical,
             ActiveDockable = null,
             VisibleDockables = CreateList<IDockable>
             (
-                new ToolDock
+                new ModelControls.ToolDock
                 {
                     Proportion = 150,
                     ActiveDockable = tool1,
                     VisibleDockables = CreateList<IDockable>(tool1, tool2),
                     Alignment = Alignment.Left
                 },
-                new PixelDockSplitter(),
-                new ToolDock
+                new ModelControls.PixelDockSplitter(),
+                new ModelControls.ToolDock
                 {
                     Proportion = 150,
                     ActiveDockable = tool3,
@@ -66,22 +66,22 @@ public class DockFactory : Factory
             )
         };
 
-        var rightDock = new ProportionalDock
+        var rightDock = new ModelControls.ProportionalDock
         {
             Proportion = 0.25,
             Orientation = Orientation.Vertical,
             ActiveDockable = null,
             VisibleDockables = CreateList<IDockable>
             (
-                new ToolDock
+                new ModelControls.ToolDock
                 {
                     ActiveDockable = tool5,
                     VisibleDockables = CreateList<IDockable>(tool5, tool6),
                     Alignment = Alignment.Top,
                     GripMode = GripMode.Hidden
                 },
-                new ProportionalDockSplitter(),
-                new ToolDock
+                new ModelControls.ProportionalDockSplitter(),
+                new ModelControls.ToolDock
                 {
                     ActiveDockable = tool7,
                     VisibleDockables = CreateList<IDockable>(tool7, tool8),
@@ -99,15 +99,15 @@ public class DockFactory : Factory
             CanCreateDocument = true
         };
 
-        var mainLayout = new ProportionalDock
+        var mainLayout = new ModelControls.ProportionalDock
         {
             Orientation = Orientation.Horizontal,
             VisibleDockables = CreateList<IDockable>
             (
                 leftDock,
-                new ProportionalDockSplitter(),
+                new ModelControls.ProportionalDockSplitter(),
                 documentDock,
-                new ProportionalDockSplitter(),
+                new ModelControls.ProportionalDockSplitter(),
                 rightDock
             )
         };
@@ -177,7 +177,7 @@ public class DockFactory : Factory
 
         HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
         {
-            [nameof(IDockWindow)] = () => new HostWindow()
+            [nameof(IDockWindow)] = () => new AvaloniaControls.HostWindow()
         };
 
         base.InitLayout(layout);

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -24,6 +24,9 @@
             <DataTemplate DataType="dmc:IProportionalDockSplitter">
               <ProportionalStackPanelSplitter />
             </DataTemplate>
+            <DataTemplate DataType="dmc:IPixelDockSplitter">
+              <ProportionalStackPanelSplitter />
+            </DataTemplate>
             <DataTemplate DataType="dmc:IDocumentDock">
               <DocumentDockControl />
             </DataTemplate>
@@ -32,6 +35,9 @@
             </DataTemplate>
             <DataTemplate DataType="dmc:IProportionalDock">
               <ProportionalDockControl />
+            </DataTemplate>
+            <DataTemplate DataType="dmc:IPixelDock">
+              <PixelDockControl />
             </DataTemplate>
             <DataTemplate DataType="dmc:IDockDock">
               <DockDockControl />

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -25,7 +25,7 @@
               <ProportionalStackPanelSplitter />
             </DataTemplate>
             <DataTemplate DataType="dmc:IPixelDockSplitter">
-              <ProportionalStackPanelSplitter />
+              <PixelDockSplitter />
             </DataTemplate>
             <DataTemplate DataType="dmc:IDocumentDock">
               <DocumentDockControl />

--- a/src/Dock.Avalonia/Controls/PixelDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/PixelDockControl.axaml
@@ -1,0 +1,33 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:dmc="using:Dock.Model.Controls"
+                    x:DataType="dmc:IPixelDock"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <PixelDockControl Width="300" Height="300" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type PixelDockControl}" TargetType="PixelDockControl">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockableControl TrackingMode="Visible">
+          <ItemsControl ItemsSource="{Binding VisibleDockables}">
+            <ItemsControl.Styles>
+              <Style Selector="StackPanel[Orientation=Horizontal] > ContentPresenter">
+                <Setter Property="Width" Value="{Binding Proportion}" />
+              </Style>
+              <Style Selector="StackPanel[Orientation=Vertical] > ContentPresenter">
+                <Setter Property="Height" Value="{Binding Proportion}" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Orientation="{Binding Orientation}" DockProperties.IsDropArea="True" Background="Transparent" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+          </ItemsControl>
+        </DockableControl>
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/PixelDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/PixelDockControl.axaml.cs
@@ -1,0 +1,10 @@
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="PixelDockControl"/> xaml.
+/// </summary>
+public class PixelDockControl : TemplatedControl
+{
+}

--- a/src/Dock.Avalonia/Controls/PixelDockSplitter.axaml
+++ b/src/Dock.Avalonia/Controls/PixelDockSplitter.axaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <ControlTheme x:Key="{x:Type PixelDockSplitter}" TargetType="PixelDockSplitter">
+
+    <Setter Property="Background" Value="Transparent" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border Background="{TemplateBinding Background}"
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}" />
+      </ControlTemplate>
+    </Setter>
+
+  </ControlTheme>
+
+</ResourceDictionary>
+

--- a/src/Dock.Avalonia/Controls/PixelDockSplitter.axaml.cs
+++ b/src/Dock.Avalonia/Controls/PixelDockSplitter.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="PixelDockSplitter"/> xaml.
+/// </summary>
+public class PixelDockSplitter : ProportionalStackPanelSplitter
+{
+}
+

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -19,6 +19,8 @@
         <ResourceInclude Source="/Controls/DocumentContentControl.axaml" />
         <ResourceInclude Source="/Controls/DocumentDockControl.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockControl.axaml" />
+        <ResourceInclude Source="/Controls/PixelDockSplitter.axaml" />
+        <ResourceInclude Source="/Controls/PixelDockControl.axaml" />
         <ResourceInclude Source="/Controls/ProportionalDockControl.axaml" />
         <ResourceInclude Source="/Controls/RootDockControl.axaml" />
         <ResourceInclude Source="/Controls/ToolContentControl.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -19,6 +19,8 @@
         <ResourceInclude Source="/Controls/DocumentContentControl.axaml" />
         <ResourceInclude Source="/Controls/DocumentDockControl.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockControl.axaml" />
+        <ResourceInclude Source="/Controls/PixelDockSplitter.axaml" />
+        <ResourceInclude Source="/Controls/PixelDockControl.axaml" />
         <ResourceInclude Source="/Controls/ProportionalDockControl.axaml" />
         <ResourceInclude Source="/Controls/RootDockControl.axaml" />
         <ResourceInclude Source="/Controls/ToolContentControl.axaml" />

--- a/src/Dock.Model.Avalonia/Controls/PixelDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/PixelDock.cs
@@ -1,0 +1,39 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Dock that arranges children using pixel size.
+/// </summary>
+[DataContract(IsReference = true)]
+public class PixelDock : DockBase, IPixelDock
+{
+    /// <summary>
+    /// Defines the <see cref="Orientation"/> property.
+    /// </summary>
+    public static readonly DirectProperty<PixelDock, Orientation> OrientationProperty =
+        AvaloniaProperty.RegisterDirect<PixelDock, Orientation>(nameof(Orientation), o => o.Orientation, (o, v) => o.Orientation = v);
+
+    private Orientation _orientation;
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="PixelDock"/> class.
+    /// </summary>
+    public PixelDock()
+    {
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Orientation")]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetAndRaise(OrientationProperty, ref _orientation, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Controls/PixelDockSplitter.cs
+++ b/src/Dock.Model.Avalonia/Controls/PixelDockSplitter.cs
@@ -1,0 +1,20 @@
+using System.Runtime.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Pixel dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public class PixelDockSplitter : DockBase, IPixelDockSplitter
+{
+    /// <summary>
+    /// Initializes new instance of the <see cref="PixelDockSplitter"/> class.
+    /// </summary>
+    public PixelDockSplitter()
+    {
+    }
+}

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -18,6 +18,8 @@ namespace Dock.Model.Avalonia.Core;
 [JsonDerivedType(typeof(DocumentDock), typeDiscriminator: "DocumentDock")]
 [JsonDerivedType(typeof(ProportionalDock), typeDiscriminator: "ProportionalDock")]
 [JsonDerivedType(typeof(ProportionalDockSplitter), typeDiscriminator: "ProportionalDockSplitter")]
+[JsonDerivedType(typeof(PixelDock), typeDiscriminator: "PixelDock")]
+[JsonDerivedType(typeof(PixelDockSplitter), typeDiscriminator: "PixelDockSplitter")]
 [JsonDerivedType(typeof(RootDock), typeDiscriminator: "RootDock")]
 [JsonDerivedType(typeof(Tool), typeDiscriminator: "Tool")]
 [JsonDerivedType(typeof(ToolDock), typeDiscriminator: "ToolDock")]

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -68,6 +68,12 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IPixelDock CreatePixelDock() => new PixelDock();
+
+    /// <inheritdoc/>
+    public override IPixelDockSplitter CreatePixelDockSplitter() => new PixelDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Controls/PixelDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/PixelDock.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Pixel dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class PixelDock : DockBase, IPixelDock
+{
+    private Orientation _orientation;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/PixelDockSplitter.cs
+++ b/src/Dock.Model.Mvvm/Controls/PixelDockSplitter.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Pixel dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public class PixelDockSplitter : DockableBase, IPixelDockSplitter
+{
+}

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -61,6 +61,12 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IPixelDock CreatePixelDock() => new PixelDock();
+
+    /// <inheritdoc/>
+    public override IPixelDockSplitter CreatePixelDockSplitter() => new PixelDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Controls/PixelDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/PixelDock.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Core;
+using ReactiveUI;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Pixel dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class PixelDock : DockBase, IPixelDock
+{
+    private Orientation _orientation;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => this.RaiseAndSetIfChanged(ref _orientation, value);
+    }
+}

--- a/src/Dock.Model.ReactiveUI/Controls/PixelDockSplitter.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/PixelDockSplitter.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.ReactiveUI.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Pixel dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class PixelDockSplitter : DockableBase, IPixelDockSplitter
+{
+}

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -61,6 +61,12 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IPixelDock CreatePixelDock() => new PixelDock();
+
+    /// <inheritdoc/>
+    public override IPixelDockSplitter CreatePixelDockSplitter() => new PixelDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Controls/IPixelDock.cs
+++ b/src/Dock.Model/Controls/IPixelDock.cs
@@ -1,0 +1,14 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Dock defined by absolute pixel size.
+/// </summary>
+public interface IPixelDock : IDock
+{
+    /// <summary>
+    /// Gets or sets layout orientation.
+    /// </summary>
+    Orientation Orientation { get; set; }
+}

--- a/src/Dock.Model/Controls/IPixelDockSplitter.cs
+++ b/src/Dock.Model/Controls/IPixelDockSplitter.cs
@@ -1,0 +1,10 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Pixel dock splitter contract.
+/// </summary>
+public interface IPixelDockSplitter : IDockable
+{
+}

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -92,6 +92,18 @@ public partial interface IFactory
     IProportionalDockSplitter CreateProportionalDockSplitter();
 
     /// <summary>
+    /// Creates <see cref="IPixelDock"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IPixelDock"/> class.</returns>
+    IPixelDock CreatePixelDock();
+
+    /// <summary>
+    /// Creates <see cref="IPixelDockSplitter"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IPixelDockSplitter"/> class.</returns>
+    IPixelDockSplitter CreatePixelDockSplitter();
+
+    /// <summary>
     /// Creates <see cref="IToolDock"/>.
     /// </summary>
     /// <returns>The new instance of the <see cref="IToolDock"/> class.</returns>

--- a/src/Dock.Model/FactoryBase.Factory.cs
+++ b/src/Dock.Model/FactoryBase.Factory.cs
@@ -40,6 +40,12 @@ public abstract partial class FactoryBase
     public abstract IProportionalDockSplitter CreateProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public abstract IPixelDock CreatePixelDock();
+
+    /// <inheritdoc/>
+    public abstract IPixelDockSplitter CreatePixelDockSplitter();
+
+    /// <inheritdoc/>
     public abstract IToolDock CreateToolDock();
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- support PixelDock in factory interfaces and implementations
- add PixelDock templates for Dock control
- update Avalonia dock templates
- demonstrate PixelDock in MVVM sample
- run `dotnet build` and `dotnet test`

## Testing
- `dotnet build Dock.sln -c Release`
- `dotnet test Dock.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685c5d26db748321a4dc5a71d5a7c49e