### PR TITLE
Improve docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,39 @@
-# Dock Documentation
+# Dock documentation
 
-Welcome to the Dock documentation.  The files in this folder describe how to
-use the Dock layout system from simple getting started examples to
-advanced customization scenarios.  The documents assume you have an
-Avalonia application created with the .NET SDK.  If you are new to Dock
-start with the MVVM guide and work your way towards the deep dive. If you
-just want to see Dock running quickly, check out the Quick Start below.
+Welcome to the Dock documentation. These articles explain how to use the Dock
+layout system from basic setup through advanced customization. The examples
+assume an Avalonia application created with the .NET SDK. If you are new to
+Dock, start with the guides under *Getting started*.
 
-## Guides
+## Getting started
 
-- [Quick Start](quick-start.md) – Install the packages and run a simple layout.
-- [MVVM Guide](dock-mvvm.md) – Build layouts using MVVM view models.
-- [ReactiveUI Guide](dock-reactiveui.md) – ReactiveUI equivalent of the MVVM guide.
-- [XAML Guide](dock-xaml.md) – Declare layouts purely in XAML.
-- [Code-Only Guide](dock-code-only.md) – Build Dock layouts entirely in C#.
-- [Reference Guide](dock-reference.md) – Overview of the core APIs.
+- [Quick start](quick-start.md) – Set up a minimal Dock layout.
+- [MVVM guide](dock-mvvm.md) – Build layouts using MVVM view models.
+- [ReactiveUI guide](dock-reactiveui.md) – ReactiveUI equivalent of the MVVM guide.
+- [XAML guide](dock-xaml.md) – Declare layouts purely in XAML.
+- [Code-only guide](dock-code-only.md) – Build Dock layouts entirely in C#.
+
+## Concepts
+
+- [Active document](dock-active-document.md) – Retrieve the currently focused document.
+- [Events guide](dock-events.md) – Subscribe to dock and window events.
+- [API scenarios](dock-api-scenarios.md) – Common coding patterns.
+- [Serialization and persistence](dock-serialization.md) – Save and restore layouts.
+- [Architecture overview](dock-architecture.md) – High level design of the docking system.
+- [Deep dive](dock-deep-dive.md) – Internals of `DockControl`.
+- [Complex layout tutorials](dock-complex-layouts.md) – Multi-window and plug-in walkthroughs.
+- [Styling and theming](dock-styling.md) – Customize the appearance of Dock controls.
+- [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
+
+## Reference
+
+- [Reference guide](dock-reference.md) – Overview of the core APIs.
 - [Glossary](dock-glossary.md) – Definitions of common Dock terms.
-- [Advanced Guide](dock-advanced.md) – Custom factories and runtime features.
-- [Events Guide](dock-events.md) – Subscribing to dock and window events.
-- [Active Document](dock-active-document.md) – Retrieve the currently focused document.
-- [API Scenarios](dock-api-scenarios.md) – Common coding patterns.
-- [Serialization and Persistence](dock-serialization.md) – Saving and restoring layouts.
-- [Architecture Overview](dock-architecture.md) – High level design of the docking system.
-- [Deep Dive](dock-deep-dive.md) – Internals of `DockControl`.
-- [Complex Layout Tutorials](dock-complex-layouts.md) – Multi-window and plug-in walkthroughs.
-- [Styling and Theming](dock-styling.md) – Customize the appearance of Dock controls.
+
+## Troubleshooting
+
 - [FAQ](dock-faq.md) – Solutions to common issues.
 
-See the sample applications under the [samples](../samples/) directory for real-world usage.
-The [project README](../README.md) also lists the available guides and provides
-basic build instructions.
+See the sample applications under the [samples](../samples/) directory for
+real‑world usage. The [project README](../README.md) also lists the available
+guides and provides basic build instructions.


### PR DESCRIPTION
## Summary
- reorganize the docs README to use groups that mirror Microsoft style

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685cdb8d40dc83218760285004575a80