### PR TITLE
Update docs for DockProperties usage

### DIFF
--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -135,6 +135,11 @@ from `Dock.Settings`:
 </Window>
 ```
 
+The default templates bind these attached properties to the `CanDrag` and `CanDrop`
+properties of each dockable. In most cases you simply toggle the boolean
+properties on your view models and let the templates update `DockProperties` for
+you.
+
 Dockables may still be floated programmatically unless their `CanFloat` property
 is set to `false`.
 


### PR DESCRIPTION
## Summary
- explain that templates bind the DockProperties attached properties automatically

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68626d034eb8832189e06e3f09526537