### PR TITLE
Add dockable properties documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ guides under *Getting started*.
 
 - [Reference guide](dock-reference.md) – Overview of the core APIs.
 - [Glossary](dock-glossary.md) – Definitions of common Dock terms.
+- [Dockable property settings](dock-dockable-properties.md) – Configure per item behaviour.
 
 ## Troubleshooting
 

--- a/docs/dock-dockable-properties.md
+++ b/docs/dock-dockable-properties.md
@@ -1,0 +1,59 @@
+# Dockable Property Settings
+
+Dockable items such as documents, tools and docks implement the `IDockable` interface. This interface exposes a number of properties that control how each item behaves at runtime. Most of these flags can be set in XAML or on your view models.
+
+## Available properties
+
+| Property | Description |
+| --- | --- |
+| `Id` | Unique identifier used by the serializer and factory helpers. |
+| `Title` | Text shown on tabs and windows. |
+| `Context` | Optional data context associated with the dockable. |
+| `Owner` | The dock or window currently hosting the item. |
+| `OriginalOwner` | Where the dockable was first created. Used when restoring pinned tools. |
+| `Factory` | Factory instance used to create and manage the layout. |
+| `IsEmpty` | Indicates a placeholder dockable with no content. |
+| `IsCollapsable` | When `false`, the dock will remain even if it contains no children. |
+| `Proportion` | Size ratio used by `ProportionalDock`. |
+| `CanClose` | Whether the user can close the dockable via UI commands. |
+| `CanPin` | Allows pinning and unpinning of tools. |
+| `CanFloat` | Controls if the item may be detached into a floating window. |
+| `CanDrag` | Enables dragging the dockable to another position. |
+| `CanDrop` | Determines if other dockables can be dropped onto this one. |
+
+## Sample usage
+
+The properties can be configured directly on your view models when creating the layout:
+
+```csharp
+var errorsTool = new ToolViewModel
+{
+    Id = "Errors",
+    Title = "Errors",
+    CanDrag = false,
+    CanFloat = false,
+    CanClose = false
+};
+```
+
+In XAML you set them as attributes:
+
+```xaml
+<Tool x:Name="SolutionExplorer"
+      Id="SolutionExplorer"
+      Title="Solution Explorer"
+      CanPin="False"
+      CanFloat="True" />
+```
+
+Global drag and drop behaviour can be toggled using the attached properties from `Dock.Settings`:
+
+```xml
+<Window xmlns:dockSettings="clr-namespace:Dock.Settings;assembly=Dock.Settings"
+        dockSettings:DockProperties.IsDragEnabled="False"
+        dockSettings:DockProperties.IsDropEnabled="False">
+    <DockControl />
+</Window>
+```
+
+For reference, the FAQ shows how these properties interact with the default templates.


### PR DESCRIPTION
## Summary
- document per-dockable flags like `CanFloat` and `CanDrag`
- link new guide from docs index

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68627174d2088321a2f67947f0a61edb