### PR TITLE
Fix drag preview float status

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -359,7 +359,7 @@ internal class DockControlState : IDockControlState
                                 _state.TargetPoint = default;
                                 _state.TargetDockControl = null;
                             }
-                            preview = "None";
+                            preview = "Float";
                         }
                     }
                     else
@@ -368,7 +368,7 @@ internal class DockControlState : IDockControlState
                         _state.DropControl = null;
                         _state.TargetPoint = default;
                         _state.TargetDockControl = null;
-                        preview = "None";
+                        preview = "Float";
                     }
 
                     DragPreviewHelper.Move(screenPoint, preview);


### PR DESCRIPTION
## Summary
- show `Float` preview when dragging over empty area or a disabled drop target

## Testing
- `dotnet test` *(fails: No test is available)*

------
https://chatgpt.com/codex/tasks/task_e_6863c20a76a08321a77002f5a72df866