### PR TITLE
Convert DragPreviewHelper to instance class

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -51,6 +51,7 @@ internal class DockControlState : IDockControlState
 {
     private readonly AdornerHelper _adornerHelper = new();
     private readonly DockDragState _state = new();
+    private readonly DragPreviewHelper _dragPreviewHelper = new();
 
     /// <inheritdoc/>
     public IDockManager DockManager { get; set; }
@@ -243,7 +244,7 @@ internal class DockControlState : IDockControlState
                     }
                 }
 
-                DragPreviewHelper.Hide();
+                _dragPreviewHelper.Hide();
 
                 Leave();
                 _state.End();
@@ -267,7 +268,7 @@ internal class DockControlState : IDockControlState
                         {
                             DockHelpers.ShowWindows(targetDockable);
                             var sp = inputActiveDockControl.PointToScreen(point);
-                            DragPreviewHelper.Show(targetDockable.Title ?? string.Empty, sp);
+                            _dragPreviewHelper.Show(targetDockable.Title ?? string.Empty, sp);
                         }
                         _state.DoDragDrop = true;
                     }
@@ -371,7 +372,7 @@ internal class DockControlState : IDockControlState
                         preview = "None";
                     }
 
-                    DragPreviewHelper.Move(screenPoint, preview);
+                    _dragPreviewHelper.Move(screenPoint, preview);
                 }
                 break;
             }
@@ -385,7 +386,7 @@ internal class DockControlState : IDockControlState
             }
             case EventType.CaptureLost:
             {
-                DragPreviewHelper.Hide();
+                _dragPreviewHelper.Hide();
                 Leave();
                 _state.End();
                 activeDockControl.IsDraggingDock = false;

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -4,12 +4,12 @@ using Dock.Avalonia.Controls;
 
 namespace Dock.Avalonia.Internal;
 
-internal static class DragPreviewHelper
+internal class DragPreviewHelper
 {
-    private static Window? _window;
-    private static DragPreviewControl? _control;
+    private Window? _window;
+    private DragPreviewControl? _control;
 
-    public static void Show(string title, PixelPoint position)
+    public void Show(string title, PixelPoint position)
     {
         Hide();
 
@@ -35,7 +35,7 @@ internal static class DragPreviewHelper
         _window.Show();
     }
 
-    public static void Move(PixelPoint position, string status)
+    public void Move(PixelPoint position, string status)
     {
         if (_window is { } && _control is { })
         {
@@ -44,7 +44,7 @@ internal static class DragPreviewHelper
         }
     }
 
-    public static void Hide()
+    public void Hide()
     {
         if (_window is { })
         {


### PR DESCRIPTION
## Summary
- refactor DragPreviewHelper to be an instance class
- inject DragPreviewHelper into DockControlState and update calls

## Testing
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release`
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj --no-build -v minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6863c26380f483219efde088b428a961