### PR TITLE
Improve drag preview UI

### DIFF
--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
@@ -6,13 +6,36 @@
       <ControlTemplate>
         <Border Background="{DynamicResource DockApplicationAccentBrushLow}"
                 Padding="4" CornerRadius="4">
-          <StackPanel>
-            <TextBlock Text="{TemplateBinding Title}"/>
-            <TextBlock Text="{TemplateBinding Status}" FontSize="10"/>
+          <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+            <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" />
+            <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
+              <Path x:Name="PART_StatusIcon" />
+              <TextBlock Text="{TemplateBinding Status}" FontSize="10" VerticalAlignment="Center"/>
+            </StackPanel>
           </StackPanel>
         </Border>
       </ControlTemplate>
     </Setter>
+
+    <Style Selector="^/template/ Path#PART_StatusIcon">
+      <Setter Property="Width" Value="10" />
+      <Setter Property="Height" Value="10" />
+      <Setter Property="Stretch" Value="Uniform" />
+      <Setter Property="Fill" Value="{DynamicResource DockThemeForegroundBrush}" />
+    </Style>
+
+    <Style Selector="^[Status=Dock]/template/ Path#PART_StatusIcon">
+      <Setter Property="Data"
+              Value="M8.41687 7.57953V2.41851C8.41687 2.18743 8.22932 1.99988 7.99823 1.99988C7.76715 1.99988 7.5796 2.18743 7.5796 2.41851V7.57953H2.41863C2.18755 7.57953 2 7.76708 2 7.99816C2 8.22925 2.18755 8.41679 2.41863 8.41679H7.5796V13.5812C7.5796 13.8123 7.76715 13.9999 7.99823 13.9999C8.22932 13.9999 8.41687 13.8123 8.41687 13.5812V8.41679L13.5799 8.41851C13.811 8.41851 13.9985 8.23096 13.9985 7.99988C13.9985 7.76879 13.811 7.58125 13.5799 7.58125L8.41687 7.57953Z" />
+    </Style>
+
+    <Style Selector="^[Status=Float]/template/ Path#PART_StatusIcon">
+      <Setter Property="Data" Value="M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3 0,3z" />
+    </Style>
+
+    <Style Selector="^[Status=None]/template/ Path#PART_StatusIcon">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
   </ControlTheme>
 </ResourceDictionary>
 


### PR DESCRIPTION
## Summary
- modernize the drag preview window style
  - move status onto the same row as the title
  - show an icon for Dock and Float states

## Testing
- `./build.sh Test` *(fails: Build failed, tests not run)*

------
https://chatgpt.com/codex/tasks/task_e_6863c471fea0832191d7b4c7316a88ad