### PR TITLE
Fix drag preview on tab strips

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -340,11 +340,9 @@ internal class DockControlState : IDockControlState
                                 Enter(targetPoint, dragAction, targetDockControl);
                             }
 
-                            var operation = DockOperation.Window;
-                            if (_adornerHelper.Adorner is DockTarget target)
-                            {
-                                operation = target.GetDockOperation(targetPoint, targetDockControl, dragAction, Validate);
-                            }
+                            var operation = _adornerHelper.Adorner is DockTarget target
+                                ? target.GetDockOperation(targetPoint, targetDockControl, dragAction, Validate)
+                                : DockOperation.Fill;
 
                             var valid = Validate(targetPoint, operation, dragAction, targetDockControl);
                             preview = valid


### PR DESCRIPTION
## Summary
- fix drag preview status when dragging over tool/document tab strips

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6863c6f355208321b43a814c377e6926