### PR TITLE
Fix drag preview on multi screens

### DIFF
--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -28,9 +28,11 @@ internal class DragPreviewHelper
             Background = null,
             SizeToContent = SizeToContent.WidthAndHeight,
             Content = _control,
-            Topmost = true,
-            Position = position
+            Topmost = true
         };
+
+        var screen = _window.Screens.ScreenFromPoint(position);
+        _window.Position = position;
 
         _window.Show();
     }
@@ -43,6 +45,7 @@ internal class DragPreviewHelper
         }
 
         _control.Status = status;
+        var screen = _window.Screens.ScreenFromPoint(position);
         _window.Position = position;
     }
 

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -32,7 +32,15 @@ internal class DragPreviewHelper
         };
 
         var screen = _window.Screens.ScreenFromPoint(position);
-        _window.Position = position;
+        if (screen is { })
+        {
+            var offset = position - screen.Bounds.Position;
+            _window.Position = offset;
+        }
+        else
+        {
+            _window.Position = position;
+        }
 
         _window.Show();
     }
@@ -46,7 +54,15 @@ internal class DragPreviewHelper
 
         _control.Status = status;
         var screen = _window.Screens.ScreenFromPoint(position);
-        _window.Position = position;
+        if (screen is { })
+        {
+            var offset = position - screen.Bounds.Position;
+            _window.Position = offset;
+        }
+        else
+        {
+            _window.Position = position;
+        }
     }
 
     public void Hide()


### PR DESCRIPTION
## Summary
- ensure drag preview uses screen coordinate space when moving across monitors

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6863c7be30dc8321b5640e7303a7f636