### PR TITLE
Add themable drag preview window

### DIFF
--- a/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml
@@ -1,0 +1,19 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <ControlTheme x:Key="{x:Type DragPreviewWindow}" TargetType="DragPreviewWindow">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+    <Setter Property="CanResize" Value="False" />
+    <Setter Property="ShowActivated" Value="False" />
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="TransparencyLevelHint" Value="Transparent" />
+    <Setter Property="SizeToContent" Value="WidthAndHeight" />
+    <Setter Property="Topmost" Value="True" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <ContentPresenter />
+      </ControlTemplate>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml
@@ -1,7 +1,8 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     x:CompileBindings="True">
-  <ControlTheme x:Key="{x:Type DragPreviewWindow}" TargetType="DragPreviewWindow">
+  <ControlTheme x:Key="{x:Type DragPreviewWindow}" TargetType="DragPreviewWindow"
+                BasedOn="{StaticResource {x:Type Window}}">
     <Setter Property="SystemDecorations" Value="None" />
     <Setter Property="ShowInTaskbar" Value="False" />
     <Setter Property="CanResize" Value="False" />
@@ -10,10 +11,5 @@
     <Setter Property="TransparencyLevelHint" Value="Transparent" />
     <Setter Property="SizeToContent" Value="WidthAndHeight" />
     <Setter Property="Topmost" Value="True" />
-    <Setter Property="Template">
-      <ControlTemplate>
-        <ContentPresenter />
-      </ControlTemplate>
-    </Setter>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DragPreviewWindow.axaml.cs
@@ -1,0 +1,14 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Window used to display drag preview content.
+/// </summary>
+public class DragPreviewWindow : Window
+{
+    /// <inheritdoc/>
+    protected override Type StyleKeyOverride => typeof(DragPreviewWindow);
+}

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -6,7 +6,7 @@ namespace Dock.Avalonia.Internal;
 
 internal class DragPreviewHelper
 {
-    private Window? _window;
+    private DragPreviewWindow? _window;
     private DragPreviewControl? _control;
 
     public void Show(string title, PixelPoint position)
@@ -19,17 +19,9 @@ internal class DragPreviewHelper
             Status = string.Empty
         };
 
-        _window = new Window
+        _window = new DragPreviewWindow
         {
-            SystemDecorations = SystemDecorations.None,
-            ShowInTaskbar = false,
-            CanResize = false,
-            ShowActivated = false,
-            Background = null,
-            TransparencyLevelHint = [WindowTransparencyLevel.Transparent],
-            SizeToContent = SizeToContent.WidthAndHeight,
             Content = _control,
-            Topmost = true,
             Position = position
         };
 

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -27,6 +27,7 @@
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
+        <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Themes/Accents/Fluent.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -27,6 +27,7 @@
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
+        <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Themes/Accents/Simple.axaml" />
       </ResourceDictionary.MergedDictionaries>
     </ResourceDictionary>


### PR DESCRIPTION
## Summary
- implement `DragPreviewWindow` custom control
- use `DragPreviewWindow` in `DragPreviewHelper`
- expose window style resources in Dock themes

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6864367e79e8832191b9d755bcd15bec