### PR TITLE
Add composition preview capture for drag operations

### DIFF
--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
@@ -7,7 +7,11 @@
         <Border Background="{DynamicResource DockApplicationAccentBrushLow}"
                 Padding="4" CornerRadius="4">
           <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
-            <Image Source="{TemplateBinding Preview}" Height="32" Stretch="Uniform" />
+            <Border Height="{TemplateBinding PreviewHeight}" Width="Auto">
+              <Border.Background>
+                <VisualBrush Visual="{TemplateBinding PreviewVisual}" Stretch="Uniform"/>
+              </Border.Background>
+            </Border>
             <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" />
             <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
               <Path x:Name="PART_StatusIcon" />

--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
@@ -7,6 +7,7 @@
         <Border Background="{DynamicResource DockApplicationAccentBrushLow}"
                 Padding="4" CornerRadius="4">
           <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+            <Image Source="{TemplateBinding Preview}" Height="32" Stretch="Uniform" />
             <TextBlock Text="{TemplateBinding Title}" VerticalAlignment="Center" />
             <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
               <Path x:Name="PART_StatusIcon" />

--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml.cs
@@ -2,7 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Media.Imaging;
+using Avalonia.Media;
 
 namespace Dock.Avalonia.Controls;
 
@@ -24,10 +24,16 @@ public class DragPreviewControl : TemplatedControl
         AvaloniaProperty.Register<DragPreviewControl, string>(nameof(Status));
 
     /// <summary>
-    /// Defines <see cref="Preview"/> property.
+    /// Defines <see cref="PreviewVisual"/> property.
     /// </summary>
-    public static readonly StyledProperty<IBitmap?> PreviewProperty =
-        AvaloniaProperty.Register<DragPreviewControl, IBitmap?>(nameof(Preview));
+    public static readonly StyledProperty<Visual?> PreviewVisualProperty =
+        AvaloniaProperty.Register<DragPreviewControl, Visual?>(nameof(PreviewVisual));
+
+    /// <summary>
+    /// Defines <see cref="PreviewHeight"/> property.
+    /// </summary>
+    public static readonly StyledProperty<double> PreviewHeightProperty =
+        AvaloniaProperty.Register<DragPreviewControl, double>(nameof(PreviewHeight), 32d);
 
     /// <summary>
     /// Gets or sets the preview title.
@@ -48,12 +54,21 @@ public class DragPreviewControl : TemplatedControl
     }
 
     /// <summary>
-    /// Gets or sets the visual preview image.
+    /// Gets or sets the visual used for live preview.
     /// </summary>
-    public IBitmap? Preview
+    public Visual? PreviewVisual
     {
-        get => GetValue(PreviewProperty);
-        set => SetValue(PreviewProperty, value);
+        get => GetValue(PreviewVisualProperty);
+        set => SetValue(PreviewVisualProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the height of the preview.
+    /// </summary>
+    public double PreviewHeight
+    {
+        get => GetValue(PreviewHeightProperty);
+        set => SetValue(PreviewHeightProperty, value);
     }
 }
 

--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Media.Imaging;
 
 namespace Dock.Avalonia.Controls;
 
@@ -23,6 +24,12 @@ public class DragPreviewControl : TemplatedControl
         AvaloniaProperty.Register<DragPreviewControl, string>(nameof(Status));
 
     /// <summary>
+    /// Defines <see cref="Preview"/> property.
+    /// </summary>
+    public static readonly StyledProperty<IBitmap?> PreviewProperty =
+        AvaloniaProperty.Register<DragPreviewControl, IBitmap?>(nameof(Preview));
+
+    /// <summary>
     /// Gets or sets the preview title.
     /// </summary>
     public string Title
@@ -38,6 +45,15 @@ public class DragPreviewControl : TemplatedControl
     {
         get => GetValue(StatusProperty);
         set => SetValue(StatusProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the visual preview image.
+    /// </summary>
+    public IBitmap? Preview
+    {
+        get => GetValue(PreviewProperty);
+        set => SetValue(PreviewProperty, value);
     }
 }
 

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -268,7 +268,10 @@ internal class DockControlState : IDockControlState
                         {
                             DockHelpers.ShowWindows(targetDockable);
                             var sp = inputActiveDockControl.PointToScreen(point);
-                            _dragPreviewHelper.Show(targetDockable.Title ?? string.Empty, sp);
+                            if (_state.DragControl is { } dragControl)
+                            {
+                                _dragPreviewHelper.Show(dragControl, targetDockable.Title ?? string.Empty, sp);
+                            }
                         }
                         _state.DoDragDrop = true;
                     }

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -1,7 +1,6 @@
 using Avalonia;
 using Avalonia.Controls;
 using Dock.Avalonia.Controls;
-using Avalonia.Media.Imaging;
 
 namespace Dock.Avalonia.Internal;
 
@@ -10,38 +9,17 @@ internal class DragPreviewHelper
     private Window? _window;
     private DragPreviewControl? _control;
 
-    private static IBitmap? Capture(Visual visual)
-    {
-        if (visual.VisualRoot is null)
-        {
-            return null;
-        }
-
-        var width = (int)visual.Bounds.Width;
-        var height = (int)visual.Bounds.Height;
-
-        if (width <= 0 || height <= 0)
-        {
-            return null;
-        }
-
-        var size = new PixelSize(width, height);
-        var bitmap = new RenderTargetBitmap(size);
-        bitmap.Render(visual);
-        return bitmap;
-    }
 
     public void Show(Visual preview, string title, PixelPoint position)
     {
         Hide();
 
-        var bitmap = Capture(preview);
-
         _control = new DragPreviewControl
         {
             Title = title,
             Status = string.Empty,
-            Preview = bitmap
+            PreviewVisual = preview,
+            PreviewHeight = preview.Bounds.Height
         };
 
         _window = new Window

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Dock.Avalonia.Controls;
+using Avalonia.Media.Imaging;
 
 namespace Dock.Avalonia.Internal;
 
@@ -9,14 +10,38 @@ internal class DragPreviewHelper
     private Window? _window;
     private DragPreviewControl? _control;
 
-    public void Show(string title, PixelPoint position)
+    private static IBitmap? Capture(Visual visual)
+    {
+        if (visual.VisualRoot is null)
+        {
+            return null;
+        }
+
+        var width = (int)visual.Bounds.Width;
+        var height = (int)visual.Bounds.Height;
+
+        if (width <= 0 || height <= 0)
+        {
+            return null;
+        }
+
+        var size = new PixelSize(width, height);
+        var bitmap = new RenderTargetBitmap(size);
+        bitmap.Render(visual);
+        return bitmap;
+    }
+
+    public void Show(Visual preview, string title, PixelPoint position)
     {
         Hide();
+
+        var bitmap = Capture(preview);
 
         _control = new DragPreviewControl
         {
             Title = title,
-            Status = string.Empty
+            Status = string.Empty,
+            Preview = bitmap
         };
 
         _window = new Window


### PR DESCRIPTION
## Summary
- extend `DragPreviewControl` with `Preview` property
- display preview image in `DragPreviewControl` template
- add bitmap capture in `DragPreviewHelper` using `RenderTargetBitmap`
- capture dragged visual when showing preview in `DockControlState`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686436c6b4748321922f0a2003bc44ff