### PR TITLE
Add clipping for ToolControl border

### DIFF
--- a/src/Dock.Avalonia/Controls/ToolControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolControl.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:dmc="using:Dock.Model.Controls"
                     xmlns:core="using:Dock.Model.Core"
+                    xmlns:converters="using:Dock.Avalonia.Converters"
                     x:DataType="dmc:IToolDock"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -30,6 +31,13 @@
                         DockPanel.Dock="Bottom"
                         DockProperties.IsDropArea="True" />
           <Border x:Name="PART_Border">
+            <Border.Clip>
+              <MultiBinding Converter="{x:Static converters:ToolControlClipConverter.Instance}">
+                <Binding ElementName="PART_Border" />
+                <Binding ElementName="PART_TabStrip" />
+                <Binding ElementName="PART_TabStrip" Path="SelectedItem" />
+              </MultiBinding>
+            </Border.Clip>
             <DockableControl DataContext="{Binding ActiveDockable}"
                              TrackingMode="Visible">
               <ContentControl x:Name="PART_ContentPresenter"

--- a/src/Dock.Avalonia/Converters/ToolControlClipConverter.cs
+++ b/src/Dock.Avalonia/Converters/ToolControlClipConverter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+
+namespace Dock.Avalonia.Converters;
+
+/// <summary>
+/// Converter that clips <see cref="ToolControl"/> border to exclude selected tab item area.
+/// </summary>
+public sealed class ToolControlClipConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Gets <see cref="ToolControlClipConverter"/> instance.
+    /// </summary>
+    public static readonly ToolControlClipConverter Instance = new();
+
+    /// <inheritdoc />
+    public object Convert(IList<object?>? values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values is null || values.Count != 3 ||
+            values[0] is not IControl border ||
+            values[1] is not ToolTabStrip tabStrip)
+        {
+            return new BindingNotification(
+                new ArgumentException("Expecting border, tab strip and selected item."),
+                BindingErrorType.Error);
+        }
+
+        var bounds = border.Bounds;
+        var selectedItem = values[2];
+        IControl? container = null;
+
+        if (selectedItem is IControl ctrl)
+        {
+            container = ctrl;
+        }
+        else if (selectedItem is not null)
+        {
+            container = tabStrip.ItemContainerGenerator.ContainerFromItem(selectedItem) as IControl;
+        }
+
+        if (container is null)
+        {
+            return new RectangleGeometry { Rect = new Rect(bounds.Size) };
+        }
+
+        var topLeft = container.TranslatePoint(new Point(), border) ?? new Point();
+        var gap = new Rect(topLeft, container.Bounds.Size);
+        gap = bounds.Intersect(gap);
+
+        return new CombinedGeometry(
+            GeometryCombineMode.Exclude,
+            new RectangleGeometry { Rect = new Rect(bounds.Size) },
+            new RectangleGeometry { Rect = new Rect(gap.Position - bounds.Position, gap.Size) });
+    }
+
+    /// <inheritdoc />
+    public IMultiValueConverter ProvideValue(IServiceProvider serviceProvider) => Instance;
+}


### PR DESCRIPTION
## Summary
- clip ToolControl border under selected tab item using ToolControlClipConverter
- wire up converter in ToolControl template

## Testing
- `dotnet test --no-build` *(fails: The argument Dock.Avalonia.UnitTests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68643771d2408321ab70363d2a55f332