### PR TITLE
Add CanResize option for proportional splitters

### DIFF
--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -12,7 +12,7 @@ This reference summarizes the most commonly used classes in Dock. It is based on
 | `IProportionalDock` | A dock that lays out its children horizontally or vertically using a `Proportion` value. |
 | `IToolDock` / `IDocumentDock` | Specialized docks used for tools and documents. |
 | `ITool` | Represents a tool pane. Tools can specify `MinWidth`, `MaxWidth`, `MinHeight` and `MaxHeight` to control their size. |
-| `IProportionalDockSplitter` | Thin splitter placed between proportional docks. |
+| `IProportionalDockSplitter` | Thin splitter placed between proportional docks. Exposes `CanResize` to enable or disable dragging. |
 | `IDockWindow` / `IHostWindow` | Interfaces representing floating windows created when dockables are detached. |
 
 ## Factory API

--- a/samples/DockMvvmSample/ViewModels/DockFactory.cs
+++ b/samples/DockMvvmSample/ViewModels/DockFactory.cs
@@ -55,7 +55,7 @@ public class DockFactory : Factory
                     Alignment = Alignment.Left,
                     // CanDrop = false
                 },
-                new ProportionalDockSplitter(),
+                new ProportionalDockSplitter { CanResize = true },
                 new ToolDock
                 {
                     ActiveDockable = tool3,

--- a/samples/DockReactiveUISample/ViewModels/DockFactory.cs
+++ b/samples/DockReactiveUISample/ViewModels/DockFactory.cs
@@ -55,7 +55,7 @@ public class DockFactory : Factory
                     Alignment = Alignment.Left,
                     // CanDrop = false
                 },
-                new ProportionalDockSplitter(),
+                new ProportionalDockSplitter { CanResize = true },
                 new ToolDock
                 {
                     ActiveDockable = tool3,

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -25,7 +25,7 @@
               <ToolContentControl />
             </DataTemplate>
             <DataTemplate DataType="dmc:IProportionalDockSplitter">
-              <ProportionalStackPanelSplitter />
+              <ProportionalStackPanelSplitter IsResizingEnabled="{Binding CanResize}" />
             </DataTemplate>
             <DataTemplate DataType="dmc:IDocumentDock">
               <DocumentDockControl />

--- a/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml.cs
+++ b/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml.cs
@@ -23,6 +23,12 @@ public class ProportionalStackPanelSplitter : Thumb
         AvaloniaProperty.Register<ProportionalStackPanelSplitter, double>(nameof(Thickness), 4.0);
 
     /// <summary>
+    /// Defines the <see cref="IsResizingEnabled"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> IsResizingEnabledProperty =
+        AvaloniaProperty.Register<ProportionalStackPanelSplitter, bool>(nameof(IsResizingEnabled), true);
+
+    /// <summary>
     /// Defines the MinimumProportionSize attached property.
     /// </summary>
     public static readonly AttachedProperty<double> MinimumProportionSizeProperty =
@@ -58,6 +64,15 @@ public class ProportionalStackPanelSplitter : Thumb
         set => SetValue(ThicknessProperty, value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether resizing is enabled.
+    /// </summary>
+    public bool IsResizingEnabled
+    {
+        get => GetValue(IsResizingEnabledProperty);
+        set => SetValue(IsResizingEnabledProperty, value);
+    }
+
     private Point _startPoint;
     private bool _isMoving;
 
@@ -91,8 +106,8 @@ public class ProportionalStackPanelSplitter : Thumb
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
-        
-        if (GetPanel() is { } panel)
+
+        if (IsResizingEnabled && GetPanel() is { } panel)
         {
             var point = e.GetPosition(panel);
             _startPoint = point;
@@ -113,8 +128,8 @@ public class ProportionalStackPanelSplitter : Thumb
     {
         base.OnPointerMoved(e);
 
-        if (_isMoving)
-        {  
+        if (_isMoving && IsResizingEnabled)
+        {
             if (GetPanel() is { } panel)
             {
                 var point = e.GetPosition(panel);

--- a/src/Dock.Model.Avalonia/Controls/ProportionalDockSplitter.cs
+++ b/src/Dock.Model.Avalonia/Controls/ProportionalDockSplitter.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 using Avalonia;
 using Dock.Model.Avalonia.Core;
 using Dock.Model.Controls;
+using System.Text.Json.Serialization;
 
 namespace Dock.Model.Avalonia.Controls;
 
@@ -15,9 +16,25 @@ namespace Dock.Model.Avalonia.Controls;
 public class ProportionalDockSplitter : DockBase, IProportionalDockSplitter
 {
     /// <summary>
+    /// Defines the <see cref="CanResize"/> property.
+    /// </summary>
+    public static readonly DirectProperty<ProportionalDockSplitter, bool> CanResizeProperty =
+        AvaloniaProperty.RegisterDirect<ProportionalDockSplitter, bool>(nameof(CanResize), o => o.CanResize, (o, v) => o.CanResize = v, true);
+
+    private bool _canResize = true;
+    /// <summary>
     /// Initializes new instance of the <see cref="ProportionalDockSplitter"/> class.
     /// </summary>
     public ProportionalDockSplitter()
     {
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("CanResize")]
+    public bool CanResize
+    {
+        get => _canResize;
+        set => SetAndRaise(CanResizeProperty, ref _canResize, value);
     }
 }

--- a/src/Dock.Model.Mvvm/Controls/ProportionalDockSplitter.cs
+++ b/src/Dock.Model.Mvvm/Controls/ProportionalDockSplitter.cs
@@ -12,4 +12,13 @@ namespace Dock.Model.Mvvm.Controls;
 [DataContract(IsReference = true)]
 public class ProportionalDockSplitter : DockableBase, IProportionalDockSplitter
 {
+    private bool _canResize = true;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool CanResize
+    {
+        get => _canResize;
+        set => SetProperty(ref _canResize, value);
+    }
 }

--- a/src/Dock.Model.ReactiveUI/Controls/ProportionalDockSplitter.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ProportionalDockSplitter.cs
@@ -3,6 +3,7 @@
 using System.Runtime.Serialization;
 using Dock.Model.Controls;
 using Dock.Model.ReactiveUI.Core;
+using ReactiveUI;
 
 namespace Dock.Model.ReactiveUI.Controls;
 
@@ -12,4 +13,13 @@ namespace Dock.Model.ReactiveUI.Controls;
 [DataContract(IsReference = true)]
 public partial class ProportionalDockSplitter : DockableBase, IProportionalDockSplitter
 {
+    private bool _canResize = true;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool CanResize
+    {
+        get => _canResize;
+        set => this.RaiseAndSetIfChanged(ref _canResize, value);
+    }
 }

--- a/src/Dock.Model.ReactiveUI/Controls/ProportionalDockSplitter.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/ProportionalDockSplitter.cs
@@ -3,7 +3,6 @@
 using System.Runtime.Serialization;
 using Dock.Model.Controls;
 using Dock.Model.ReactiveUI.Core;
-using ReactiveUI;
 
 namespace Dock.Model.ReactiveUI.Controls;
 
@@ -13,13 +12,15 @@ namespace Dock.Model.ReactiveUI.Controls;
 [DataContract(IsReference = true)]
 public partial class ProportionalDockSplitter : DockableBase, IProportionalDockSplitter
 {
-    private bool _canResize = true;
-
+    /// <summary>
+    /// Initializes new instance of the <see cref="ProportionalDockSplitter"/> class.
+    /// </summary>
+    public ProportionalDockSplitter()
+    {
+        _canResize = true;
+    }
+    
     /// <inheritdoc/>
     [DataMember(IsRequired = false, EmitDefaultValue = true)]
-    public bool CanResize
-    {
-        get => _canResize;
-        set => this.RaiseAndSetIfChanged(ref _canResize, value);
-    }
+    public partial bool CanResize { get; set; }
 }

--- a/src/Dock.Model/Controls/IProportionalDockSplitter.cs
+++ b/src/Dock.Model/Controls/IProportionalDockSplitter.cs
@@ -9,4 +9,8 @@ namespace Dock.Model.Controls;
 /// </summary>
 public interface IProportionalDockSplitter : IDockable
 {
+    /// <summary>
+    /// Gets or sets whether the splitter allows resizing.
+    /// </summary>
+    bool CanResize { get; set; }
 }

--- a/tests/Dock.Model.Mvvm.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.Mvvm.UnitTests/FactoryTests.cs
@@ -60,6 +60,7 @@ public class FactoryTests
         var actual = factory.CreateProportionalDockSplitter();
         Assert.NotNull(actual);
         Assert.IsType<ProportionalDockSplitter>(actual);
+        Assert.True(actual.CanResize);
     }
 
     [Fact]

--- a/tests/Dock.Model.ReactiveUI.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/FactoryTests.cs
@@ -60,6 +60,7 @@ public class FactoryTests
         var actual = factory.CreateProportionalDockSplitter();
         Assert.NotNull(actual);
         Assert.IsType<ProportionalDockSplitter>(actual);
+        Assert.True(actual.CanResize);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add `CanResize` property to `IProportionalDockSplitter` and implementations
- expose `IsResizingEnabled` on `ProportionalStackPanelSplitter`
- bind dock splitter resize property in `DockControl` template
- document new splitter capability
- test default `CanResize` value in factories

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686438a272a88321b5e90e465e13d459