### PR TITLE
Enable intra-tab reordering before tear-out

### DIFF
--- a/src/Dock.Avalonia/Internal/DockHelpers.cs
+++ b/src/Dock.Avalonia/Internal/DockHelpers.cs
@@ -54,6 +54,20 @@ internal static class DockHelpers
         return null;
     }
 
+    public static T? FindAncestor<T>(Visual? visual) where T : Visual
+    {
+        var current = visual?.VisualParent;
+        while (current is { })
+        {
+            if (current is T result)
+            {
+                return result;
+            }
+            current = current.VisualParent;
+        }
+        return null;
+    }
+
     private static void Print(Exception ex)
     {
         Debug.WriteLine(ex.Message);


### PR DESCRIPTION
## Summary
- add helper to walk up the visual tree
- store tab strip in drag state
- allow moving tabs within the strip while pointer stays inside

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68643805be248321bbfe1184255172a5