### PR TITLE
Add adapter and enum docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ guides under *Getting started*.
 - [Glossary](dock-glossary.md) – Definitions of common Dock terms.
 - [Dockable property settings](dock-dockable-properties.md) – Configure per item behaviour.
 - [Markup extensions](dock-markup-extensions.md) – Load and reference XAML fragments.
+- [Adapter classes](dock-adapters.md) – Host, navigation and tracking helpers.
+- [Enumerations](dock-enums.md) – Values used by Dock APIs.
 
 ## Troubleshooting
 

--- a/docs/dock-adapters.md
+++ b/docs/dock-adapters.md
@@ -1,0 +1,42 @@
+# Adapter Classes
+
+Dock exposes a small set of helper classes that adapt the core interfaces to different host environments or provide additional runtime services. These adapters are mainly used by the sample applications but are part of the public API and can be reused in your own projects.
+
+## HostAdapter
+
+`HostAdapter` implements `IHostAdapter` and bridges a dock window (`IDockWindow`) with a platform specific host window. It is responsible for presenting the floating window, updating its size and location and closing it when requested.
+
+Typical usage looks like the following:
+
+```csharp
+var hostAdapter = new HostAdapter(dockWindow);
+window.Host = hostAdapter;
+hostAdapter.Present(isDialog: false);
+```
+
+The adapter fetches the window instance from `Factory.GetHostWindow` if it has not already been assigned. Calling `Save` stores the last known position and dimensions so that they can be restored later.
+
+## NavigateAdapter
+
+`NavigateAdapter` implements `INavigateAdapter` and provides history based navigation for docks. It maintains two stacks for back and forward navigation and exposes methods such as `GoBack`, `GoForward` and `Navigate`.
+
+Create an instance for a given `IDock` and use it to issue navigation commands:
+
+```csharp
+var adapter = new NavigateAdapter(rootDock);
+adapter.Navigate(document, bSnapshot: true);
+```
+
+The adapter cooperates with the factory to activate dockables and can also show or close floating windows via `ShowWindows` and `ExitWindows`.
+
+## TrackingAdapter
+
+`TrackingAdapter` stores bounds and pointer positions used when tools are pinned, visible or displayed as tabs. The docking logic reads these values when calculating drop targets or restoring the layout after a drag operation.
+
+A new adapter contains `NaN` values for all coordinates until you call the various `Set*` methods. Most applications interact with `TrackingAdapter` indirectly through the built in docking controls.
+
+## When to use adapters
+
+The provided adapters give you a ready made implementation for common behaviours such as window hosting and dock navigation. You can derive from them or implement the corresponding interfaces yourself if your application has special requirements.
+
+For an overview of other Dock concepts see the [documentation index](README.md).

--- a/docs/dock-enums.md
+++ b/docs/dock-enums.md
@@ -1,0 +1,82 @@
+# Dock Enumerations
+
+Several Dock APIs rely on small enumeration types. This page lists the most common ones so you know what values to expect when configuring docks or handling events.
+
+## Alignment
+
+Used by tools and docks to describe where they are placed relative to the main layout.
+
+| Value | Description |
+| ----- | ----------- |
+| `Unset` | Alignment has not been specified. |
+| `Left` | Positioned on the left side. |
+| `Bottom` | Positioned at the bottom. |
+| `Right` | Positioned on the right side. |
+| `Top` | Positioned at the top. |
+
+## DockMode
+
+Indicates the default docking location for a dock or dockable.
+
+| Value | Description |
+| ----- | ----------- |
+| `Center` | Fills the remaining space. |
+| `Left` | Docks to the left. |
+| `Bottom` | Docks to the bottom. |
+| `Right` | Docks to the right. |
+| `Top` | Docks to the top. |
+
+## DockOperation
+
+Specifies the operation being performed when a dockable is moved or split.
+
+| Value | Description |
+| ----- | ----------- |
+| `Fill` | Replace the target area. |
+| `Left` | Insert to the left. |
+| `Bottom` | Insert below. |
+| `Right` | Insert to the right. |
+| `Top` | Insert above. |
+| `Window` | Open in a floating window. |
+
+## Orientation
+
+Controls whether a proportional dock arranges its children horizontally or vertically.
+
+| Value | Description |
+| ----- | ----------- |
+| `Horizontal` | Children are stacked from left to right. |
+| `Vertical` | Children are stacked from top to bottom. |
+
+## GripMode
+
+Determines how the grip element of a splitter behaves.
+
+| Value | Description |
+| ----- | ----------- |
+| `Visible` | Grip is always shown. |
+| `AutoHide` | Grip hides until the pointer is over it. |
+| `Hidden` | Grip is not displayed. |
+
+## TrackingMode
+
+Indicates which bounds `TrackingAdapter` is currently storing.
+
+| Value | Description |
+| ----- | ----------- |
+| `Visible` | Tracks the visible bounds. |
+| `Pinned` | Tracks the pinned bounds. |
+| `Tab` | Tracks the tab bounds. |
+
+## DragAction
+
+Represents the allowed drag and drop actions when interacting with external data sources.
+
+| Value | Description |
+| ----- | ----------- |
+| `None` | No action permitted. |
+| `Copy` | Data will be copied. |
+| `Move` | Data will be moved. |
+| `Link` | A link to the data will be created. |
+
+For a high level overview of Dock terminology see the [glossary](dock-glossary.md).

--- a/docs/dock-glossary.md
+++ b/docs/dock-glossary.md
@@ -13,5 +13,10 @@ This page defines common terms used throughout the Dock documentation and sample
 - **Factory** – Class responsible for creating and modifying layouts at runtime.
 - **DockSerializer** – Component that saves or loads layouts so user customisations persist across sessions.
 - **DockManager** – Implements the algorithms that move or swap dockables during drag and drop.
+- **HostAdapter** – Bridges an `IDockWindow` with the platform window used to display it.
+- **NavigateAdapter** – Provides back and forward history navigation for docks.
+- **TrackingAdapter** – Stores bounds information while dockables are moved or pinned.
+- **DockMode** – Enumerates the default docking location such as Left, Right or Center.
+- **DockPoint** – Simple structure representing an X/Y coordinate.
 
 For an overview of all guides see the [documentation index](README.md).


### PR DESCRIPTION
## Summary
- document HostAdapter, NavigateAdapter and TrackingAdapter
- list all Dock enums and their values
- link new docs from the docs index
- expand glossary with new terms

## Testing
- `dotnet test --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6865679b78348321bb9a4ae9145a17da