### PR TITLE
Improve Dock docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ guides under *Getting started*.
 - [Control recycling](dock-control-recycling.md) – Reuse visuals when dockables return.
 - [Proportional StackPanel](dock-proportional-stackpanel.md) – Layout panel with adjustable proportions.
 - [Sizing guide](dock-sizing.md) – Control pixel sizes and fixed dimensions.
+- [Floating windows](dock-windows.md) – Detach dockables into separate windows.
 - [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
 
 ## Reference
@@ -39,6 +40,7 @@ guides under *Getting started*.
 - [Markup extensions](dock-markup-extensions.md) – Load and reference XAML fragments.
 - [Adapter classes](dock-adapters.md) – Host, navigation and tracking helpers.
 - [Enumerations](dock-enums.md) – Values used by Dock APIs.
+- [Dock settings](dock-settings.md) – Global drag/drop options and thresholds.
 
 ## Troubleshooting
 

--- a/docs/dock-dockable-properties.md
+++ b/docs/dock-dockable-properties.md
@@ -50,7 +50,7 @@ In XAML you set them as attributes:
       CanFloat="True" />
 ```
 
-Global drag and drop behaviour can be toggled using the attached properties from `Dock.Settings`:
+Global drag and drop behaviour can be toggled using the attached properties from [`Dock.Settings`](dock-settings.md):
 
 ```xml
 <Window xmlns:dockSettings="clr-namespace:Dock.Settings;assembly=Dock.Settings"

--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -125,7 +125,7 @@ tool.CanDrop = false;
 ```
 
 You can still toggle drag or drop globally using the attached `DockProperties`
-from `Dock.Settings`:
+from [`Dock.Settings`](dock-settings.md):
 
 ```xml
 <Window xmlns:dockSettings="clr-namespace:Dock.Settings;assembly=Dock.Settings"

--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -1,0 +1,41 @@
+# Dock Settings
+
+`Dock.Settings` exposes global properties and constants that control drag and drop behaviour.
+Use these when you need to adjust interaction distances or override the default templates.
+
+## Attached properties
+
+`DockProperties` defines several attached properties that can be applied to any Avalonia control.
+They are used by the default control templates but you can set them manually:
+
+| Property | Type | Description |
+| -------- | ---- | ----------- |
+| `IsDockTarget` | `bool` | Marks a control as a docking surface. |
+| `IsDragArea` | `bool` | Identifies a region that allows starting a drag. |
+| `IsDropArea` | `bool` | Identifies a region that can accept dropped dockables. |
+| `IsDragEnabled` | `bool` | Globally enables or disables dragging for child dockables. |
+| `IsDropEnabled` | `bool` | Globally enables or disables dropping of dockables. |
+
+Example disabling drag and drop for an entire window:
+
+```xml
+<Window xmlns:dockSettings="clr-namespace:Dock.Settings;assembly=Dock.Settings"
+        dockSettings:DockProperties.IsDragEnabled="False"
+        dockSettings:DockProperties.IsDropEnabled="False">
+    <DockControl />
+</Window>
+```
+
+## Drag thresholds
+
+`DockSettings` contains two public fields controlling how far the pointer must move
+before a drag operation begins:
+
+```csharp
+DockSettings.MinimumHorizontalDragDistance = 4;
+DockSettings.MinimumVerticalDragDistance = 4;
+```
+
+Increase these values if small pointer movements should not initiate dragging.
+
+For more details on dockable properties see [Dockable Property Settings](dock-dockable-properties.md).

--- a/docs/dock-windows.md
+++ b/docs/dock-windows.md
@@ -1,0 +1,31 @@
+# Floating Windows
+
+Dock can detach dockables into separate floating windows. These windows are represented by the `IDockWindow` interface and hosted using `IHostWindow` implementations.
+
+## Creating windows
+
+`FactoryBase` exposes a `CreateWindowFrom` method which returns an `IHostWindow`. Override this method on your factory to customize the platform window used for floating docks:
+
+```csharp
+public override IHostWindow CreateWindowFrom(IDockWindow source)
+{
+    var window = base.CreateWindowFrom(source);
+    window.Title = $"Dock - {source.Id}";
+    return window;
+}
+```
+
+Calling `FloatDockable` on the factory opens a dockable in a new window. The returned `IDockWindow` stores its bounds and title and can be serialized together with the layout.
+
+## Presenting and closing
+
+`IDockWindow` exposes `Present(bool isDialog)` to show the window and `Exit()` to close it programmatically. The default implementation uses `HostAdapter` to bridge between the interface and the underlying Avalonia `Window`.
+
+Use the `WindowOpened` and `WindowClosed` events on the factory to track when floating windows appear or disappear.
+
+```csharp
+factory.WindowClosed += (_, e) =>
+    Console.WriteLine($"Closed {e.Window?.Title}");
+```
+
+For more advanced scenarios see [Adapter Classes](dock-adapters.md) and the [Advanced Guide](dock-advanced.md).


### PR DESCRIPTION
## Summary
- add new doc on Dock.Settings and its attached properties
- document floating window support and host windows
- link the new docs from the index and cross-reference from existing pages

## Testing
- `dotnet test --verbosity minimal` *(fails: Repository has no remote and blocked internet)*

------
https://chatgpt.com/codex/tasks/task_e_6865774a25c08321b1ac3d37972993da