### PR TITLE
Fix preview size after pinning

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -328,7 +328,7 @@ public abstract partial class FactoryBase
 
         foreach (var dockable in rootDock.PinnedDock.VisibleDockables)
         {
-            dockable.GetVisibleBounds(out _, out _, out var width, out var height);
+            dockable.GetPinnedBounds(out _, out _, out var width, out var height);
             var proportion = dockable.Proportion;
             if (!double.IsNaN(width) && !double.IsNaN(height))
             {
@@ -370,7 +370,7 @@ public abstract partial class FactoryBase
         {
             if (!double.IsNaN(size.Width) && !double.IsNaN(size.Height))
             {
-                dockable.SetVisibleBounds(double.NaN, double.NaN, size.Width, size.Height);
+                dockable.SetPinnedBounds(double.NaN, double.NaN, size.Width, size.Height);
             }
             if (!double.IsNaN(size.Proportion))
             {

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -358,7 +358,7 @@ public abstract partial class FactoryBase
         RemoveAllVisibleDockables(rootDock.PinnedDock!);
 
         dockable.GetPinnedBounds(out _, out _, out var width, out var height);
-        if (!double.IsNaN(width) || !double.IsNaN(height))
+        if (!double.IsNaN(width) && !double.IsNaN(height))
         {
             dockable.SetVisibleBounds(double.NaN, double.NaN, width, height);
         }
@@ -398,7 +398,10 @@ public abstract partial class FactoryBase
                     // Pin dockable.
 
                     dockable.GetVisibleBounds(out var x, out var y, out var width, out var height);
-                    dockable.SetPinnedBounds(x, y, width, height);
+                    if (!double.IsNaN(width) && !double.IsNaN(height))
+                    {
+                        dockable.SetPinnedBounds(x, y, width, height);
+                    }
 
                     switch (alignment)
                     {

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -357,6 +357,12 @@ public abstract partial class FactoryBase
 
         RemoveAllVisibleDockables(rootDock.PinnedDock!);
 
+        dockable.GetPinnedBounds(out _, out _, out var width, out var height);
+        if (!double.IsNaN(width) || !double.IsNaN(height))
+        {
+            dockable.SetVisibleBounds(double.NaN, double.NaN, width, height);
+        }
+
         dockable.OriginalOwner = dockable.Owner;
         AddVisibleDockable(rootDock.PinnedDock!, dockable);
     }
@@ -390,6 +396,9 @@ public abstract partial class FactoryBase
                 if (isVisible && !isPinned)
                 {
                     // Pin dockable.
+
+                    dockable.GetVisibleBounds(out var x, out var y, out var width, out var height);
+                    dockable.SetPinnedBounds(x, y, width, height);
 
                     switch (alignment)
                     {

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -13,7 +13,7 @@ namespace Dock.Model;
 /// </summary>
 public abstract partial class FactoryBase
 {
-    private readonly Dictionary<IDockable, (double Width, double Height)> _pinnedPreviewSizes = new();
+    private readonly Dictionary<IDockable, (double Width, double Height, double Proportion)> _pinnedPreviewSizes = new();
     /// <inheritdoc/>
     public virtual void AddDockable(IDock dock, IDockable dockable)
     {
@@ -328,6 +328,13 @@ public abstract partial class FactoryBase
 
         foreach (var dockable in rootDock.PinnedDock.VisibleDockables)
         {
+            dockable.GetVisibleBounds(out _, out _, out var width, out var height);
+            var proportion = dockable.Proportion;
+            if (!double.IsNaN(width) && !double.IsNaN(height))
+            {
+                _pinnedPreviewSizes[dockable] = (width, height, proportion);
+            }
+
             dockable.Owner = dockable.OriginalOwner;
             dockable.OriginalOwner = null;
         }
@@ -364,6 +371,10 @@ public abstract partial class FactoryBase
             if (!double.IsNaN(size.Width) && !double.IsNaN(size.Height))
             {
                 dockable.SetVisibleBounds(double.NaN, double.NaN, size.Width, size.Height);
+            }
+            if (!double.IsNaN(size.Proportion))
+            {
+                dockable.Proportion = size.Proportion;
             }
         }
 
@@ -402,9 +413,10 @@ public abstract partial class FactoryBase
                     // Pin dockable.
 
                     dockable.GetVisibleBounds(out _, out _, out var width, out var height);
+                    var proportion = dockable.Proportion;
                     if (!double.IsNaN(width) && !double.IsNaN(height))
                     {
-                        _pinnedPreviewSizes[dockable] = (width, height);
+                        _pinnedPreviewSizes[dockable] = (width, height, proportion);
                     }
 
                     switch (alignment)


### PR DESCRIPTION
## Summary
- keep the dockable bounds when pinning
- restore stored size when previewing pinned dockable

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68658ea23d108321bf4d79e56813a352