### PR TITLE
Add root control tracking

### DIFF
--- a/src/Dock.Avalonia/Controls/DockableControl.cs
+++ b/src/Dock.Avalonia/Controls/DockableControl.cs
@@ -85,24 +85,28 @@ public class DockableControl : Panel, IDockableControl
 
     private void Register(IDockable dockable)
     {
+        var root = TemplatedParent ?? this;
         switch (TrackingMode)
         {
             case TrackingMode.Visible:
                 if (dockable.Factory is not null)
                 {
                     dockable.Factory.VisibleDockableControls[dockable] = this;
+                    dockable.Factory.VisibleRootControls[dockable] = root;
                 }
                 break;
             case TrackingMode.Pinned:
                 if (dockable.Factory is not null)
                 {
                     dockable.Factory.PinnedDockableControls[dockable] = this;
+                    dockable.Factory.PinnedRootControls[dockable] = root;
                 }
                 break;
             case TrackingMode.Tab:
                 if (dockable.Factory is not null)
                 {
                     dockable.Factory.TabDockableControls[dockable] = this;
+                    dockable.Factory.TabRootControls[dockable] = root;
                 }
                 break;
         }
@@ -113,13 +117,25 @@ public class DockableControl : Panel, IDockableControl
         switch (TrackingMode)
         {
             case TrackingMode.Visible:
-                dockable.Factory?.VisibleDockableControls.Remove(dockable);
+                if (dockable.Factory is not null)
+                {
+                    dockable.Factory.VisibleDockableControls.Remove(dockable);
+                    dockable.Factory.VisibleRootControls.Remove(dockable);
+                }
                 break;
             case TrackingMode.Pinned:
-                dockable.Factory?.PinnedDockableControls.Remove(dockable);
+                if (dockable.Factory is not null)
+                {
+                    dockable.Factory.PinnedDockableControls.Remove(dockable);
+                    dockable.Factory.PinnedRootControls.Remove(dockable);
+                }
                 break;
             case TrackingMode.Tab:
-                dockable.Factory?.TabDockableControls.Remove(dockable);
+                if (dockable.Factory is not null)
+                {
+                    dockable.Factory.TabDockableControls.Remove(dockable);
+                    dockable.Factory.TabRootControls.Remove(dockable);
+                }
                 break;
         }
     }

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -24,6 +24,9 @@ public class Factory : FactoryBase
         VisibleDockableControls = new Dictionary<IDockable, IDockableControl>();
         PinnedDockableControls = new Dictionary<IDockable, IDockableControl>();
         TabDockableControls = new Dictionary<IDockable, IDockableControl>();
+        VisibleRootControls = new Dictionary<IDockable, object>();
+        PinnedRootControls = new Dictionary<IDockable, object>();
+        TabRootControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -34,11 +37,23 @@ public class Factory : FactoryBase
 
     /// <inheritdoc/>
     [JsonIgnore]
+    public override IDictionary<IDockable, object> VisibleRootControls { get; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
     public override IDictionary<IDockable, IDockableControl> PinnedDockableControls { get; }
 
     /// <inheritdoc/>
     [JsonIgnore]
+    public override IDictionary<IDockable, object> PinnedRootControls { get; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
     public override IDictionary<IDockable, IDockableControl> TabDockableControls { get; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public override IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -22,6 +22,9 @@ public class Factory : FactoryBase
         VisibleDockableControls = new Dictionary<IDockable, IDockableControl>();
         PinnedDockableControls = new Dictionary<IDockable, IDockableControl>();
         TabDockableControls = new Dictionary<IDockable, IDockableControl>();
+        VisibleRootControls = new Dictionary<IDockable, object>();
+        PinnedRootControls = new Dictionary<IDockable, object>();
+        TabRootControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -30,10 +33,19 @@ public class Factory : FactoryBase
     public override IDictionary<IDockable, IDockableControl> VisibleDockableControls { get; }
 
     /// <inheritdoc/>
+    public override IDictionary<IDockable, object> VisibleRootControls { get; }
+
+    /// <inheritdoc/>
     public override IDictionary<IDockable, IDockableControl> PinnedDockableControls { get; }
 
     /// <inheritdoc/>
+    public override IDictionary<IDockable, object> PinnedRootControls { get; }
+
+    /// <inheritdoc/>
     public override IDictionary<IDockable, IDockableControl> TabDockableControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <inheritdoc/>
     public override IList<IDockControl> DockControls { get; }

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -22,6 +22,9 @@ public class Factory : FactoryBase
         VisibleDockableControls = new Dictionary<IDockable, IDockableControl>();
         PinnedDockableControls = new Dictionary<IDockable, IDockableControl>();
         TabDockableControls = new Dictionary<IDockable, IDockableControl>();
+        VisibleRootControls = new Dictionary<IDockable, object>();
+        PinnedRootControls = new Dictionary<IDockable, object>();
+        TabRootControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -30,10 +33,19 @@ public class Factory : FactoryBase
     public override IDictionary<IDockable, IDockableControl> VisibleDockableControls { get; }
 
     /// <inheritdoc/>
+    public override IDictionary<IDockable, object> VisibleRootControls { get; }
+
+    /// <inheritdoc/>
     public override IDictionary<IDockable, IDockableControl> PinnedDockableControls { get; }
 
     /// <inheritdoc/>
+    public override IDictionary<IDockable, object> PinnedRootControls { get; }
+
+    /// <inheritdoc/>
     public override IDictionary<IDockable, IDockableControl> TabDockableControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <inheritdoc/>
     public override IList<IDockControl> DockControls { get; }

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -17,14 +17,29 @@ public partial interface IFactory
     IDictionary<IDockable, IDockableControl> VisibleDockableControls { get; }
 
     /// <summary>
+    /// Gets visible dockable root controls.
+    /// </summary>
+    IDictionary<IDockable, object> VisibleRootControls { get; }
+
+    /// <summary>
     /// Gets pinned dockable controls.
     /// </summary>
     IDictionary<IDockable, IDockableControl> PinnedDockableControls { get; }
 
     /// <summary>
+    /// Gets pinned dockable root controls.
+    /// </summary>
+    IDictionary<IDockable, object> PinnedRootControls { get; }
+
+    /// <summary>
     /// Gets tab dockable controls.
     /// </summary>
     IDictionary<IDockable, IDockableControl> TabDockableControls { get; }
+
+    /// <summary>
+    /// Gets tab dockable root controls.
+    /// </summary>
+    IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <summary>
     /// Gets dock controls.

--- a/src/Dock.Model/FactoryBase.Factory.cs
+++ b/src/Dock.Model/FactoryBase.Factory.cs
@@ -15,10 +15,19 @@ public abstract partial class FactoryBase
     public abstract IDictionary<IDockable, IDockableControl> VisibleDockableControls { get; }
 
     /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> VisibleRootControls { get; }
+
+    /// <inheritdoc/>
     public abstract IDictionary<IDockable, IDockableControl> PinnedDockableControls { get; }
 
     /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> PinnedRootControls { get; }
+
+    /// <inheritdoc/>
     public abstract IDictionary<IDockable, IDockableControl> TabDockableControls { get; }
+
+    /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <inheritdoc/>
     public abstract IList<IDockControl> DockControls { get; }


### PR DESCRIPTION
## Summary
- track DockableControl separately from the templated root control
- expose dictionaries for dockable root controls in factory interfaces
- store both DockableControl and its root when registering

## Testing
- `dotnet build Dock.sln -c Release`
- `dotnet test Dock.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68659679e9f083219b9db2e08e42391d