### PR TITLE
Add documentation for dockable tracking methods

### DIFF
--- a/docs/dock-advanced.md
+++ b/docs/dock-advanced.md
@@ -106,6 +106,26 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
 }
 ```
 
+## Tracking bounds
+
+`DockableBase` keeps track of several coordinate sets used while dragging or
+pinning dockables. Methods like `SetVisibleBounds`, `SetPinnedBounds` and
+`SetTabBounds` store the latest position, whereas the matching `Get*` methods
+return the values. Two additional methods record the pointer location relative to
+the dock control and to the screen.
+
+```csharp
+// Record the bounds of a tool while it is pinned
+tool.SetPinnedBounds(x, y, width, height);
+
+// Retrieve the saved pointer location from the last drag
+tool.GetPointerScreenPosition(out var screenX, out var screenY);
+```
+
+Override `OnVisibleBoundsChanged`, `OnPinnedBoundsChanged`, `OnTabBoundsChanged`
+and the pointer variants if you need to react when these coordinates change,
+for example to persist them or to show custom overlays.
+
 ## Conclusion
 
 Explore the samples under `samples/` for complete implementations. Mixing these techniques with the basics lets you build complex layouts that can be persisted and restored.

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -15,6 +15,29 @@ This reference summarizes the most commonly used classes in Dock. It is based on
 | `IProportionalDockSplitter` | Thin splitter placed between proportional docks. Exposes `CanResize` to enable or disable dragging. |
 | `IDockWindow` / `IHostWindow` | Interfaces representing floating windows created when dockables are detached. |
 
+## Tracking bounds and pointer positions
+
+`IDockable` includes a set of methods used by the docking logic to remember the
+position of a dockable and the pointer during drag operations. These methods are
+implemented by `DockableBase` which stores the values in a `TrackingAdapter`.
+The adapter starts with `NaN` coordinates until a value is set.
+
+- `GetVisibleBounds(out x, out y, out width, out height)` and
+  `SetVisibleBounds(x, y, width, height)` return or store the last known bounds
+  of the dockable while it is visible in a dock. `OnVisibleBoundsChanged` is
+  invoked whenever the values are updated.
+- `GetPinnedBounds`/`SetPinnedBounds`/`OnPinnedBoundsChanged` track the
+  dimensions used when a tool is pinned to one of the layout edges.
+- `GetTabBounds`/`SetTabBounds`/`OnTabBoundsChanged` hold the bounds of a
+  dockable displayed as a tab inside another dock.
+- `GetPointerPosition`/`SetPointerPosition`/`OnPointerPositionChanged` store the
+  pointer coordinates relative to the dock control.
+- `GetPointerScreenPosition`/`SetPointerScreenPosition`/
+  `OnPointerScreenPositionChanged` do the same using screen coordinates.
+
+These values are consulted when calculating drop targets or restoring a layout
+from a saved state.
+
 ## Factory API
 
 The `IFactory` interface (implemented by `Factory` in `Dock.Model.Mvvm` and `Dock.Model.ReactiveUI`) contains numerous helpers used by the samples to build and manipulate layouts. Important members include:


### PR DESCRIPTION
## Summary
- add reference section describing IDockable tracking members
- document advanced usage of Set/Get*Bounds and pointer methods

## Testing
- `dotnet test --no-build` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68659c13385c8321ab0f6cc2ac3adaf2