### PR TITLE
Complete context menu string resources

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -13,28 +13,35 @@
     </Border>
   </Design.PreviewWith>
 
+  <x:String x:Key="DocumentTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseString">_Close</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseOtherTabsString">Close other tabs</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Close all tabs</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseTabsLeftString">_Close tabs to the left</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseTabsRightString">_Close tabs to the right</x:String>
+
   <ContextMenu x:Key="DocumentTabStripItemContextMenu">
-    <MenuItem Header="_Float"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
-    <MenuItem Header="_Close"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>
-    <MenuItem Header="Close other tabs"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemCloseOtherTabsString}"
               Command="{Binding Owner.Factory.CloseOtherDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>
-    <MenuItem Header="Close all tabs"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemCloseAllTabsString}"
               Command="{Binding Owner.Factory.CloseAllDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>
-    <MenuItem Header="_Close tabs to the left"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsLeftString}"
               Command="{Binding Owner.Factory.CloseLeftDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>
-    <MenuItem Header="_Close tabs to the right"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsRightString}"
               Command="{Binding Owner.Factory.CloseRightDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -5,20 +5,25 @@
                     x:DataType="controls:IToolDock" 
                     x:CompileBindings="True">
   <Design.PreviewWith>
-    <ToolChromeControl Width="300" Height="400" />
+  <ToolChromeControl Width="300" Height="400" />
   </Design.PreviewWith>
 
+  <x:String x:Key="ToolChromeControlFloatString">_Float</x:String>
+  <x:String x:Key="ToolChromeControlDockString">_Dock</x:String>
+  <x:String x:Key="ToolChromeControlAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolChromeControlCloseString">_Close</x:String>
+
   <MenuFlyout x:Key="ToolChromeControlContextMenu">
-    <MenuItem Header="_Float"
+    <MenuItem Header="{DynamicResource ToolChromeControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding ActiveDockable}"
               IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}"/>
-    <MenuItem Header="_Dock"
+    <MenuItem Header="{DynamicResource ToolChromeControlDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding ActiveDockable}"
               IsEnabled="{Binding ActiveDockable.OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
               IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"/>
-    <MenuItem Header="_Auto Hide"
+    <MenuItem Header="{DynamicResource ToolChromeControlAutoHideString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding ActiveDockable}"
               IsEnabled="{Binding ActiveDockable.OriginalOwner, Converter={x:Static ObjectConverters.IsNull}, FallbackValue=False}">
@@ -29,7 +34,7 @@
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
-    <MenuItem Header="_Close"
+    <MenuItem Header="{DynamicResource ToolChromeControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding ActiveDockable}"
               IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"/>

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -7,16 +7,20 @@
     <ToolPinItemControl Width="30" Height="400" />
   </Design.PreviewWith>
 
+  <x:String x:Key="ToolPinItemControlFloatString">_Float</x:String>
+  <x:String x:Key="ToolPinItemControlShowString">_Show</x:String>
+  <x:String x:Key="ToolPinItemControlCloseString">_Close</x:String>
+
   <ContextMenu x:Key="ToolPinItemControlContextMenu">
-    <MenuItem Header="_Float"
+    <MenuItem Header="{DynamicResource ToolPinItemControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
-    <MenuItem Header="_Show"
+    <MenuItem Header="{DynamicResource ToolPinItemControlShowString}"
               Command="{Binding Owner.Factory.PreviewPinnedDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanPin}"/>
-    <MenuItem Header="_Close"
+    <MenuItem Header="{DynamicResource ToolPinItemControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -16,17 +16,22 @@
   <x:Double x:Key="TabStripItemMinHeight">48</x:Double>
   <x:Double x:Key="TabStripItemPipeThickness">2</x:Double>
 
+  <x:String x:Key="ToolTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="ToolTabStripItemDockString">_Dock</x:String>
+  <x:String x:Key="ToolTabStripItemAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
+
   <ContextMenu x:Key="ToolTabStripItemContextMenu">
-    <MenuItem Header="_Float"
+    <MenuItem Header="{DynamicResource ToolTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
-    <MenuItem Header="_Dock"
+    <MenuItem Header="{DynamicResource ToolTabStripItemDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding}"
               IsEnabled="{Binding OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
               IsVisible="{Binding CanPin, FallbackValue=False}"/>
-    <MenuItem Header="_Auto Hide"
+    <MenuItem Header="{DynamicResource ToolTabStripItemAutoHideString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding }"
               IsEnabled="{Binding OriginalOwner, Converter={x:Static ObjectConverters.IsNull}, FallbackValue=False}">
@@ -37,7 +42,7 @@
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
-    <MenuItem Header="_Close"
+    <MenuItem Header="{DynamicResource ToolTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>


### PR DESCRIPTION
## Summary
- localize DocumentTabStripItem context menu strings
- add string resources for ToolTabStripItem, ToolChromeControl and ToolPinItemControl menus

## Testing
- `dotnet test --no-build`
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release -f netstandard2.0`

------
https://chatgpt.com/codex/tasks/task_e_6865a3dd397083218a4594468b98d2ec