### PR TITLE
Add title bar drag docking

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -103,7 +103,7 @@ public class HostWindow : Window, IHostWindow
             {
                 _hostWindowTitleBar.BackgroundControl.PointerPressed += (_, args) =>
                 {
-                    MoveDrag(args);
+                    MoveDrag(args, fromTitleBar: true);
                 };
             }
         }
@@ -117,9 +117,9 @@ public class HostWindow : Window, IHostWindow
         return relativeScreenDiff;
     }
 
-    private void MoveDrag(PointerPressedEventArgs e)
+    private void MoveDrag(PointerPressedEventArgs e, bool fromTitleBar = false)
     {
-        if (!ToolChromeControlsWholeWindow)
+        if (!fromTitleBar && !ToolChromeControlsWholeWindow)
             return;
 
         if (Window?.Factory?.OnWindowMoveDragBegin(Window) != true)

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -99,14 +99,16 @@ public class HostWindow : Window, IHostWindow
         {
             _hostWindowTitleBar.ApplyTemplate();
 
-            if (_hostWindowTitleBar.BackgroundControl is { })
-            {
-                _hostWindowTitleBar.BackgroundControl.PointerPressed += (_, args) =>
-                {
-                    MoveDrag(args, fromTitleBar: true);
-                };
-            }
+            _hostWindowTitleBar.AddHandler(PointerPressedEvent,
+                TitleBarPointerPressed,
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+                handledEventsToo: true);
         }
+    }
+
+    private void TitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        MoveDrag(e, fromTitleBar: true);
     }
 
     private PixelPoint ClientPointToScreenRelativeToWindow(Point clientPoint)

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -99,16 +99,8 @@ public class HostWindow : Window, IHostWindow
         {
             _hostWindowTitleBar.ApplyTemplate();
 
-            _hostWindowTitleBar.AddHandler(PointerPressedEvent,
-                TitleBarPointerPressed,
-                RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
-                handledEventsToo: true);
+            _chromeGrips.Add(_hostWindowTitleBar);
         }
-    }
-
-    private void TitleBarPointerPressed(object? sender, PointerPressedEventArgs e)
-    {
-        MoveDrag(e, fromTitleBar: true);
     }
 
     private PixelPoint ClientPointToScreenRelativeToWindow(Point clientPoint)
@@ -119,9 +111,9 @@ public class HostWindow : Window, IHostWindow
         return relativeScreenDiff;
     }
 
-    private void MoveDrag(PointerPressedEventArgs e, bool fromTitleBar = false)
+    private void MoveDrag(PointerPressedEventArgs e)
     {
-        if (!fromTitleBar && !ToolChromeControlsWholeWindow)
+        if (!ToolChromeControlsWholeWindow)
             return;
 
         if (Window?.Factory?.OnWindowMoveDragBegin(Window) != true)


### PR DESCRIPTION
## Summary
- allow drag operations to be initiated from floating window title bars

## Testing
- `dotnet test --no-restore --verbosity minimal` *(fails: build canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68664c6917b48321be0ccc65e2cb7bf1