### PR TITLE
Add Float All context menu

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -14,6 +14,7 @@
   </Design.PreviewWith>
 
   <x:String x:Key="DocumentTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="DocumentTabStripItemFloatAllString">Float all</x:String>
   <x:String x:Key="DocumentTabStripItemCloseString">_Close</x:String>
   <x:String x:Key="DocumentTabStripItemCloseOtherTabsString">Close other tabs</x:String>
   <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Close all tabs</x:String>
@@ -23,6 +24,10 @@
   <ContextMenu x:Key="DocumentTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
+              CommandParameter="{Binding}"
+              IsVisible="{Binding CanFloat}"/>
+    <MenuItem Header="{DynamicResource DocumentTabStripItemFloatAllString}"
+              Command="{Binding Owner.Factory.FloatAllDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -17,6 +17,7 @@
   <x:Double x:Key="TabStripItemPipeThickness">2</x:Double>
 
   <x:String x:Key="ToolTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="ToolTabStripItemFloatAllString">Float all</x:String>
   <x:String x:Key="ToolTabStripItemDockString">_Dock</x:String>
   <x:String x:Key="ToolTabStripItemAutoHideString">_Auto Hide</x:String>
   <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
@@ -24,6 +25,10 @@
   <ContextMenu x:Key="ToolTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
+              CommandParameter="{Binding}"
+              IsVisible="{Binding CanFloat}"/>
+    <MenuItem Header="{DynamicResource ToolTabStripItemFloatAllString}"
+              Command="{Binding Owner.Factory.FloatAllDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
     <MenuItem Header="{DynamicResource ToolTabStripItemDockString}"

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -330,6 +330,12 @@ public partial interface IFactory
     void FloatDockable(IDockable dockable);
 
     /// <summary>
+    /// Floats owner dock with all dockables.
+    /// </summary>
+    /// <param name="dockable">The dockable owner source.</param>
+    void FloatAllDockables(IDockable dockable);
+
+    /// <summary>
     /// Removes dockable from owner <see cref="IDock.VisibleDockables"/> collection, and call IDockable.OnClose.
     /// </summary>
     /// <param name="dockable">The dockable to remove.</param>

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -605,6 +605,17 @@ public abstract partial class FactoryBase
     }
 
     /// <inheritdoc/>
+    public virtual void FloatAllDockables(IDockable dockable)
+    {
+        if (dockable.Owner is not IDock dock)
+        {
+            return;
+        }
+
+        FloatDockable(dock);
+    }
+
+    /// <inheritdoc/>
     public virtual void CloseDockable(IDockable dockable)
     {
         if (dockable.CanClose && dockable.OnClose())

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -607,12 +607,82 @@ public abstract partial class FactoryBase
     /// <inheritdoc/>
     public virtual void FloatAllDockables(IDockable dockable)
     {
-        if (dockable.Owner is not IDock dock)
+        if (dockable.Owner is not IDock dock || dock.VisibleDockables is null)
         {
             return;
         }
 
-        FloatDockable(dock);
+        var rootDock = FindRoot(dock, _ => true);
+        if (rootDock is null)
+        {
+            return;
+        }
+
+        dock.GetPointerScreenPosition(out var pointerX, out var pointerY);
+        dock.GetVisibleBounds(out var ownerX, out var ownerY, out var ownerWidth, out var ownerHeight);
+
+        if (double.IsNaN(pointerX))
+        {
+            pointerX = !double.IsNaN(ownerX) ? ownerX : 0;
+        }
+        if (double.IsNaN(pointerY))
+        {
+            pointerY = !double.IsNaN(ownerY) ? ownerY : 0;
+        }
+
+        var width = double.IsNaN(ownerWidth) ? 300 : ownerWidth;
+        var height = double.IsNaN(ownerHeight) ? 400 : ownerHeight;
+
+        IDock targetDock = dock switch
+        {
+            IDocumentDock => CreateDocumentDock(),
+            IToolDock => CreateToolDock(),
+            _ => CreateDockDock()
+        };
+
+        targetDock.Title = dock.Title;
+        targetDock.Id = dock.Id;
+        targetDock.VisibleDockables = CreateList<IDockable>();
+
+        if (dock is IDocumentDock sourceDoc && targetDock is IDocumentDock targetDoc)
+        {
+            targetDoc.CanCreateDocument = sourceDoc.CanCreateDocument;
+
+            if (sourceDoc is IDocumentDockContent sourceContent && targetDoc is IDocumentDockContent targetContent)
+            {
+                targetContent.DocumentTemplate = sourceContent.DocumentTemplate;
+            }
+        }
+
+        if (dock is IToolDock sourceTool && targetDock is IToolDock targetTool)
+        {
+            targetTool.Alignment = sourceTool.Alignment;
+            targetTool.IsExpanded = sourceTool.IsExpanded;
+            targetTool.AutoHide = sourceTool.AutoHide;
+            targetTool.GripMode = sourceTool.GripMode;
+        }
+
+        var dockables = dock.VisibleDockables.ToList();
+        foreach (var d in dockables)
+        {
+            MoveDockable(dock, targetDock, d, null);
+        }
+
+        var window = CreateWindowFrom(targetDock);
+        if (window is not null)
+        {
+            AddWindow(rootDock, window);
+            window.X = pointerX;
+            window.Y = pointerY;
+            window.Width = width;
+            window.Height = height;
+            window.Present(false);
+
+            if (window.Layout is { })
+            {
+                SetFocusedDockable(window.Layout, targetDock.ActiveDockable);
+            }
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -665,7 +665,12 @@ public abstract partial class FactoryBase
         var dockables = dock.VisibleDockables.ToList();
         foreach (var d in dockables)
         {
-            MoveDockable(dock, targetDock, d, null);
+            // move dockables one by one but do not force collapse when the
+            // owner dock declares it should stay visible
+            RemoveDockable(d, dock.IsCollapsable);
+            AddDockable(targetDock, d);
+            OnDockableMoved(d);
+            targetDock.ActiveDockable = d;
         }
 
         var window = CreateWindowFrom(targetDock);


### PR DESCRIPTION
## Summary
- allow floating all document tabs together
- expose new `IFactory.FloatAllDockables` API
- implement default logic in `FactoryBase`
- add `Float all` option in DocumentTabStripItem context menu

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: .NET 9.0 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68664cde195083218d76e65b3d503844