### PR TITLE
Add document dock split options

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -32,12 +32,7 @@
               Command="{Binding Owner.Factory.FloatAllDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
-    <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
-              Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"
-              CommandParameter="{Binding}"/>
-    <MenuItem Header="{DynamicResource DocumentTabStripItemNewVerticalDockString}"
-              Command="{Binding Owner.Factory.NewVerticalDocumentDock}"
-              CommandParameter="{Binding}"/>
+    <Separator />
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
@@ -58,6 +53,27 @@
               Command="{Binding Owner.Factory.CloseRightDockables}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanClose}"/>
+    <Separator />
+    <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
+              Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanDrag" />
+          <Binding Path="CanDrop" />
+        </MultiBinding>
+      </MenuItem.IsVisible>
+    </MenuItem>
+    <MenuItem Header="{DynamicResource DocumentTabStripItemNewVerticalDockString}"
+              Command="{Binding Owner.Factory.NewVerticalDocumentDock}"
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanDrag" />
+          <Binding Path="CanDrop" />
+        </MultiBinding>
+      </MenuItem.IsVisible>
+    </MenuItem>
   </ContextMenu>
   
   <ControlTheme x:Key="{x:Type DocumentTabStripItem}" TargetType="DocumentTabStripItem">

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -19,12 +19,20 @@
   <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Close all tabs</x:String>
   <x:String x:Key="DocumentTabStripItemCloseTabsLeftString">_Close tabs to the left</x:String>
   <x:String x:Key="DocumentTabStripItemCloseTabsRightString">_Close tabs to the right</x:String>
+  <x:String x:Key="DocumentTabStripItemNewHorizontalDockString">New Horizontal Document Dock</x:String>
+  <x:String x:Key="DocumentTabStripItemNewVerticalDockString">New Vertical Document Dock</x:String>
 
   <ContextMenu x:Key="DocumentTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanFloat}"/>
+    <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
+              Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"
+              CommandParameter="{Binding}"/>
+    <MenuItem Header="{DynamicResource DocumentTabStripItemNewVerticalDockString}"
+              Command="{Binding Owner.Factory.NewVerticalDocumentDock}"
+              CommandParameter="{Binding}"/>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -445,4 +445,16 @@ public partial interface IFactory
     /// <param name="width">The window width.</param>
     /// <param name="height">The window height.</param>
     void SplitToWindow(IDock dock, IDockable dockable, double x, double y, double width, double height);
+
+    /// <summary>
+    /// Splits document into a new horizontal document dock.
+    /// </summary>
+    /// <param name="dockable">The dockable to split.</param>
+    void NewHorizontalDocumentDock(IDockable dockable);
+
+    /// <summary>
+    /// Splits document into a new vertical document dock.
+    /// </summary>
+    /// <param name="dockable">The dockable to split.</param>
+    void NewVerticalDocumentDock(IDockable dockable);
 }

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -698,6 +698,60 @@ public abstract partial class FactoryBase
     }
 
     /// <inheritdoc/>
+    public virtual void NewHorizontalDocumentDock(IDockable dockable)
+    {
+        if (dockable.Owner is not IDock dock)
+        {
+            return;
+        }
+
+        var newDock = CreateDocumentDock();
+        newDock.Title = nameof(IDocumentDock);
+        newDock.VisibleDockables = CreateList<IDockable>();
+
+        if (dock is IDocumentDock sourceDock && newDock is IDocumentDock targetDock)
+        {
+            targetDock.Id = sourceDock.Id;
+            targetDock.CanCreateDocument = sourceDock.CanCreateDocument;
+
+            if (sourceDock is IDocumentDockContent sdc && targetDock is IDocumentDockContent tdc)
+            {
+                tdc.DocumentTemplate = sdc.DocumentTemplate;
+            }
+        }
+
+        MoveDockable(dock, newDock, dockable, null);
+        SplitToDock(dock, newDock, DockOperation.Right);
+    }
+
+    /// <inheritdoc/>
+    public virtual void NewVerticalDocumentDock(IDockable dockable)
+    {
+        if (dockable.Owner is not IDock dock)
+        {
+            return;
+        }
+
+        var newDock = CreateDocumentDock();
+        newDock.Title = nameof(IDocumentDock);
+        newDock.VisibleDockables = CreateList<IDockable>();
+
+        if (dock is IDocumentDock sourceDock && newDock is IDocumentDock targetDock)
+        {
+            targetDock.Id = sourceDock.Id;
+            targetDock.CanCreateDocument = sourceDock.CanCreateDocument;
+
+            if (sourceDock is IDocumentDockContent sdc && targetDock is IDocumentDockContent tdc)
+            {
+                tdc.DocumentTemplate = sdc.DocumentTemplate;
+            }
+        }
+
+        MoveDockable(dock, newDock, dockable, null);
+        SplitToDock(dock, newDock, DockOperation.Bottom);
+    }
+
+    /// <inheritdoc/>
     public virtual void HideDockable(IDockable dockable)
     {
         UnpinDockable(dockable);


### PR DESCRIPTION
## Summary
- add menu items to split a document tab
- expose commands for splitting into new document docks
- implement command logic for horizontal and vertical splits

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68664d34f89483219034e1e3b92d91c4