### PR TITLE
Add Dock as Document context option

### DIFF
--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -11,6 +11,7 @@
   <x:String x:Key="ToolChromeControlFloatString">_Float</x:String>
   <x:String x:Key="ToolChromeControlDockString">_Dock</x:String>
   <x:String x:Key="ToolChromeControlAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolChromeControlDockAsDocumentString">Dock as Tabbed Document</x:String>
   <x:String x:Key="ToolChromeControlCloseString">_Close</x:String>
 
   <MenuFlyout x:Key="ToolChromeControlContextMenu">
@@ -23,6 +24,10 @@
               CommandParameter="{Binding ActiveDockable}"
               IsEnabled="{Binding ActiveDockable.OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
               IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"/>
+    <MenuItem Header="{DynamicResource ToolChromeControlDockAsDocumentString}"
+              Command="{Binding Owner.Factory.DockAsDocument}"
+              CommandParameter="{Binding ActiveDockable}"
+              IsVisible="{Binding ActiveDockable.Owner, Converter={x:Static converters:OwnerIsToolDockConverter.Instance}}"/>
     <MenuItem Header="{DynamicResource ToolChromeControlAutoHideString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding ActiveDockable}"

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:core="using:Dock.Model.Core" 
-                    x:DataType="core:IDockable" 
+                    xmlns:core="using:Dock.Model.Core"
+                    xmlns:converters="using:Dock.Avalonia.Converters"
+                    x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
     <ToolPinItemControl Width="30" Height="400" />
@@ -9,6 +10,7 @@
 
   <x:String x:Key="ToolPinItemControlFloatString">_Float</x:String>
   <x:String x:Key="ToolPinItemControlShowString">_Show</x:String>
+  <x:String x:Key="ToolPinItemControlDockAsDocumentString">Dock as Tabbed Document</x:String>
   <x:String x:Key="ToolPinItemControlCloseString">_Close</x:String>
 
   <ContextMenu x:Key="ToolPinItemControlContextMenu">
@@ -20,6 +22,10 @@
               Command="{Binding Owner.Factory.PreviewPinnedDockable}"
               CommandParameter="{Binding}"
               IsVisible="{Binding CanPin}"/>
+    <MenuItem Header="{DynamicResource ToolPinItemControlDockAsDocumentString}"
+              Command="{Binding Owner.Factory.DockAsDocument}"
+              CommandParameter="{Binding}"
+              IsVisible="{Binding Owner, Converter={x:Static converters:OwnerIsToolDockConverter.Instance}}"/>
     <MenuItem Header="{DynamicResource ToolPinItemControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -1,7 +1,8 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:core="using:Dock.Model.Core" 
-                    x:DataType="core:IDockable" 
+                    xmlns:core="using:Dock.Model.Core"
+                    xmlns:converters="using:Dock.Avalonia.Converters"
+                    x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
     <Border Padding="20">
@@ -19,6 +20,7 @@
   <x:String x:Key="ToolTabStripItemFloatString">_Float</x:String>
   <x:String x:Key="ToolTabStripItemDockString">_Dock</x:String>
   <x:String x:Key="ToolTabStripItemAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolTabStripItemDockAsDocumentString">Dock as Tabbed Document</x:String>
   <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
 
   <ContextMenu x:Key="ToolTabStripItemContextMenu">
@@ -31,6 +33,10 @@
               CommandParameter="{Binding}"
               IsEnabled="{Binding OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
               IsVisible="{Binding CanPin, FallbackValue=False}"/>
+    <MenuItem Header="{DynamicResource ToolTabStripItemDockAsDocumentString}"
+              Command="{Binding Owner.Factory.DockAsDocument}"
+              CommandParameter="{Binding}"
+              IsVisible="{Binding Owner, Converter={x:Static converters:OwnerIsToolDockConverter.Instance}}"/>
     <MenuItem Header="{DynamicResource ToolTabStripItemAutoHideString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding }"

--- a/src/Dock.Avalonia/Converters/OwnerIsToolDockConverter.cs
+++ b/src/Dock.Avalonia/Converters/OwnerIsToolDockConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Dock.Model.Controls;
+
+namespace Dock.Avalonia.Converters;
+
+internal class OwnerIsToolDockConverter : IValueConverter
+{
+    public static readonly OwnerIsToolDockConverter Instance = new OwnerIsToolDockConverter();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is IToolDock;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -330,6 +330,12 @@ public partial interface IFactory
     void FloatDockable(IDockable dockable);
 
     /// <summary>
+    /// Docks dockable as tabbed document in the nearest document dock.
+    /// </summary>
+    /// <param name="dockable">The dockable to dock.</param>
+    void DockAsDocument(IDockable dockable);
+
+    /// <summary>
     /// Removes dockable from owner <see cref="IDock.VisibleDockables"/> collection, and call IDockable.OnClose.
     /// </summary>
     /// <param name="dockable">The dockable to remove.</param>

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -691,6 +691,29 @@ public abstract partial class FactoryBase
     }
 
     /// <inheritdoc/>
+    public virtual void DockAsDocument(IDockable dockable)
+    {
+        if (dockable.Owner is not IDock sourceDock)
+        {
+            return;
+        }
+
+        var rootDock = FindRoot(sourceDock, _ => true);
+        if (rootDock is null)
+        {
+            return;
+        }
+
+        var target = FindDockable(rootDock, d => d is IDocumentDock) as IDock;
+        if (target is null)
+        {
+            return;
+        }
+
+        MoveDockable(sourceDock, target, dockable, null);
+    }
+
+    /// <inheritdoc/>
     public virtual void CloseDockable(IDockable dockable)
     {
         if (dockable.CanClose && dockable.OnClose())

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -605,6 +605,29 @@ public abstract partial class FactoryBase
     }
 
     /// <inheritdoc/>
+    public virtual void DockAsDocument(IDockable dockable)
+    {
+        if (dockable.Owner is not IDock sourceDock)
+        {
+            return;
+        }
+
+        var rootDock = FindRoot(sourceDock, _ => true);
+        if (rootDock is null)
+        {
+            return;
+        }
+
+        var target = FindDockable(rootDock, d => d is IDocumentDock) as IDock;
+        if (target is null)
+        {
+            return;
+        }
+
+        MoveDockable(sourceDock, target, dockable, null);
+    }
+
+    /// <inheritdoc/>
     public virtual void CloseDockable(IDockable dockable)
     {
         if (dockable.CanClose && dockable.OnClose())

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -710,7 +710,9 @@ public abstract partial class FactoryBase
             return;
         }
 
-        MoveDockable(sourceDock, target, dockable, null);
+        var targetDockable = target.VisibleDockables?.LastOrDefault();
+
+        MoveDockable(sourceDock, target, dockable, targetDockable);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- add `DockAsDocument` API to `IFactory` and default implementation
- implement `DockAsDocument` to move a tool into the nearest document dock
- expose new option in tool context menus
- add `OwnerIsToolDockConverter` helper for menu visibility

## Testing
- `dotnet test` *(fails: The argument <dll> is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686655e43bdc83219719340fb0b24201