### PR TITLE
Track tool and document controls

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia;
 using Avalonia.Controls.Primitives;
+using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
 
@@ -9,4 +11,25 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class DocumentContentControl : TemplatedControl
 {
+    /// <inheritdoc/>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        if (DataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.DocumentControls[dockable] = this;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+
+        if (DataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.DocumentControls.Remove(dockable);
+        }
+    }
 }

--- a/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia;
 using Avalonia.Controls.Primitives;
+using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
 
@@ -9,4 +11,25 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class ToolContentControl : TemplatedControl
 {
+    /// <inheritdoc/>
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+
+        if (DataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.ToolControls[dockable] = this;
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+
+        if (DataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.ToolControls.Remove(dockable);
+        }
+    }
 }

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -27,6 +27,8 @@ public class Factory : FactoryBase
         VisibleRootControls = new Dictionary<IDockable, object>();
         PinnedRootControls = new Dictionary<IDockable, object>();
         TabRootControls = new Dictionary<IDockable, object>();
+        ToolControls = new Dictionary<IDockable, object>();
+        DocumentControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -54,6 +56,14 @@ public class Factory : FactoryBase
     /// <inheritdoc/>
     [JsonIgnore]
     public override IDictionary<IDockable, object> TabRootControls { get; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public override IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <inheritdoc/>
+    [JsonIgnore]
+    public override IDictionary<IDockable, object> DocumentControls { get; }
 
     /// <inheritdoc/>
     [JsonIgnore]

--- a/src/Dock.Model.Avalonia/FactoryBase.Controls.cs
+++ b/src/Dock.Model.Avalonia/FactoryBase.Controls.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Collections.Generic;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model;
+
+/// <summary>
+/// Factory base class.
+/// </summary>
+public abstract partial class FactoryBase
+{
+    /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> DocumentControls { get; }
+}

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -25,6 +25,8 @@ public class Factory : FactoryBase
         VisibleRootControls = new Dictionary<IDockable, object>();
         PinnedRootControls = new Dictionary<IDockable, object>();
         TabRootControls = new Dictionary<IDockable, object>();
+        ToolControls = new Dictionary<IDockable, object>();
+        DocumentControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -46,6 +48,12 @@ public class Factory : FactoryBase
 
     /// <inheritdoc/>
     public override IDictionary<IDockable, object> TabRootControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> DocumentControls { get; }
 
     /// <inheritdoc/>
     public override IList<IDockControl> DockControls { get; }

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -25,6 +25,8 @@ public class Factory : FactoryBase
         VisibleRootControls = new Dictionary<IDockable, object>();
         PinnedRootControls = new Dictionary<IDockable, object>();
         TabRootControls = new Dictionary<IDockable, object>();
+        ToolControls = new Dictionary<IDockable, object>();
+        DocumentControls = new Dictionary<IDockable, object>();
         DockControls = new ObservableCollection<IDockControl>();
         HostWindows = new ObservableCollection<IHostWindow>();
     }
@@ -46,6 +48,12 @@ public class Factory : FactoryBase
 
     /// <inheritdoc/>
     public override IDictionary<IDockable, object> TabRootControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <inheritdoc/>
+    public override IDictionary<IDockable, object> DocumentControls { get; }
 
     /// <inheritdoc/>
     public override IList<IDockControl> DockControls { get; }

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -42,6 +42,16 @@ public partial interface IFactory
     IDictionary<IDockable, object> TabRootControls { get; }
 
     /// <summary>
+    /// Gets tool controls.
+    /// </summary>
+    IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <summary>
+    /// Gets document controls.
+    /// </summary>
+    IDictionary<IDockable, object> DocumentControls { get; }
+
+    /// <summary>
     /// Gets dock controls.
     /// </summary>
     IList<IDockControl> DockControls { get; }

--- a/src/Dock.Model/FactoryBase.Controls.cs
+++ b/src/Dock.Model/FactoryBase.Controls.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Collections.Generic;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model;
+
+/// <summary>
+/// Factory base class.
+/// </summary>
+public abstract partial class FactoryBase
+{
+    /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> ToolControls { get; }
+
+    /// <inheritdoc/>
+    public abstract IDictionary<IDockable, object> DocumentControls { get; }
+}


### PR DESCRIPTION
## Summary
- expose ToolControls and DocumentControls dictionaries on IFactory
- implement them in Factory classes
- register ToolContentControl and DocumentContentControl with the factory

## Testing
- `DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release -f net6.0`

------
https://chatgpt.com/codex/tasks/task_e_68665743929c8321a75627f15b22744c