### PR TITLE
Add root docking indicators

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTarget.axaml
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml
@@ -44,6 +44,14 @@
               <Image x:Name="PART_CenterSelector" Grid.Row="1" Grid.Column="1" />
             </Grid>
           </Panel>
+          <Image x:Name="PART_RootTopSelector" VerticalAlignment="Top" HorizontalAlignment="Center" />
+          <Image x:Name="PART_RootBottomSelector" VerticalAlignment="Bottom" HorizontalAlignment="Center" />
+          <Image x:Name="PART_RootLeftSelector" VerticalAlignment="Center" HorizontalAlignment="Left" />
+          <Image x:Name="PART_RootRightSelector" VerticalAlignment="Center" HorizontalAlignment="Right" />
+          <Panel x:Name="PART_RootTopIndicator" VerticalAlignment="Top" HorizontalAlignment="Stretch" Height="40" />
+          <Panel x:Name="PART_RootBottomIndicator" VerticalAlignment="Bottom" HorizontalAlignment="Stretch" Height="40" />
+          <Panel x:Name="PART_RootLeftIndicator" HorizontalAlignment="Left" VerticalAlignment="Stretch" Width="40" />
+          <Panel x:Name="PART_RootRightIndicator" HorizontalAlignment="Right" VerticalAlignment="Stretch" Width="40" />
         </Grid>
       </ControlTemplate>
     </Setter>
@@ -106,6 +114,50 @@
       <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockDocumentInside.png" />
       <Setter Property="Width" Value="40" />
       <Setter Property="Height" Value="40" />
+    </Style>
+
+    <Style Selector="^/template/ Image#PART_RootTopSelector">
+      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableTop.png" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+    </Style>
+
+    <Style Selector="^/template/ Image#PART_RootBottomSelector">
+      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableBottom.png" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+    </Style>
+
+    <Style Selector="^/template/ Image#PART_RootLeftSelector">
+      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableLeft.png" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+    </Style>
+
+    <Style Selector="^/template/ Image#PART_RootRightSelector">
+      <Setter Property="Source" Value="avares://Dock.Avalonia/Assets/DockAnchorableRight.png" />
+      <Setter Property="Width" Value="40" />
+      <Setter Property="Height" Value="40" />
+    </Style>
+
+    <Style Selector="^/template/ Panel#PART_RootTopIndicator">
+      <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+
+    <Style Selector="^/template/ Panel#PART_RootBottomIndicator">
+      <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+
+    <Style Selector="^/template/ Panel#PART_RootLeftIndicator">
+      <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
+      <Setter Property="Opacity" Value="0" />
+    </Style>
+
+    <Style Selector="^/template/ Panel#PART_RootRightIndicator">
+      <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushIndicator}" />
+      <Setter Property="Opacity" Value="0" />
     </Style>
 
   </ControlTheme>

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -20,11 +20,24 @@ public class DockTarget : TemplatedControl
     private Panel? _leftIndicator;
     private Panel? _rightIndicator;
     private Panel? _centerIndicator;
+    private Panel? _rootTopIndicator;
+    private Panel? _rootBottomIndicator;
+    private Panel? _rootLeftIndicator;
+    private Panel? _rootRightIndicator;
     private Control? _topSelector;
     private Control? _bottomSelector;
     private Control? _leftSelector;
     private Control? _rightSelector;
     private Control? _centerSelector;
+    private Control? _rootTopSelector;
+    private Control? _rootBottomSelector;
+    private Control? _rootLeftSelector;
+    private Control? _rootRightSelector;
+    private Grid? _indicatorGrid;
+
+    public Rect RootBounds { get; set; }
+
+    public Rect PlacementBounds { get; set; }
 
     /// <inheritdoc/>
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -36,12 +49,34 @@ public class DockTarget : TemplatedControl
         _leftIndicator = e.NameScope.Find<Panel>("PART_LeftIndicator");
         _rightIndicator = e.NameScope.Find<Panel>("PART_RightIndicator");
         _centerIndicator = e.NameScope.Find<Panel>("PART_CenterIndicator");
+        _rootTopIndicator = e.NameScope.Find<Panel>("PART_RootTopIndicator");
+        _rootBottomIndicator = e.NameScope.Find<Panel>("PART_RootBottomIndicator");
+        _rootLeftIndicator = e.NameScope.Find<Panel>("PART_RootLeftIndicator");
+        _rootRightIndicator = e.NameScope.Find<Panel>("PART_RootRightIndicator");
 
         _topSelector = e.NameScope.Find<Control>("PART_TopSelector");
         _bottomSelector = e.NameScope.Find<Control>("PART_BottomSelector");
         _leftSelector = e.NameScope.Find<Control>("PART_LeftSelector");
         _rightSelector = e.NameScope.Find<Control>("PART_RightSelector");
         _centerSelector = e.NameScope.Find<Control>("PART_CenterSelector");
+        _rootTopSelector = e.NameScope.Find<Control>("PART_RootTopSelector");
+        _rootBottomSelector = e.NameScope.Find<Control>("PART_RootBottomSelector");
+        _rootLeftSelector = e.NameScope.Find<Control>("PART_RootLeftSelector");
+        _rootRightSelector = e.NameScope.Find<Control>("PART_RootRightSelector");
+        _indicatorGrid = e.NameScope.Find<Grid>("PART_IndicatorGrid");
+        UpdatePlacement();
+    }
+
+    internal void UpdatePlacement()
+    {
+        if (_indicatorGrid is { })
+        {
+            var left = PlacementBounds.X;
+            var top = PlacementBounds.Y;
+            var right = RootBounds.Width - PlacementBounds.Right;
+            var bottom = RootBounds.Height - PlacementBounds.Bottom;
+            _indicatorGrid.Margin = new Thickness(left, top, right, bottom);
+        }
     }
 
     internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction, Func<Point, DockOperation, DragAction, Visual, bool> validate)
@@ -71,6 +106,26 @@ public class DockTarget : TemplatedControl
         if (InvalidateIndicator(_centerSelector, _centerIndicator, point, relativeTo, DockOperation.Fill, dragAction, validate))
         {
             result = DockOperation.Fill;
+        }
+
+        if (InvalidateIndicator(_rootLeftSelector, _rootLeftIndicator, point, relativeTo, DockOperation.RootLeft, dragAction, validate))
+        {
+            result = DockOperation.RootLeft;
+        }
+
+        if (InvalidateIndicator(_rootRightSelector, _rootRightIndicator, point, relativeTo, DockOperation.RootRight, dragAction, validate))
+        {
+            result = DockOperation.RootRight;
+        }
+
+        if (InvalidateIndicator(_rootTopSelector, _rootTopIndicator, point, relativeTo, DockOperation.RootTop, dragAction, validate))
+        {
+            result = DockOperation.RootTop;
+        }
+
+        if (InvalidateIndicator(_rootBottomSelector, _rootBottomIndicator, point, relativeTo, DockOperation.RootBottom, dragAction, validate))
+        {
+            result = DockOperation.RootBottom;
         }
 
         return result;

--- a/src/Dock.Avalonia/Controls/RootDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/RootDockControl.axaml
@@ -16,7 +16,8 @@
       <ControlTemplate>
         <DockableControl TrackingMode="Visible">
           <DockPanel Background="Transparent"
-                     DockProperties.IsDropArea="False">
+                     DockProperties.IsDropArea="True"
+                     DockProperties.IsDockTarget="True">
             <ToolPinnedControl DockPanel.Dock="Left" 
                                Orientation="Vertical"
                                Items="{Binding LeftPinnedDockables}"

--- a/src/Dock.Avalonia/Internal/AdornerHelper.cs
+++ b/src/Dock.Avalonia/Internal/AdornerHelper.cs
@@ -15,39 +15,44 @@ internal class AdornerHelper
 
     public void AddAdorner(Visual visual)
     {
-        var layer = AdornerLayer.GetAdornerLayer(visual);
+        var root = DockHelpers.FindRootDockControl(visual) ?? visual.GetVisualRoot() as Visual ?? visual;
+        var layer = AdornerLayer.GetAdornerLayer(root);
         if (layer is null)
         {
             return;
         }
-            
+
         if (Adorner is { })
         {
             layer.Children.Remove(Adorner);
             Adorner = null;
         }
 
+        var rootBounds = root.Bounds;
+        var origin = visual.TranslatePoint(new Point(0, 0), root) ?? default;
+        var placement = new Rect(origin, visual.Bounds.Size);
+
         Adorner = new DockTarget
         {
-            [AdornerLayer.AdornedElementProperty] = visual,
+            RootBounds = rootBounds,
+            PlacementBounds = placement,
+            [AdornerLayer.AdornedElementProperty] = root,
         };
 
-        ((ISetLogicalParent) Adorner).SetParent(visual as ILogical);
+        ((ISetLogicalParent)Adorner).SetParent(root as ILogical);
 
         layer.Children.Add(Adorner);
     }
 
     public void RemoveAdorner(Visual visual)
     {
-        var layer = AdornerLayer.GetAdornerLayer(visual);
-        if (layer is { })
+        var root = DockHelpers.FindRootDockControl(visual) ?? visual.GetVisualRoot() as Visual ?? visual;
+        var layer = AdornerLayer.GetAdornerLayer(root);
+        if (layer is { } && Adorner is { })
         {
-            if (Adorner is { })
-            {
-                layer.Children.Remove(Adorner);
-                ((ISetLogicalParent) Adorner).SetParent(null);
-                Adorner = null;
-            }
+            layer.Children.Remove(Adorner);
+            ((ISetLogicalParent)Adorner).SetParent(null);
+            Adorner = null;
         }
     }
 }

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -126,7 +126,15 @@ internal class DockControlState : IDockControlState
             var screenPoint = relativeTo.PointToScreen(point).ToPoint(1.0);
             DockManager.ScreenPosition = DockHelpers.ToDockPoint(screenPoint);
 
-            return DockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, bExecute: false);
+            var target = targetDockable;
+            if ((operation == DockOperation.RootLeft || operation == DockOperation.RootRight ||
+                 operation == DockOperation.RootTop || operation == DockOperation.RootBottom) &&
+                targetDockable.Factory is { } factory)
+            {
+                target = factory.FindRoot(targetDockable, _ => true) ?? targetDockable;
+            }
+
+            return DockManager.ValidateDockable(sourceDockable, target, dragAction, operation, bExecute: false);
         }
 
         return false;
@@ -165,7 +173,15 @@ internal class DockControlState : IDockControlState
             var relativePoint = relativeTo.PointToScreen(point).ToPoint(1.0);
             DockManager.ScreenPosition = DockHelpers.ToDockPoint(relativePoint);
 
-            DockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, true);
+            var target = targetDockable;
+            if ((operation == DockOperation.RootLeft || operation == DockOperation.RootRight ||
+                 operation == DockOperation.RootTop || operation == DockOperation.RootBottom) &&
+                targetDockable.Factory is { } factory)
+            {
+                target = factory.FindRoot(targetDockable, _ => true) ?? targetDockable;
+            }
+
+            DockManager.ValidateDockable(sourceDockable, target, dragAction, operation, true);
         }
     }
 

--- a/src/Dock.Avalonia/Internal/DockHelpers.cs
+++ b/src/Dock.Avalonia/Internal/DockHelpers.cs
@@ -8,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.VisualTree;
+using Dock.Avalonia.Controls;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 
@@ -81,5 +82,21 @@ internal static class DockHelpers
                 }
             }
         }
+    }
+
+    public static RootDockControl? FindRootDockControl(Visual? visual)
+    {
+        var current = visual;
+        while (current is { })
+        {
+            if (current is RootDockControl rootDock)
+            {
+                return rootDock;
+            }
+
+            current = current.GetVisualParent();
+        }
+
+        return null;
     }
 }

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -133,8 +133,16 @@ internal class HostWindowState : IHostWindowState
             }
             var screenPoint = relativeTo.PointToScreen(point).ToPoint(1.0);
             DockManager.ScreenPosition = DockHelpers.ToDockPoint(screenPoint);
-                
-            return DockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, bExecute: false);
+
+            var target = targetDockable;
+            if ((operation == DockOperation.RootLeft || operation == DockOperation.RootRight ||
+                 operation == DockOperation.RootTop || operation == DockOperation.RootBottom) &&
+                targetDockable.Factory is { } factory)
+            {
+                target = factory.FindRoot(targetDockable, _ => true) ?? targetDockable;
+            }
+
+            return DockManager.ValidateDockable(sourceDockable, target, dragAction, operation, bExecute: false);
         }
 
         return false;
@@ -160,7 +168,15 @@ internal class HostWindowState : IHostWindowState
             var screenPoint = relativeTo.PointToScreen(point).ToPoint(1.0);
             DockManager.ScreenPosition = DockHelpers.ToDockPoint(screenPoint);
 
-            DockManager.ValidateDockable(sourceDockable, targetDockable, dragAction, operation, bExecute: true);
+            var target = targetDockable;
+            if ((operation == DockOperation.RootLeft || operation == DockOperation.RootRight ||
+                 operation == DockOperation.RootTop || operation == DockOperation.RootBottom) &&
+                targetDockable.Factory is { } factory)
+            {
+                target = factory.FindRoot(targetDockable, _ => true) ?? targetDockable;
+            }
+
+            DockManager.ValidateDockable(sourceDockable, target, dragAction, operation, bExecute: true);
         }
     }
 

--- a/src/Dock.Model/Core/DockOperation.cs
+++ b/src/Dock.Model/Core/DockOperation.cs
@@ -36,5 +36,25 @@ public enum DockOperation
     /// <summary>
     /// Dock to window.
     /// </summary>
-    Window
+    Window,
+
+    /// <summary>
+    /// Dock to root left.
+    /// </summary>
+    RootLeft,
+
+    /// <summary>
+    /// Dock to root bottom.
+    /// </summary>
+    RootBottom,
+
+    /// <summary>
+    /// Dock to root right.
+    /// </summary>
+    RootRight,
+
+    /// <summary>
+    /// Dock to root top.
+    /// </summary>
+    RootTop
 }

--- a/src/Dock.Model/Core/DockOperationExtensions.cs
+++ b/src/Dock.Model/Core/DockOperationExtensions.cs
@@ -12,7 +12,31 @@ internal static class DockOperationExtensions
             DockOperation.Bottom => Alignment.Bottom,
             DockOperation.Right => Alignment.Right,
             DockOperation.Top => Alignment.Top,
+            DockOperation.RootLeft => Alignment.Left,
+            DockOperation.RootBottom => Alignment.Bottom,
+            DockOperation.RootRight => Alignment.Right,
+            DockOperation.RootTop => Alignment.Top,
             _ => Alignment.Unset
         };
+    }
+
+    public static DockOperation WithoutRoot(this DockOperation operation)
+    {
+        return operation switch
+        {
+            DockOperation.RootLeft => DockOperation.Left,
+            DockOperation.RootRight => DockOperation.Right,
+            DockOperation.RootTop => DockOperation.Top,
+            DockOperation.RootBottom => DockOperation.Bottom,
+            _ => operation
+        };
+    }
+
+    public static bool IsRootOperation(this DockOperation operation)
+    {
+        return operation is DockOperation.RootLeft
+            or DockOperation.RootRight
+            or DockOperation.RootTop
+            or DockOperation.RootBottom;
     }
 }

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -299,14 +299,23 @@ public class DockManager : IDockManager
 
     private bool DockDockable(IDockable sourceDockable, IDock sourceDockableOwner, IDock targetDock, DockOperation operation, bool bExecute)
     {
-        return operation switch
+        var dock = targetDock;
+        var op = operation;
+
+        if (operation.IsRootOperation() && targetDock is IRootDock rootDock && rootDock.ActiveDockable is IDock active)
         {
-            DockOperation.Fill => MoveDockable(sourceDockable, sourceDockableOwner, targetDock, bExecute),
-            DockOperation.Left => SplitDockable(sourceDockable, sourceDockableOwner, targetDock, operation, bExecute),
-            DockOperation.Right => SplitDockable(sourceDockable, sourceDockableOwner, targetDock, operation, bExecute),
-            DockOperation.Top => SplitDockable(sourceDockable, sourceDockableOwner, targetDock, operation, bExecute),
-            DockOperation.Bottom => SplitDockable(sourceDockable, sourceDockableOwner, targetDock, operation, bExecute),
-            DockOperation.Window => DockDockableIntoWindow(sourceDockable, targetDock, bExecute),
+            dock = active;
+            op = operation.WithoutRoot();
+        }
+
+        return op switch
+        {
+            DockOperation.Fill => MoveDockable(sourceDockable, sourceDockableOwner, dock, bExecute),
+            DockOperation.Left => SplitDockable(sourceDockable, sourceDockableOwner, dock, op, bExecute),
+            DockOperation.Right => SplitDockable(sourceDockable, sourceDockableOwner, dock, op, bExecute),
+            DockOperation.Top => SplitDockable(sourceDockable, sourceDockableOwner, dock, op, bExecute),
+            DockOperation.Bottom => SplitDockable(sourceDockable, sourceDockableOwner, dock, op, bExecute),
+            DockOperation.Window => DockDockableIntoWindow(sourceDockable, dock, bExecute),
             _ => false
         };
     }


### PR DESCRIPTION
## Summary
- adjust `DockTarget` to position selectors using root bounds
- attach dock adorners to the root control and track placement
- direct root docking operations to the root dock
- ensure adorner helper finds the first root dock control
- handle root dock split operations

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686648c32ae08321982f5ea026d50a50