### PR TITLE
Fix drop on empty tab strip area

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -77,6 +77,12 @@ internal class DockControlState : IDockControlState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+
+            if (operation == DockOperation.Window &&
+                Validate(point, DockOperation.Fill, dragAction, relativeTo))
+            {
+                operation = DockOperation.Fill;
+            }
         }
 
         Validate(point, operation, dragAction, relativeTo);
@@ -89,6 +95,12 @@ internal class DockControlState : IDockControlState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+
+            if (operation == DockOperation.Window &&
+                Validate(point, DockOperation.Fill, dragAction, relativeTo))
+            {
+                operation = DockOperation.Fill;
+            }
         }
         else if (!Validate(point, operation, dragAction, relativeTo))
         {

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -360,6 +360,13 @@ internal class DockControlState : IDockControlState
                                 ? target.GetDockOperation(targetPoint, targetDockControl, dragAction, Validate)
                                 : DockOperation.Fill;
 
+                            if (_adornerHelper.Adorner is DockTarget &&
+                                operation == DockOperation.Window &&
+                                Validate(targetPoint, DockOperation.Fill, dragAction, targetDockControl))
+                            {
+                                operation = DockOperation.Fill;
+                            }
+
                             var valid = Validate(targetPoint, operation, dragAction, targetDockControl);
                             preview = valid
                                 ? operation == DockOperation.Window ? "Float" : "Dock"

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -84,11 +84,15 @@ internal class DockControlState : IDockControlState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Window;
+        var operation = DockOperation.Fill;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+        }
+        else if (!Validate(point, operation, dragAction, relativeTo))
+        {
+            operation = DockOperation.Window;
         }
 
         if (_state.DropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.VisualTree;
 using Dock.Avalonia.Controls;
 using Dock.Model.Core;
@@ -77,12 +78,13 @@ internal class DockControlState : IDockControlState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+        }
 
-            if (operation == DockOperation.Window &&
-                Validate(point, DockOperation.Fill, dragAction, relativeTo))
-            {
-                operation = DockOperation.Fill;
-            }
+        if (_state.DropControl is TabStrip &&
+            operation == DockOperation.Window &&
+            Validate(point, DockOperation.Fill, dragAction, relativeTo))
+        {
+            operation = DockOperation.Fill;
         }
 
         Validate(point, operation, dragAction, relativeTo);
@@ -90,21 +92,17 @@ internal class DockControlState : IDockControlState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Fill;
+        var operation = DockOperation.Window;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
-
-            if (operation == DockOperation.Window &&
-                Validate(point, DockOperation.Fill, dragAction, relativeTo))
-            {
-                operation = DockOperation.Fill;
-            }
         }
-        else if (!Validate(point, operation, dragAction, relativeTo))
+
+        if (_state.DropControl is TabStrip &&
+            Validate(point, DockOperation.Fill, dragAction, relativeTo))
         {
-            operation = DockOperation.Window;
+            operation = DockOperation.Fill;
         }
 
         if (_state.DropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
@@ -360,7 +358,7 @@ internal class DockControlState : IDockControlState
                                 ? target.GetDockOperation(targetPoint, targetDockControl, dragAction, Validate)
                                 : DockOperation.Fill;
 
-                            if (_adornerHelper.Adorner is DockTarget &&
+                            if (_state.DropControl is TabStrip &&
                                 operation == DockOperation.Window &&
                                 Validate(targetPoint, DockOperation.Fill, dragAction, targetDockControl))
                             {

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -78,6 +78,12 @@ internal class HostWindowState : IHostWindowState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+
+            if (operation == DockOperation.Window &&
+                Validate(point, DockOperation.Fill, dragAction, relativeTo))
+            {
+                operation = DockOperation.Fill;
+            }
         }
 
         if (operation != DockOperation.Window)
@@ -93,6 +99,12 @@ internal class HostWindowState : IHostWindowState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+
+            if (operation == DockOperation.Window &&
+                Validate(point, DockOperation.Fill, dragAction, relativeTo))
+            {
+                operation = DockOperation.Fill;
+            }
         }
         else if (!Validate(point, operation, dragAction, relativeTo))
         {

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -3,6 +3,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.VisualTree;
 using Dock.Avalonia.Controls;
 using Dock.Model.Core;
@@ -78,12 +79,13 @@ internal class HostWindowState : IHostWindowState
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+        }
 
-            if (operation == DockOperation.Window &&
-                Validate(point, DockOperation.Fill, dragAction, relativeTo))
-            {
-                operation = DockOperation.Fill;
-            }
+        if (_state.TargetDropControl is TabStrip &&
+            operation == DockOperation.Window &&
+            Validate(point, DockOperation.Fill, dragAction, relativeTo))
+        {
+            operation = DockOperation.Fill;
         }
 
         if (operation != DockOperation.Window)
@@ -94,21 +96,17 @@ internal class HostWindowState : IHostWindowState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Fill;
+        var operation = DockOperation.Window;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
-
-            if (operation == DockOperation.Window &&
-                Validate(point, DockOperation.Fill, dragAction, relativeTo))
-            {
-                operation = DockOperation.Fill;
-            }
         }
-        else if (!Validate(point, operation, dragAction, relativeTo))
+
+        if (_state.TargetDropControl is TabStrip &&
+            Validate(point, DockOperation.Fill, dragAction, relativeTo))
         {
-            operation = DockOperation.Window;
+            operation = DockOperation.Fill;
         }
 
         if (_state.TargetDropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
@@ -116,7 +114,10 @@ internal class HostWindowState : IHostWindowState
             _adornerHelper.RemoveAdorner(control);
         }
 
-        Execute(point, operation, dragAction, relativeTo);
+        if (operation != DockOperation.Window)
+        {
+            Execute(point, operation, dragAction, relativeTo);
+        }
     }
 
     private void Leave()

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -88,11 +88,15 @@ internal class HostWindowState : IHostWindowState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Window;
+        var operation = DockOperation.Fill;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {
             operation = target.GetDockOperation(point, relativeTo, dragAction, Validate);
+        }
+        else if (!Validate(point, operation, dragAction, relativeTo))
+        {
+            operation = DockOperation.Window;
         }
 
         if (_state.TargetDropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
@@ -100,10 +104,7 @@ internal class HostWindowState : IHostWindowState
             _adornerHelper.RemoveAdorner(control);
         }
 
-        if (operation != DockOperation.Window)
-        {
-            Execute(point, operation, dragAction, relativeTo);
-        }
+        Execute(point, operation, dragAction, relativeTo);
     }
 
     private void Leave()


### PR DESCRIPTION
## Summary
- fix dropping on empty tab strip so the document/tool docks instead of floating

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68666c4d009083219649d1c3c209ed89