### PR TITLE
Add drop area region to tab strips

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -63,6 +63,8 @@
           </Button>
           <ItemsPresenter x:Name="PART_ItemsPresenter"
                           ItemsPanel="{TemplateBinding ItemsPanel}" />
+          <Border Name="PART_BorderFill"
+                  DockProperties.IsDropArea="True" />
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
@@ -36,7 +36,8 @@
             <ItemsPresenter Name="PART_ItemsPresenter"
                             ItemsPanel="{TemplateBinding ItemsPanel}"/>
           </Border>
-          <Border Name="PART_BorderFill" />
+          <Border Name="PART_BorderFill"
+                 DockProperties.IsDropArea="True" />
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -84,7 +84,7 @@ internal class DockControlState : IDockControlState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Window;
+        var operation = DockOperation.Fill;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -88,7 +88,7 @@ internal class HostWindowState : IHostWindowState
 
     private void Drop(Point point, DragAction dragAction, Visual relativeTo)
     {
-        var operation = DockOperation.Window;
+        var operation = DockOperation.Fill;
 
         if (_adornerHelper.Adorner is DockTarget target)
         {


### PR DESCRIPTION
## Summary
- revert previous tab strip fallback logic
- add invisible drop area inside ToolTabStrip and DocumentTabStrip templates
- ensure dropping on empty tab strips docks by default

## Testing
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68666c4d009083219649d1c3c209ed89