### PR TITLE
Update docs for document tab layout

### DIFF
--- a/docs/dock-advanced.md
+++ b/docs/dock-advanced.md
@@ -104,7 +104,10 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
     window.Height = 600;
     return window;
 }
+
 ```
+
+If `EnableWindowDrag` on a `DocumentDock` is set to `true`, the tab strip doubles as a drag handle for the entire window. This lets users reposition floating windows by dragging the tabs themselves.
 
 ## Tracking bounds
 

--- a/docs/dock-enums.md
+++ b/docs/dock-enums.md
@@ -48,6 +48,16 @@ Controls whether a proportional dock arranges its children horizontally or verti
 | `Horizontal` | Children are stacked from left to right. |
 | `Vertical` | Children are stacked from top to bottom. |
 
+## DocumentTabLayout
+
+Controls where document tabs are placed around a document dock. Setting this affects both orientation and docking position of the tab strip.
+
+| Value | Description |
+| ----- | ----------- |
+| `Top` | Tabs are shown above the document content. |
+| `Left` | Tabs are arranged vertically to the left. |
+| `Right` | Tabs are arranged vertically to the right. |
+
 ## GripMode
 
 Determines how the grip element of a splitter behaves.

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -38,6 +38,12 @@ The adapter starts with `NaN` coordinates until a value is set.
 These values are consulted when calculating drop targets or restoring a layout
 from a saved state.
 
+## Document dock options
+
+`IDocumentDock` exposes two key properties for controlling its tab strip. `EnableWindowDrag` allows the entire window to be dragged via the tab area. `TabsLayout` chooses where the tabs appear using the `DocumentTabLayout` enum.
+
+The factory provides helper methods `SetDocumentDockTabsLayoutLeft`, `SetDocumentDockTabsLayoutTop` and `SetDocumentDockTabsLayoutRight` to change the layout at runtime.
+
 ## Factory API
 
 The `IFactory` interface (implemented by `Factory` in `Dock.Model.Mvvm` and `Dock.Model.ReactiveUI`) contains numerous helpers used by the samples to build and manipulate layouts. Important members include:


### PR DESCRIPTION
## Summary
- document the new `EnableWindowDrag` and `TabsLayout` features
- add `DocumentTabLayout` enum to the enumeration guide
- mention window dragging via tab strip in advanced guide

## Testing
- `./build.sh --target Test --configuration Release` *(fails: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6866df4db5988321b4925df62b45d4fc