### PR TITLE
Add tracking controls documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ guides under *Getting started*.
 - [Dockable property settings](dock-dockable-properties.md) – Configure per item behaviour.
 - [Markup extensions](dock-markup-extensions.md) – Load and reference XAML fragments.
 - [Adapter classes](dock-adapters.md) – Host, navigation and tracking helpers.
+- [Tracking controls](dock-tracking-controls.md) – Collections that map dockables to their visuals.
 - [Enumerations](dock-enums.md) – Values used by Dock APIs.
 - [Dock settings](dock-settings.md) – Global drag/drop options and thresholds.
 

--- a/docs/dock-tracking-controls.md
+++ b/docs/dock-tracking-controls.md
@@ -1,0 +1,38 @@
+# Dock Tracking Controls
+
+Dock tracks the UI elements that represent each dockable at runtime.  The `IFactory` interface exposes several collections so applications can look up or manage these controls when they need to manipulate the visual tree directly.
+
+## Why controls are tracked
+
+Dock layouts are described using view models but the framework also creates visual controls for each dockable, window and host.  When advanced scenarios require accessing these visuals—such as customizing the appearance of a tab strip or integrating with a platform windowing API—the factory needs to know which control belongs to which dockable.  The tracking collections provide this mapping.
+
+## Tracking collections
+
+The following properties on `IFactory` keep track of runtime controls.  Each dictionary uses the dockable as the key so it is easy to locate the corresponding control.
+
+| Property | Description |
+| -------- | ----------- |
+| `VisibleDockableControls` | Mapping of visible dockables to their controls inside a dock. |
+| `VisibleRootControls` | Mapping of root dockables to the control hosting them, typically a window. |
+| `PinnedDockableControls` | Controls for dockables that are currently pinned. |
+| `PinnedRootControls` | Root controls for pinned dockables. |
+| `TabDockableControls` | Controls displayed in a tab strip. |
+| `TabRootControls` | Root controls for dockables in tab strips. |
+| `ToolControls` | Lookup for controls that present tools. |
+| `DocumentControls` | Lookup for controls that present documents. |
+| `DockControls` | List of `DockControl` instances displaying layouts. |
+| `HostWindows` | List of floating windows created by the factory. |
+
+These collections are populated automatically by `FactoryBase` when layouts are initialised.  They can be inspected or modified at runtime if you create custom host controls or windows.
+
+## Typical usage
+
+Most applications rely on these collections indirectly via the factory helpers.  For example `ShowWindows` iterates `HostWindows` to open any floating tools and documents.  You can also retrieve a specific control:
+
+```csharp
+var documentControl = factory.VisibleDockableControls[myDocument];
+```
+
+When implementing your own visuals or integrating with other frameworks, update the dictionaries accordingly when controls are created or destroyed.  Removing entries prevents stale references after dockables are closed.
+
+For an overview of all guides see the [documentation index](README.md).


### PR DESCRIPTION
## Summary
- document tracking dictionaries exposed by `IFactory`
- add new guide to the docs index

## Testing
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -c Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686788a7639c8321abb01f6486c26c32