### PR TITLE
Add host window locator docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ guides under *Getting started*.
 - [Proportional StackPanel](dock-proportional-stackpanel.md) – Layout panel with adjustable proportions.
 - [Sizing guide](dock-sizing.md) – Control pixel sizes and fixed dimensions.
 - [Floating windows](dock-windows.md) – Detach dockables into separate windows.
+- [Host window locators](dock-host-window-locator.md) – Provide platform windows for floating docks.
 - [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
 
 ## Reference

--- a/docs/dock-host-window-locator.md
+++ b/docs/dock-host-window-locator.md
@@ -1,0 +1,58 @@
+# Host Window Locators
+
+Dock can display floating windows when a dockable is detached from the main layout.
+`IFactory` uses *host window locators* to supply the platform window objects
+that wrap these floating docks. This guide explains how the `HostWindowLocator`
+and `DefaultHostWindowLocator` properties work and shows typical usage patterns.
+
+## Why locators are required
+
+The `HostAdapter` component bridges an `IDockWindow` with an `IHostWindow`
+implementation. When a dockable is floated the adapter queries the factory using
+`GetHostWindow` to obtain the actual host window instance. Without a locator the
+factory cannot create platform windows and floating docks will fail to appear.
+
+Registering locators also allows you to integrate dependency injection or apply
+platform specific customisation when new windows are created.
+
+## Providing host windows
+
+`HostWindowLocator` is a dictionary mapping string keys to functions that return
+an `IHostWindow`. When `GetHostWindow` is called with a key, the factory invokes
+the matching function. A common setup registers a default entry for
+`IDockWindow`:
+
+```csharp
+HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
+{
+    [nameof(IDockWindow)] = () => new HostWindow()
+};
+```
+
+When different window styles are required, add additional keys and choose which
+one to pass to `GetHostWindow`.
+
+## Fallback locator
+
+If no entry matches the provided key, `GetHostWindow` calls
+`DefaultHostWindowLocator`. Set this delegate to return a generic host window
+when the dictionary does not contain a specific mapping:
+
+```csharp
+DefaultHostWindowLocator = () => new HostWindow();
+```
+
+The fallback ensures floating windows still open even if a key is missing.
+
+## Recommended setup
+
+1. Populate `HostWindowLocator` inside `InitLayout` or during application
+   startup.
+2. Provide a `DefaultHostWindowLocator` so floating windows always have a host.
+3. Call `GetHostWindow(id)` from custom code or rely on `HostAdapter`, which
+   invokes it automatically when presenting windows.
+
+Using locators in this way keeps window creation centralized in the factory and
+makes it easy to customise the hosting behaviour.
+
+For further details on floating windows see the [Floating windows guide](dock-windows.md).


### PR DESCRIPTION
## Summary
- add a new guide about HostWindowLocator and DefaultHostWindowLocator usage
- link the guide from the docs index

## Testing
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_686788e228208321875fdae7f839fba2