### PR TITLE
Implement Notepad menu commands

### DIFF
--- a/samples/Notepad/ViewModels/Documents/FileViewModel.cs
+++ b/samples/Notepad/ViewModels/Documents/FileViewModel.cs
@@ -1,4 +1,6 @@
 ﻿using Dock.Model.Mvvm.Controls;
+using Avalonia.Media;
+using System.Collections.Generic;
 
 namespace Notepad.ViewModels.Documents;
 
@@ -7,6 +9,13 @@ public class FileViewModel : Document
     private string _path = string.Empty;
     private string _text = string.Empty;
     private string _encoding = string.Empty;
+    private int _selectionStart;
+    private int _selectionEnd;
+    private int _caretIndex;
+    private TextWrapping _textWrapping = TextWrapping.NoWrap;
+    private bool _showStatusBar = true;
+    private readonly Stack<string> _undoStack = new();
+    private FontFamily _fontFamily = new("Consolas");
 
     public string Path
     {
@@ -17,12 +26,63 @@ public class FileViewModel : Document
     public string Text
     {
         get => _text;
-        set => SetProperty(ref _text, value);
+        set
+        {
+            if (value != _text)
+            {
+                _undoStack.Push(_text);
+                SetProperty(ref _text, value);
+            }
+        }
     }
 
     public string Encoding
     {
         get => _encoding;
         set => SetProperty(ref _encoding, value);
+    }
+
+    public int SelectionStart
+    {
+        get => _selectionStart;
+        set => SetProperty(ref _selectionStart, value);
+    }
+
+    public int SelectionEnd
+    {
+        get => _selectionEnd;
+        set => SetProperty(ref _selectionEnd, value);
+    }
+
+    public int CaretIndex
+    {
+        get => _caretIndex;
+        set => SetProperty(ref _caretIndex, value);
+    }
+
+    public TextWrapping TextWrapping
+    {
+        get => _textWrapping;
+        set => SetProperty(ref _textWrapping, value);
+    }
+
+    public bool ShowStatusBar
+    {
+        get => _showStatusBar;
+        set => SetProperty(ref _showStatusBar, value);
+    }
+
+    public FontFamily FontFamily
+    {
+        get => _fontFamily;
+        set => SetProperty(ref _fontFamily, value);
+    }
+
+    public void Undo()
+    {
+        if (_undoStack.Count > 0)
+        {
+            Text = _undoStack.Pop();
+        }
     }
 }

--- a/samples/Notepad/ViewModels/MainWindowViewModel.cs
+++ b/samples/Notepad/ViewModels/MainWindowViewModel.cs
@@ -266,7 +266,10 @@ public class MainWindowViewModel : ObservableObject, IDropTarget
             if (length > 0)
             {
                 var text = file.Text.Substring(file.SelectionStart, length);
-                await Application.Current?.Clipboard.SetTextAsync(text)!;
+                if (GetWindow()?.Clipboard is { } clipboard)
+                {
+                    await clipboard.SetTextAsync(text);
+                }
                 file.Text = file.Text.Remove(file.SelectionStart, length);
                 file.SelectionEnd = file.SelectionStart;
                 file.CaretIndex = file.SelectionStart;
@@ -282,7 +285,10 @@ public class MainWindowViewModel : ObservableObject, IDropTarget
             if (length > 0)
             {
                 var text = file.Text.Substring(file.SelectionStart, length);
-                await Application.Current?.Clipboard.SetTextAsync(text)!;
+                if (GetWindow()?.Clipboard is { } clipboard)
+                {
+                    await clipboard.SetTextAsync(text);
+                }
             }
         }
     }
@@ -291,15 +297,18 @@ public class MainWindowViewModel : ObservableObject, IDropTarget
     {
         if (GetFileViewModel() is { } file)
         {
-            var text = await Application.Current?.Clipboard.GetTextAsync()!;
-            if (!string.IsNullOrEmpty(text))
+            if (GetWindow()?.Clipboard is { } clipboard)
             {
-                var start = file.SelectionStart;
-                var length = file.SelectionEnd - file.SelectionStart;
-                file.Text = file.Text.Remove(start, length).Insert(start, text);
-                file.SelectionStart = start + text.Length;
-                file.SelectionEnd = file.SelectionStart;
-                file.CaretIndex = file.SelectionStart;
+                var text = await clipboard.GetTextAsync();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    var start = file.SelectionStart;
+                    var length = file.SelectionEnd - file.SelectionStart;
+                    file.Text = file.Text.Remove(start, length).Insert(start, text);
+                    file.SelectionStart = start + text.Length;
+                    file.SelectionEnd = file.SelectionStart;
+                    file.CaretIndex = file.SelectionStart;
+                }
             }
         }
     }

--- a/samples/Notepad/ViewModels/Tools/FindViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/FindViewModel.cs
@@ -17,13 +17,30 @@ public class FindViewModel : Tool
 
     public void FindNext()
     {
+        if (string.IsNullOrEmpty(Find))
+        {
+            return;
+        }
+
         if (Context is IRootDock root && root.ActiveDockable is IDock active)
         {
-            if (active.Factory?.FindDockable(active, (d) => d.Id == "Files") is IDock files)
+            if (active.Factory?.FindDockable(active, d => d.Id == "Files") is IDock files)
             {
                 if (files.ActiveDockable is FileViewModel fileViewModel)
                 {
-                    // TODO: 
+                    var start = fileViewModel.SelectionEnd;
+                    if (start < 0 || start > fileViewModel.Text.Length)
+                    {
+                        start = 0;
+                    }
+
+                    var index = fileViewModel.Text.IndexOf(Find, start, StringComparison.CurrentCultureIgnoreCase);
+                    if (index >= 0)
+                    {
+                        fileViewModel.SelectionStart = index;
+                        fileViewModel.SelectionEnd = index + Find.Length;
+                        fileViewModel.CaretIndex = fileViewModel.SelectionEnd;
+                    }
                 }
             }
         }

--- a/samples/Notepad/ViewModels/Tools/FindViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/FindViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Dock.Model.Controls;
+using System;
 using Dock.Model.Core;
 using Dock.Model.Mvvm.Controls;
 using Notepad.ViewModels.Documents;

--- a/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Dock.Model.Controls;
+using System;
 using Dock.Model.Core;
 using Dock.Model.Mvvm.Controls;
 using Notepad.ViewModels.Documents;

--- a/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
+++ b/samples/Notepad/ViewModels/Tools/ReplaceViewModel.cs
@@ -24,13 +24,31 @@ public class ReplaceViewModel : Tool
 
     public void ReplaceNext()
     {
+        if (string.IsNullOrEmpty(Find))
+        {
+            return;
+        }
+
         if (Context is IRootDock root && root.ActiveDockable is IDock active)
         {
-            if (active.Factory?.FindDockable(active, (d) => d.Id == "Files") is IDock files)
+            if (active.Factory?.FindDockable(active, d => d.Id == "Files") is IDock files)
             {
                 if (files.ActiveDockable is FileViewModel fileViewModel)
                 {
-                    // TODO: 
+                    var start = fileViewModel.SelectionEnd;
+                    if (start < 0 || start > fileViewModel.Text.Length)
+                    {
+                        start = 0;
+                    }
+
+                    var index = fileViewModel.Text.IndexOf(Find, start, StringComparison.CurrentCultureIgnoreCase);
+                    if (index >= 0)
+                    {
+                        fileViewModel.Text = fileViewModel.Text.Remove(index, Find.Length).Insert(index, Replace);
+                        fileViewModel.SelectionStart = index;
+                        fileViewModel.SelectionEnd = index + Replace.Length;
+                        fileViewModel.CaretIndex = fileViewModel.SelectionEnd;
+                    }
                 }
             }
         }

--- a/samples/Notepad/Views/Documents/FileView.axaml
+++ b/samples/Notepad/Views/Documents/FileView.axaml
@@ -11,13 +11,16 @@
     <TextBox BorderThickness="0"
              AcceptsReturn="True"
              AcceptsTab="True"
-             FontFamily="Consolas, Inconsolata"
+             FontFamily="{Binding FontFamily}"
              FontWeight="Light"
              FontSize="14"
-             TextWrapping="NoWrap"
+             SelectionStart="{Binding SelectionStart, Mode=TwoWay}"
+             SelectionEnd="{Binding SelectionEnd, Mode=TwoWay}"
+             CaretIndex="{Binding CaretIndex, Mode=TwoWay}"
+             TextWrapping="{Binding TextWrapping}"
              Text="{Binding Text}"
              Grid.Row="0" />
-    <Grid ColumnDefinitions="*,Auto" Grid.Row="1">
+    <Grid ColumnDefinitions="*,Auto" Grid.Row="1" IsVisible="{Binding ShowStatusBar}">
       <TextBlock Text="{Binding Path}"
                  Margin="2"
                  VerticalAlignment="Center"

--- a/samples/Notepad/Views/MenuView.axaml
+++ b/samples/Notepad/Views/MenuView.axaml
@@ -17,31 +17,31 @@
       <MenuItem Header="E_xit" Command="{Binding FileExit}" />
     </MenuItem>
     <MenuItem Header="_Edit">
-      <MenuItem Header="_Undo" />
+      <MenuItem Header="_Undo" Command="{Binding EditUndo}" />
       <Separator />
-      <MenuItem Header="Cu_t" />
-      <MenuItem Header="_Copy" />
-      <MenuItem Header="_Paste" />
-      <MenuItem Header="_Delete" />
+      <MenuItem Header="Cu_t" Command="{Binding EditCut}" />
+      <MenuItem Header="_Copy" Command="{Binding EditCopy}" />
+      <MenuItem Header="_Paste" Command="{Binding EditPaste}" />
+      <MenuItem Header="_Delete" Command="{Binding EditDelete}" />
       <Separator />
-      <MenuItem Header="_Find..." />
-      <MenuItem Header="Find _Next" />
-      <MenuItem Header="_Replace..." />
+      <MenuItem Header="_Find..." Command="{Binding EditFind}" />
+      <MenuItem Header="Find _Next" Command="{Binding EditFindNext}" />
+      <MenuItem Header="_Replace..." Command="{Binding EditReplace}" />
       <MenuItem Header="_Go to..." />
       <Separator />
-      <MenuItem Header="Select _All" />
-      <MenuItem Header="_Time/date" />
+      <MenuItem Header="Select _All" Command="{Binding EditSelectAll}" />
+      <MenuItem Header="_Time/date" Command="{Binding EditTimeDate}" />
     </MenuItem>
     <MenuItem Header="_Format">
-      <MenuItem Header="_Wrap lines" />
-      <MenuItem Header="_Font..." />
+      <MenuItem Header="_Wrap lines" Command="{Binding EditWrapLines}" />
+      <MenuItem Header="_Font..." Command="{Binding FormatFont}" />
     </MenuItem>
     <MenuItem Header="_View">
-      <MenuItem Header="_Status bar" />
+      <MenuItem Header="_Status bar" Command="{Binding ViewStatusBar}" />
     </MenuItem>
     <MenuItem Header="_Help">
-      <MenuItem Header="Get _Help" />
-      <MenuItem Header="Notepad - _About" />
+      <MenuItem Header="Get _Help" Command="{Binding HelpGetHelp}" />
+      <MenuItem Header="Notepad - _About" Command="{Binding HelpAbout}" />
     </MenuItem>
   </Menu>
 </UserControl>


### PR DESCRIPTION
## Summary
- allow toggling wrap lines and status bar visibility
- add selection tracking in `FileViewModel`
- implement `FindNext` and `ReplaceNext`
- expose edit commands from `MainWindowViewModel`
- hook up menu items to new commands
- implement clipboard actions, font toggle, and help/about windows

## Testing
- `dotnet test` *(fails: invalid arguments)*


------
https://chatgpt.com/codex/tasks/task_e_686789f743988321beee6f7c86e07b25