### PR TITLE
Add additional dock panel controls

### DIFF
--- a/docs/dock-enums.md
+++ b/docs/dock-enums.md
@@ -48,6 +48,15 @@ Controls whether a proportional dock arranges its children horizontally or verti
 | `Horizontal` | Children are stacked from left to right. |
 | `Vertical` | Children are stacked from top to bottom. |
 
+## GridResizeDirection
+
+Specifies whether a grid splitter moves rows or columns.
+
+| Value | Description |
+| ----- | ----------- |
+| `Columns` | Resize grid columns. |
+| `Rows` | Resize grid rows. |
+
 ## DocumentTabLayout
 
 Controls where document tabs are placed around a document dock. Setting this affects both orientation and docking position of the tab strip.

--- a/docs/dock-model-controls.md
+++ b/docs/dock-model-controls.md
@@ -19,7 +19,12 @@ when creating your own docks and documents.
 | `IDocumentDockContent` | Dock that creates documents from a `DocumentTemplate`. |
 | `IDocumentTemplate` | Template object used when creating new documents on demand. |
 | `IProportionalDock` | Dock that arranges children vertically or horizontally using proportions. |
+| `IStackDock` | Dock based on `StackPanel` with `Orientation` and `Spacing`. |
+| `IGridDock` | Dock that uses `Grid` layout defined by `ColumnDefinitions` and `RowDefinitions`. |
+| `IWrapDock` | Dock built on `WrapPanel` exposing `Orientation`. |
+| `IUniformGridDock` | Dock with equally sized cells configured by `Rows` and `Columns`. |
 | `IProportionalDockSplitter` | Splitter element between proportional dock children. |
+| `IGridDockSplitter` | Splitter used inside a grid dock to resize rows or columns. |
 | `IRootDock` | Top level container responsible for pinned docks and windows. |
 | `ITool` | Basic interface for tool panes such as explorers or output views. |
 | `IToolContent` | Tool containing arbitrary `Content`. |

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -10,9 +10,14 @@ This reference summarizes the most commonly used classes in Dock. It is based on
 | `IDock` | Extends `IDockable` with collections of visible dockables and commands such as `GoBack`, `GoForward`, `Navigate` or `Close`. |
 | `IRootDock` | The top level container. In addition to the `IDock` members it exposes pinned dock collections and commands to manage windows. |
 | `IProportionalDock` | A dock that lays out its children horizontally or vertically using a `Proportion` value. |
+| `IStackDock` | Dock based on `StackPanel` with `Orientation` and `Spacing`. |
+| `IGridDock` | Dock using `Grid` layout via `ColumnDefinitions` and `RowDefinitions`. |
+| `IWrapDock` | Dock built on `WrapPanel` exposing `Orientation`. |
+| `IUniformGridDock` | Dock that arranges items in equally sized cells using `Rows` and `Columns`. |
 | `IToolDock` / `IDocumentDock` | Specialized docks used for tools and documents. |
 | `ITool` | Represents a tool pane. Tools can specify `MinWidth`, `MaxWidth`, `MinHeight` and `MaxHeight` to control their size. |
 | `IProportionalDockSplitter` | Thin splitter placed between proportional docks. Exposes `CanResize` to enable or disable dragging. |
+| `IGridDockSplitter` | Splitter for `IGridDock` controlling the resize direction. |
 | `IDockWindow` / `IHostWindow` | Interfaces representing floating windows created when dockables are detached. |
 
 ## Tracking bounds and pointer positions

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -27,6 +27,11 @@
             <DataTemplate DataType="dmc:IProportionalDockSplitter">
               <ProportionalStackPanelSplitter IsResizingEnabled="{Binding CanResize}" />
             </DataTemplate>
+            <DataTemplate DataType="dmc:IGridDockSplitter">
+              <GridSplitter Grid.Column="{Binding Column}"
+                            Grid.Row="{Binding Row}"
+                            ResizeDirection="{Binding ResizeDirection}" />
+            </DataTemplate>
             <DataTemplate DataType="dmc:IDocumentDock">
               <DocumentDockControl />
             </DataTemplate>

--- a/src/Dock.Avalonia/Controls/DockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml
@@ -36,6 +36,18 @@
             <DataTemplate DataType="dmc:IProportionalDock">
               <ProportionalDockControl />
             </DataTemplate>
+            <DataTemplate DataType="dmc:IStackDock">
+              <StackDockControl />
+            </DataTemplate>
+            <DataTemplate DataType="dmc:IGridDock">
+              <GridDockControl />
+            </DataTemplate>
+            <DataTemplate DataType="dmc:IWrapDock">
+              <WrapDockControl />
+            </DataTemplate>
+            <DataTemplate DataType="dmc:IUniformGridDock">
+              <UniformGridDockControl />
+            </DataTemplate>
             <DataTemplate DataType="dmc:IDockDock">
               <DockDockControl />
             </DataTemplate>

--- a/src/Dock.Avalonia/Controls/GridDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/GridDockControl.axaml
@@ -1,0 +1,40 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="using:Dock.Model.Controls"
+                    x:DataType="controls:IGridDock"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <GridDockControl Width="300" Height="300" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type GridDockControl}" TargetType="GridDockControl">
+
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockableControl TrackingMode="Visible">
+          <ItemsControl ItemsSource="{Binding VisibleDockables}">
+            <ItemsControl.Styles>
+              <Style Selector="ItemsControl > ContentPresenter">
+                <Setter Property="MinWidth" Value="{Binding MinWidth}" />
+                <Setter Property="MaxWidth" Value="{Binding MaxWidth}" />
+                <Setter Property="MinHeight" Value="{Binding MinHeight}" />
+                <Setter Property="MaxHeight" Value="{Binding MaxHeight}" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <Grid DockProperties.IsDropArea="True"
+                      Background="Transparent" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+          </ItemsControl>
+        </DockableControl>
+      </ControlTemplate>
+    </Setter>
+
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/GridDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GridDockControl.axaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="GridDockControl"/> xaml.
+/// </summary>
+public class GridDockControl : TemplatedControl
+{
+}

--- a/src/Dock.Avalonia/Controls/StackDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/StackDockControl.axaml
@@ -1,0 +1,41 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="using:Dock.Model.Controls"
+                    x:DataType="controls:IStackDock"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <StackDockControl Width="300" Height="300" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type StackDockControl}" TargetType="StackDockControl">
+
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockableControl TrackingMode="Visible">
+          <ItemsControl ItemsSource="{Binding VisibleDockables}">
+            <ItemsControl.Styles>
+              <Style Selector="ItemsControl > ContentPresenter">
+                <Setter Property="MinWidth" Value="{Binding MinWidth}" />
+                <Setter Property="MaxWidth" Value="{Binding MaxWidth}" />
+                <Setter Property="MinHeight" Value="{Binding MinHeight}" />
+                <Setter Property="MaxHeight" Value="{Binding MaxHeight}" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel DockProperties.IsDropArea="True"
+                            Background="Transparent"
+                            Orientation="{Binding Orientation, Converter={x:Static OrientationConverter.Instance}}" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+          </ItemsControl>
+        </DockableControl>
+      </ControlTemplate>
+    </Setter>
+
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/StackDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/StackDockControl.axaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="StackDockControl"/> xaml.
+/// </summary>
+public class StackDockControl : TemplatedControl
+{
+}

--- a/src/Dock.Avalonia/Controls/UniformGridDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/UniformGridDockControl.axaml
@@ -1,0 +1,39 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="using:Dock.Model.Controls"
+                    x:DataType="controls:IUniformGridDock"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <UniformGridDockControl Width="300" Height="300" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type UniformGridDockControl}" TargetType="UniformGridDockControl">
+
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockableControl TrackingMode="Visible">
+          <ItemsControl ItemsSource="{Binding VisibleDockables}">
+            <ItemsControl.Styles>
+              <Style Selector="ItemsControl > ContentPresenter">
+                <Setter Property="MinWidth" Value="{Binding MinWidth}" />
+                <Setter Property="MaxWidth" Value="{Binding MaxWidth}" />
+                <Setter Property="MinHeight" Value="{Binding MinHeight}" />
+                <Setter Property="MaxHeight" Value="{Binding MaxHeight}" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <UniformGrid DockProperties.IsDropArea="True" Background="Transparent" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+          </ItemsControl>
+        </DockableControl>
+      </ControlTemplate>
+    </Setter>
+
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/UniformGridDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/UniformGridDockControl.axaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="UniformGridDockControl"/> xaml.
+/// </summary>
+public class UniformGridDockControl : TemplatedControl
+{
+}

--- a/src/Dock.Avalonia/Controls/WrapDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/WrapDockControl.axaml
@@ -1,0 +1,41 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="using:Dock.Model.Controls"
+                    x:DataType="controls:IWrapDock"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <WrapDockControl Width="300" Height="300" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type WrapDockControl}" TargetType="WrapDockControl">
+
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <DockableControl TrackingMode="Visible">
+          <ItemsControl ItemsSource="{Binding VisibleDockables}">
+            <ItemsControl.Styles>
+              <Style Selector="ItemsControl > ContentPresenter">
+                <Setter Property="MinWidth" Value="{Binding MinWidth}" />
+                <Setter Property="MaxWidth" Value="{Binding MaxWidth}" />
+                <Setter Property="MinHeight" Value="{Binding MinHeight}" />
+                <Setter Property="MaxHeight" Value="{Binding MaxHeight}" />
+              </Style>
+            </ItemsControl.Styles>
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <WrapPanel DockProperties.IsDropArea="True"
+                           Background="Transparent"
+                           Orientation="{Binding Orientation, Converter={x:Static OrientationConverter.Instance}}" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+          </ItemsControl>
+        </DockableControl>
+      </ControlTemplate>
+    </Setter>
+
+  </ControlTheme>
+
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/WrapDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/WrapDockControl.axaml.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Avalonia.Controls.Primitives;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interaction logic for <see cref="WrapDockControl"/> xaml.
+/// </summary>
+public class WrapDockControl : TemplatedControl
+{
+}

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -20,6 +20,10 @@
         <ResourceInclude Source="/Controls/DocumentDockControl.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockControl.axaml" />
         <ResourceInclude Source="/Controls/ProportionalDockControl.axaml" />
+        <ResourceInclude Source="/Controls/StackDockControl.axaml" />
+        <ResourceInclude Source="/Controls/GridDockControl.axaml" />
+        <ResourceInclude Source="/Controls/WrapDockControl.axaml" />
+        <ResourceInclude Source="/Controls/UniformGridDockControl.axaml" />
         <ResourceInclude Source="/Controls/RootDockControl.axaml" />
         <ResourceInclude Source="/Controls/ToolContentControl.axaml" />
         <ResourceInclude Source="/Controls/ToolDockControl.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -20,6 +20,10 @@
         <ResourceInclude Source="/Controls/DocumentDockControl.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockControl.axaml" />
         <ResourceInclude Source="/Controls/ProportionalDockControl.axaml" />
+        <ResourceInclude Source="/Controls/StackDockControl.axaml" />
+        <ResourceInclude Source="/Controls/GridDockControl.axaml" />
+        <ResourceInclude Source="/Controls/WrapDockControl.axaml" />
+        <ResourceInclude Source="/Controls/UniformGridDockControl.axaml" />
         <ResourceInclude Source="/Controls/RootDockControl.axaml" />
         <ResourceInclude Source="/Controls/ToolContentControl.axaml" />
         <ResourceInclude Source="/Controls/ToolDockControl.axaml" />

--- a/src/Dock.Model.Avalonia/Controls/GridDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/GridDock.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class GridDock : DockBase, IGridDock
+{
+    /// <summary>
+    /// Defines the <see cref="ColumnDefinitions"/> property.
+    /// </summary>
+    public static readonly DirectProperty<GridDock, string?> ColumnDefinitionsProperty =
+        AvaloniaProperty.RegisterDirect<GridDock, string?>(nameof(ColumnDefinitions), o => o.ColumnDefinitions, (o, v) => o.ColumnDefinitions = v);
+
+    /// <summary>
+    /// Defines the <see cref="RowDefinitions"/> property.
+    /// </summary>
+    public static readonly DirectProperty<GridDock, string?> RowDefinitionsProperty =
+        AvaloniaProperty.RegisterDirect<GridDock, string?>(nameof(RowDefinitions), o => o.RowDefinitions, (o, v) => o.RowDefinitions = v);
+
+    private string? _columnDefinitions;
+    private string? _rowDefinitions;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("ColumnDefinitions")]
+    public string? ColumnDefinitions
+    {
+        get => _columnDefinitions;
+        set => SetAndRaise(ColumnDefinitionsProperty, ref _columnDefinitions, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("RowDefinitions")]
+    public string? RowDefinitions
+    {
+        get => _rowDefinitions;
+        set => SetAndRaise(RowDefinitionsProperty, ref _rowDefinitions, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Controls/GridDockSplitter.cs
+++ b/src/Dock.Model.Avalonia/Controls/GridDockSplitter.cs
@@ -1,0 +1,64 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Grid dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public class GridDockSplitter : DockableBase, IGridDockSplitter
+{
+    /// <summary>
+    /// Defines the <see cref="Column"/> property.
+    /// </summary>
+    public static readonly DirectProperty<GridDockSplitter, int> ColumnProperty =
+        AvaloniaProperty.RegisterDirect<GridDockSplitter, int>(nameof(Column), o => o.Column, (o, v) => o.Column = v);
+
+    /// <summary>
+    /// Defines the <see cref="Row"/> property.
+    /// </summary>
+    public static readonly DirectProperty<GridDockSplitter, int> RowProperty =
+        AvaloniaProperty.RegisterDirect<GridDockSplitter, int>(nameof(Row), o => o.Row, (o, v) => o.Row = v);
+
+    /// <summary>
+    /// Defines the <see cref="ResizeDirection"/> property.
+    /// </summary>
+    public static readonly DirectProperty<GridDockSplitter, GridResizeDirection> ResizeDirectionProperty =
+        AvaloniaProperty.RegisterDirect<GridDockSplitter, GridResizeDirection>(nameof(ResizeDirection), o => o.ResizeDirection, (o, v) => o.ResizeDirection = v);
+
+    private int _column;
+    private int _row;
+    private GridResizeDirection _resizeDirection;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Column")]
+    public int Column
+    {
+        get => _column;
+        set => SetAndRaise(ColumnProperty, ref _column, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Row")]
+    public int Row
+    {
+        get => _row;
+        set => SetAndRaise(RowProperty, ref _row, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("ResizeDirection")]
+    public GridResizeDirection ResizeDirection
+    {
+        get => _resizeDirection;
+        set => SetAndRaise(ResizeDirectionProperty, ref _resizeDirection, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Controls/StackDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/StackDock.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Stack dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class StackDock : DockBase, IStackDock
+{
+    /// <summary>
+    /// Defines the <see cref="Orientation"/> property.
+    /// </summary>
+    public static readonly DirectProperty<StackDock, Orientation> OrientationProperty =
+        AvaloniaProperty.RegisterDirect<StackDock, Orientation>(nameof(Orientation), o => o.Orientation, (o, v) => o.Orientation = v);
+
+    /// <summary>
+    /// Defines the <see cref="Spacing"/> property.
+    /// </summary>
+    public static readonly DirectProperty<StackDock, double> SpacingProperty =
+        AvaloniaProperty.RegisterDirect<StackDock, double>(nameof(Spacing), o => o.Spacing, (o, v) => o.Spacing = v);
+
+    private Orientation _orientation;
+    private double _spacing;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Orientation")]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetAndRaise(OrientationProperty, ref _orientation, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Spacing")]
+    public double Spacing
+    {
+        get => _spacing;
+        set => SetAndRaise(SpacingProperty, ref _spacing, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Controls/UniformGridDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/UniformGridDock.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Uniform grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class UniformGridDock : DockBase, IUniformGridDock
+{
+    /// <summary>
+    /// Defines the <see cref="Rows"/> property.
+    /// </summary>
+    public static readonly DirectProperty<UniformGridDock, int> RowsProperty =
+        AvaloniaProperty.RegisterDirect<UniformGridDock, int>(nameof(Rows), o => o.Rows, (o, v) => o.Rows = v);
+
+    /// <summary>
+    /// Defines the <see cref="Columns"/> property.
+    /// </summary>
+    public static readonly DirectProperty<UniformGridDock, int> ColumnsProperty =
+        AvaloniaProperty.RegisterDirect<UniformGridDock, int>(nameof(Columns), o => o.Columns, (o, v) => o.Columns = v);
+
+    private int _rows;
+    private int _columns;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Rows")]
+    public int Rows
+    {
+        get => _rows;
+        set => SetAndRaise(RowsProperty, ref _rows, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Columns")]
+    public int Columns
+    {
+        get => _columns;
+        set => SetAndRaise(ColumnsProperty, ref _columns, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Controls/WrapDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/WrapDock.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model.Avalonia.Controls;
+
+/// <summary>
+/// Wrap dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class WrapDock : DockBase, IWrapDock
+{
+    /// <summary>
+    /// Defines the <see cref="Orientation"/> property.
+    /// </summary>
+    public static readonly DirectProperty<WrapDock, Orientation> OrientationProperty =
+        AvaloniaProperty.RegisterDirect<WrapDock, Orientation>(nameof(Orientation), o => o.Orientation, (o, v) => o.Orientation = v);
+
+    private Orientation _orientation;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Orientation")]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetAndRaise(OrientationProperty, ref _orientation, value);
+    }
+}

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -59,6 +59,36 @@ public abstract class DockBase : DockableBase, IDock
         AvaloniaProperty.RegisterDirect<DockBase, DockMode>(nameof(Dock), o => o.Dock, (o, v) => o.Dock = v);
 
     /// <summary>
+    /// Defines the <see cref="Column"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, int> ColumnProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, int>(nameof(Column), o => o.Column, (o, v) => o.Column = v);
+
+    /// <summary>
+    /// Defines the <see cref="Row"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, int> RowProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, int>(nameof(Row), o => o.Row, (o, v) => o.Row = v);
+
+    /// <summary>
+    /// Defines the <see cref="ColumnSpan"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, int> ColumnSpanProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, int>(nameof(ColumnSpan), o => o.ColumnSpan, (o, v) => o.ColumnSpan = v, 1);
+
+    /// <summary>
+    /// Defines the <see cref="RowSpan"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, int> RowSpanProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, int>(nameof(RowSpan), o => o.RowSpan, (o, v) => o.RowSpan = v, 1);
+
+    /// <summary>
+    /// Defines the <see cref="IsSharedSizeScope"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, bool> IsSharedSizeScopeProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, bool>(nameof(IsSharedSizeScope), o => o.IsSharedSizeScope, (o, v) => o.IsSharedSizeScope = v);
+
+    /// <summary>
     /// Defines the <see cref="IsActive"/> property.
     /// </summary>
     public static readonly DirectProperty<DockBase, bool> IsActiveProperty =
@@ -88,6 +118,11 @@ public abstract class DockBase : DockableBase, IDock
     private IDockable? _defaultDockable;
     private IDockable? _focusedDockable;
     private DockMode _dock = DockMode.Center;
+    private int _column;
+    private int _row;
+    private int _columnSpan = 1;
+    private int _rowSpan = 1;
+    private bool _isSharedSizeScope;
     private bool _isActive;
     private bool _canGoBack;
     private bool _canGoForward;
@@ -163,6 +198,51 @@ public abstract class DockBase : DockableBase, IDock
     {
         get => _dock;
         set => SetAndRaise(DockProperty, ref _dock, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Column")]
+    public int Column
+    {
+        get => _column;
+        set => SetAndRaise(ColumnProperty, ref _column, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Row")]
+    public int Row
+    {
+        get => _row;
+        set => SetAndRaise(RowProperty, ref _row, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("ColumnSpan")]
+    public int ColumnSpan
+    {
+        get => _columnSpan;
+        set => SetAndRaise(ColumnSpanProperty, ref _columnSpan, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("RowSpan")]
+    public int RowSpan
+    {
+        get => _rowSpan;
+        set => SetAndRaise(RowSpanProperty, ref _rowSpan, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("IsSharedSizeScope")]
+    public bool IsSharedSizeScope
+    {
+        get => _isSharedSizeScope;
+        set => SetAndRaise(IsSharedSizeScopeProperty, ref _isSharedSizeScope, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -107,6 +107,9 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IGridDockSplitter CreateGridDockSplitter() => new GridDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -92,6 +92,18 @@ public class Factory : FactoryBase
     public override IDockDock CreateDockDock() => new DockDock();
 
     /// <inheritdoc/>
+    public override IStackDock CreateStackDock() => new StackDock();
+
+    /// <inheritdoc/>
+    public override IGridDock CreateGridDock() => new GridDock();
+
+    /// <inheritdoc/>
+    public override IWrapDock CreateWrapDock() => new WrapDock();
+
+    /// <inheritdoc/>
+    public override IUniformGridDock CreateUniformGridDock() => new UniformGridDock();
+
+    /// <inheritdoc/>
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Controls/GridDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/GridDock.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class GridDock : DockBase, IGridDock
+{
+    private string? _columnDefinitions;
+    private string? _rowDefinitions;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public string? ColumnDefinitions
+    {
+        get => _columnDefinitions;
+        set => SetProperty(ref _columnDefinitions, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public string? RowDefinitions
+    {
+        get => _rowDefinitions;
+        set => SetProperty(ref _rowDefinitions, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/GridDockSplitter.cs
+++ b/src/Dock.Model.Mvvm/Controls/GridDockSplitter.cs
@@ -1,0 +1,41 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Mvvm.Core;
+using Dock.Model.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Grid dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public class GridDockSplitter : DockableBase, IGridDockSplitter
+{
+    private int _column;
+    private int _row;
+    private GridResizeDirection _resizeDirection;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Column
+    {
+        get => _column;
+        set => SetProperty(ref _column, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Row
+    {
+        get => _row;
+        set => SetProperty(ref _row, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public GridResizeDirection ResizeDirection
+    {
+        get => _resizeDirection;
+        set => SetProperty(ref _resizeDirection, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/StackDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/StackDock.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Stack dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class StackDock : DockBase, IStackDock
+{
+    private Orientation _orientation;
+    private double _spacing;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public double Spacing
+    {
+        get => _spacing;
+        set => SetProperty(ref _spacing, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/UniformGridDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/UniformGridDock.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Uniform grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class UniformGridDock : DockBase, IUniformGridDock
+{
+    private int _rows;
+    private int _columns;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Rows
+    {
+        get => _rows;
+        set => SetProperty(ref _rows, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Columns
+    {
+        get => _columns;
+        set => SetProperty(ref _columns, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/WrapDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/WrapDock.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Core;
+
+namespace Dock.Model.Mvvm.Controls;
+
+/// <summary>
+/// Wrap dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public class WrapDock : DockBase, IWrapDock
+{
+    private Orientation _orientation;
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public Orientation Orientation
+    {
+        get => _orientation;
+        set => SetProperty(ref _orientation, value);
+    }
+}

--- a/src/Dock.Model.Mvvm/Core/DockBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockBase.cs
@@ -21,6 +21,11 @@ public abstract class DockBase : DockableBase, IDock
     private IDockable? _defaultDockable;
     private IDockable? _focusedDockable;
     private DockMode _dock = DockMode.Center;
+    private int _column;
+    private int _row;
+    private int _columnSpan = 1;
+    private int _rowSpan = 1;
+    private bool _isSharedSizeScope;
     private int _openedDockablesCount = 0;
     private bool _isActive;
 
@@ -84,6 +89,46 @@ public abstract class DockBase : DockableBase, IDock
     {
         get => _dock;
         set => SetProperty(ref _dock, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Column
+    {
+        get => _column;
+        set => SetProperty(ref _column, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int Row
+    {
+        get => _row;
+        set => SetProperty(ref _row, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int ColumnSpan
+    {
+        get => _columnSpan;
+        set => SetProperty(ref _columnSpan, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public int RowSpan
+    {
+        get => _rowSpan;
+        set => SetProperty(ref _rowSpan, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool IsSharedSizeScope
+    {
+        get => _isSharedSizeScope;
+        set => SetProperty(ref _isSharedSizeScope, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -80,6 +80,18 @@ public class Factory : FactoryBase
     public override IDockDock CreateDockDock() => new DockDock();
 
     /// <inheritdoc/>
+    public override IStackDock CreateStackDock() => new StackDock();
+
+    /// <inheritdoc/>
+    public override IGridDock CreateGridDock() => new GridDock();
+
+    /// <inheritdoc/>
+    public override IWrapDock CreateWrapDock() => new WrapDock();
+
+    /// <inheritdoc/>
+    public override IUniformGridDock CreateUniformGridDock() => new UniformGridDock();
+
+    /// <inheritdoc/>
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -95,6 +95,9 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IGridDockSplitter CreateGridDockSplitter() => new GridDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Controls/GridDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/GridDock.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.ReactiveUI.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class GridDock : DockBase, IGridDock
+{
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial string? ColumnDefinitions { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial string? RowDefinitions { get; set; }
+}

--- a/src/Dock.Model.ReactiveUI/Controls/GridDockSplitter.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/GridDockSplitter.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.ReactiveUI.Core;
+using Dock.Model.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Grid dock splitter.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class GridDockSplitter : DockableBase, IGridDockSplitter
+{
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Column { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Row { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial GridResizeDirection ResizeDirection { get; set; }
+}

--- a/src/Dock.Model.ReactiveUI/Controls/StackDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/StackDock.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Stack dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class StackDock : DockBase, IStackDock
+{
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial Orientation Orientation { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial double Spacing { get; set; }
+}

--- a/src/Dock.Model.ReactiveUI/Controls/UniformGridDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/UniformGridDock.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.ReactiveUI.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Uniform grid dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class UniformGridDock : DockBase, IUniformGridDock
+{
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Rows { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Columns { get; set; }
+}

--- a/src/Dock.Model.ReactiveUI/Controls/WrapDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/WrapDock.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Runtime.Serialization;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Core;
+
+namespace Dock.Model.ReactiveUI.Controls;
+
+/// <summary>
+/// Wrap dock.
+/// </summary>
+[DataContract(IsReference = true)]
+public partial class WrapDock : DockBase, IWrapDock
+{
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial Orientation Orientation { get; set; }
+}

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -67,6 +67,26 @@ public abstract partial class DockBase : DockableBase, IDock
 
     /// <inheritdoc/>
     [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Column { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int Row { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int ColumnSpan { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial int RowSpan { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial bool IsSharedSizeScope { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
     public partial bool IsActive { get; set; }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -80,6 +80,18 @@ public class Factory : FactoryBase
     public override IDockDock CreateDockDock() => new DockDock();
 
     /// <inheritdoc/>
+    public override IStackDock CreateStackDock() => new StackDock();
+
+    /// <inheritdoc/>
+    public override IGridDock CreateGridDock() => new GridDock();
+
+    /// <inheritdoc/>
+    public override IWrapDock CreateWrapDock() => new WrapDock();
+
+    /// <inheritdoc/>
+    public override IUniformGridDock CreateUniformGridDock() => new UniformGridDock();
+
+    /// <inheritdoc/>
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -95,6 +95,9 @@ public class Factory : FactoryBase
     public override IProportionalDockSplitter CreateProportionalDockSplitter() => new ProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public override IGridDockSplitter CreateGridDockSplitter() => new GridDockSplitter();
+
+    /// <inheritdoc/>
     public override IToolDock CreateToolDock() => new ToolDock();
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Controls/IGridDock.cs
+++ b/src/Dock.Model/Controls/IGridDock.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Grid dock contract.
+/// </summary>
+public interface IGridDock : IDock
+{
+    /// <summary>
+    /// Gets or sets column definitions string.
+    /// </summary>
+    string? ColumnDefinitions { get; set; }
+
+    /// <summary>
+    /// Gets or sets row definitions string.
+    /// </summary>
+    string? RowDefinitions { get; set; }
+}

--- a/src/Dock.Model/Controls/IGridDockSplitter.cs
+++ b/src/Dock.Model/Controls/IGridDockSplitter.cs
@@ -1,0 +1,24 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Grid splitter dock contract.
+/// </summary>
+public interface IGridDockSplitter : IDockable
+{
+    /// <summary>
+    /// Gets or sets grid column.
+    /// </summary>
+    int Column { get; set; }
+
+    /// <summary>
+    /// Gets or sets grid row.
+    /// </summary>
+    int Row { get; set; }
+
+    /// <summary>
+    /// Gets or sets resize direction.
+    /// </summary>
+    GridResizeDirection ResizeDirection { get; set; }
+}

--- a/src/Dock.Model/Controls/IStackDock.cs
+++ b/src/Dock.Model/Controls/IStackDock.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Stack dock contract.
+/// </summary>
+public interface IStackDock : IDock
+{
+    /// <summary>
+    /// Gets or sets layout orientation.
+    /// </summary>
+    Orientation Orientation { get; set; }
+
+    /// <summary>
+    /// Gets or sets spacing between items.
+    /// </summary>
+    double Spacing { get; set; }
+}

--- a/src/Dock.Model/Controls/IUniformGridDock.cs
+++ b/src/Dock.Model/Controls/IUniformGridDock.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Uniform grid dock contract.
+/// </summary>
+public interface IUniformGridDock : IDock
+{
+    /// <summary>
+    /// Gets or sets number of rows.
+    /// </summary>
+    int Rows { get; set; }
+
+    /// <summary>
+    /// Gets or sets number of columns.
+    /// </summary>
+    int Columns { get; set; }
+}

--- a/src/Dock.Model/Controls/IWrapDock.cs
+++ b/src/Dock.Model/Controls/IWrapDock.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using Dock.Model.Core;
+
+namespace Dock.Model.Controls;
+
+/// <summary>
+/// Wrap dock contract.
+/// </summary>
+public interface IWrapDock : IDock
+{
+    /// <summary>
+    /// Gets or sets layout orientation.
+    /// </summary>
+    Orientation Orientation { get; set; }
+}

--- a/src/Dock.Model/Core/GridResizeDirection.cs
+++ b/src/Dock.Model/Core/GridResizeDirection.cs
@@ -1,0 +1,16 @@
+namespace Dock.Model.Core;
+
+/// <summary>
+/// Specifies the direction in which a grid can be resized.
+/// </summary>
+public enum GridResizeDirection
+{
+    /// <summary>
+    /// Resize grid columns.
+    /// </summary>
+    Columns,
+    /// <summary>
+    /// Resize grid rows.
+    /// </summary>
+    Rows
+}

--- a/src/Dock.Model/Core/IDock.cs
+++ b/src/Dock.Model/Core/IDock.cs
@@ -36,6 +36,31 @@ public interface IDock : IDockable
     DockMode Dock { get; set; }
 
     /// <summary>
+    /// Gets or sets grid column.
+    /// </summary>
+    int Column { get; set; }
+
+    /// <summary>
+    /// Gets or sets grid row.
+    /// </summary>
+    int Row { get; set; }
+
+    /// <summary>
+    /// Gets or sets grid column span.
+    /// </summary>
+    int ColumnSpan { get; set; }
+
+    /// <summary>
+    /// Gets or sets grid row span.
+    /// </summary>
+    int RowSpan { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this dock participates in shared size scope.
+    /// </summary>
+    bool IsSharedSizeScope { get; set; }
+
+    /// <summary>
     /// Gets or sets if the dockable is the currently active.
     /// </summary>
     bool IsActive { get; set; }

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -123,6 +123,30 @@ public partial interface IFactory
     IDockDock CreateDockDock();
 
     /// <summary>
+    /// Creates <see cref="IStackDock"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IStackDock"/> class.</returns>
+    IStackDock CreateStackDock();
+
+    /// <summary>
+    /// Creates <see cref="IGridDock"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IGridDock"/> class.</returns>
+    IGridDock CreateGridDock();
+
+    /// <summary>
+    /// Creates <see cref="IWrapDock"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IWrapDock"/> class.</returns>
+    IWrapDock CreateWrapDock();
+
+    /// <summary>
+    /// Creates <see cref="IUniformGridDock"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IUniformGridDock"/> class.</returns>
+    IUniformGridDock CreateUniformGridDock();
+
+    /// <summary>
     /// Creates <see cref="IProportionalDockSplitter"/>.
     /// </summary>
     /// <returns>The new instance of the <see cref="IProportionalDockSplitter"/> class.</returns>

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -153,6 +153,12 @@ public partial interface IFactory
     IProportionalDockSplitter CreateProportionalDockSplitter();
 
     /// <summary>
+    /// Creates <see cref="IGridDockSplitter"/>.
+    /// </summary>
+    /// <returns>The new instance of the <see cref="IGridDockSplitter"/> class.</returns>
+    IGridDockSplitter CreateGridDockSplitter();
+
+    /// <summary>
     /// Creates <see cref="IToolDock"/>.
     /// </summary>
     /// <returns>The new instance of the <see cref="IToolDock"/> class.</returns>

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -457,6 +457,82 @@ public class DockManager : IDockManager
         return all;
     }
 
+    private bool ValidateStackDock(IStackDock sourceDock, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute)
+    {
+        if (sourceDock.VisibleDockables == null ||
+            sourceDock.VisibleDockables.Count == 0)
+            return false;
+
+        bool all = true;
+        for (int i = sourceDock.VisibleDockables.Count - 1; i >= 0; --i)
+        {
+            var dockable = sourceDock.VisibleDockables[i];
+            if (dockable is not IDock dock)
+                continue;
+
+            all &= ValidateDockable(dock, targetDockable, action, operation, bExecute);
+        }
+
+        return all;
+    }
+
+    private bool ValidateGridDock(IGridDock sourceDock, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute)
+    {
+        if (sourceDock.VisibleDockables == null ||
+            sourceDock.VisibleDockables.Count == 0)
+            return false;
+
+        bool all = true;
+        for (int i = sourceDock.VisibleDockables.Count - 1; i >= 0; --i)
+        {
+            var dockable = sourceDock.VisibleDockables[i];
+            if (dockable is not IDock dock)
+                continue;
+
+            all &= ValidateDockable(dock, targetDockable, action, operation, bExecute);
+        }
+
+        return all;
+    }
+
+    private bool ValidateWrapDock(IWrapDock sourceDock, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute)
+    {
+        if (sourceDock.VisibleDockables == null ||
+            sourceDock.VisibleDockables.Count == 0)
+            return false;
+
+        bool all = true;
+        for (int i = sourceDock.VisibleDockables.Count - 1; i >= 0; --i)
+        {
+            var dockable = sourceDock.VisibleDockables[i];
+            if (dockable is not IDock dock)
+                continue;
+
+            all &= ValidateDockable(dock, targetDockable, action, operation, bExecute);
+        }
+
+        return all;
+    }
+
+    private bool ValidateUniformGridDock(IUniformGridDock sourceDock, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute)
+    {
+        if (sourceDock.VisibleDockables == null ||
+            sourceDock.VisibleDockables.Count == 0)
+            return false;
+
+        bool all = true;
+        for (int i = sourceDock.VisibleDockables.Count - 1; i >= 0; --i)
+        {
+            var dockable = sourceDock.VisibleDockables[i];
+            if (dockable is not IDock dock)
+                continue;
+
+            all &= ValidateDockable(dock, targetDockable, action, operation, bExecute);
+        }
+
+        return all;
+    }
+
     /// <inheritdoc/>
     public bool ValidateDockable(IDockable sourceDockable, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute)
     {
@@ -467,6 +543,10 @@ public class DockManager : IDockManager
             ITool tool => ValidateTool(tool, targetDockable, action, operation, bExecute),
             IDocument document => ValidateDocument(document, targetDockable, action, operation, bExecute),
             IProportionalDock proportionalDock => ValidateProportionalDock(proportionalDock, targetDockable, action, operation, bExecute),
+            IStackDock stackDock => ValidateStackDock(stackDock, targetDockable, action, operation, bExecute),
+            IGridDock gridDock => ValidateGridDock(gridDock, targetDockable, action, operation, bExecute),
+            IWrapDock wrapDock => ValidateWrapDock(wrapDock, targetDockable, action, operation, bExecute),
+            IUniformGridDock uniformGridDock => ValidateUniformGridDock(uniformGridDock, targetDockable, action, operation, bExecute),
             _ => false
         };
     }

--- a/src/Dock.Model/FactoryBase.Factory.cs
+++ b/src/Dock.Model/FactoryBase.Factory.cs
@@ -48,6 +48,18 @@ public abstract partial class FactoryBase
     public abstract IDockDock CreateDockDock();
 
     /// <inheritdoc/>
+    public abstract IStackDock CreateStackDock();
+
+    /// <inheritdoc/>
+    public abstract IGridDock CreateGridDock();
+
+    /// <inheritdoc/>
+    public abstract IWrapDock CreateWrapDock();
+
+    /// <inheritdoc/>
+    public abstract IUniformGridDock CreateUniformGridDock();
+
+    /// <inheritdoc/>
     public abstract IProportionalDockSplitter CreateProportionalDockSplitter();
 
     /// <inheritdoc/>

--- a/src/Dock.Model/FactoryBase.Factory.cs
+++ b/src/Dock.Model/FactoryBase.Factory.cs
@@ -63,6 +63,9 @@ public abstract partial class FactoryBase
     public abstract IProportionalDockSplitter CreateProportionalDockSplitter();
 
     /// <inheritdoc/>
+    public abstract IGridDockSplitter CreateGridDockSplitter();
+
+    /// <inheritdoc/>
     public abstract IToolDock CreateToolDock();
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- add spacing, row/column options to dock interfaces
- implement new properties across Mvvm, ReactiveUI and Avalonia layers
- expose column definitions, row definitions and uniform grid counts
- provide grid placement properties on all docks

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: The argument ... is invalid.)*

------
https://chatgpt.com/codex/tasks/task_e_686795a2cdc483219213e2f5f5d5b2af