### PR TITLE
Add DockableDocked event

### DIFF
--- a/docs/dock-events.md
+++ b/docs/dock-events.md
@@ -36,6 +36,10 @@ factory.ActiveDockableChanged += (_, args) =>
     Console.WriteLine($"Active dockable: {args.Dockable?.Title}");
 factory.DockableAdded += (_, args) =>
     Console.WriteLine($"Added: {args.Dockable?.Title}");
+factory.DockableDocked += (_, args) =>
+    Console.WriteLine($"Docked: {args.Dockable?.Title} via {args.Operation}");
+factory.DockableUndocked += (_, args) =>
+    Console.WriteLine($"Undocked: {args.Dockable?.Title}");
 factory.WindowOpened += (_, args) =>
     Console.WriteLine($"Window opened: {args.Window?.Title}");
 

--- a/docs/dock-events.md
+++ b/docs/dock-events.md
@@ -18,6 +18,8 @@ possible to intercept an operation before it completes.
 | `DockableRemoved` | Raised after a dockable has been removed. |
 | `DockableClosed` | Occurs when a dockable is closed via command or UI. |
 | `DockableMoved` | Indicates a dockable was rearranged within its parent. |
+| `DockableDocked` | Raised after a dock operation completes such as splitting or floating. |
+| `DockableUndocked` | Raised when a dockable is removed from a dock before being moved or floated. |
 | `DockablePinned` / `DockableUnpinned` | Signalled when a tool is pinned or unpinned. |
 | `WindowOpened` / `WindowClosed` | Fired when a floating window is created or closed. |
 

--- a/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
@@ -110,6 +110,16 @@ public class MainWindowViewModel : ObservableObject
             Debug.WriteLine($"[DockableMoved] Title='{args.Dockable?.Title}'");
         };
 
+        factory.DockableDocked += (_, args) =>
+        {
+            Debug.WriteLine($"[DockableDocked] Title='{args.Dockable?.Title}', Operation='{args.Operation}'");
+        };
+
+        factory.DockableUndocked += (_, args) =>
+        {
+            Debug.WriteLine($"[DockableUndocked] Title='{args.Dockable?.Title}', Operation='{args.Operation}'");
+        };
+
         factory.DockableSwapped += (_, args) =>
         {
             Debug.WriteLine($"[DockableSwapped] Title='{args.Dockable?.Title}'");

--- a/samples/DockReactiveUISample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockReactiveUISample/ViewModels/MainWindowViewModel.cs
@@ -71,6 +71,16 @@ public class MainWindowViewModel : ReactiveObject
             Debug.WriteLine($"[DockableMoved] Title='{args.Dockable?.Title}'");
         };
 
+        factory.DockableDocked += (_, args) =>
+        {
+            Debug.WriteLine($"[DockableDocked] Title='{args.Dockable?.Title}', Operation='{args.Operation}'");
+        };
+
+        factory.DockableUndocked += (_, args) =>
+        {
+            Debug.WriteLine($"[DockableUndocked] Title='{args.Dockable?.Title}', Operation='{args.Operation}'");
+        };
+
         factory.DockableSwapped += (_, args) =>
         {
             Debug.WriteLine($"[DockableSwapped] Title='{args.Dockable?.Title}'");

--- a/src/Dock.Model/Core/Events/DockableDockedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableDockedEventArgs.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+
+namespace Dock.Model.Core.Events;
+
+/// <summary>
+/// Dockable docked event args.
+/// </summary>
+public class DockableDockedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets docked dockable.
+    /// </summary>
+    public IDockable? Dockable { get; }
+
+    /// <summary>
+    /// Gets dock operation.
+    /// </summary>
+    public DockOperation Operation { get; }
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="DockableDockedEventArgs"/> class.
+    /// </summary>
+    /// <param name="dockable">The docked dockable.</param>
+    /// <param name="operation">Dock operation that was performed.</param>
+    public DockableDockedEventArgs(IDockable? dockable, DockOperation operation)
+    {
+        Dockable = dockable;
+        Operation = operation;
+    }
+}

--- a/src/Dock.Model/Core/Events/DockableUndockedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableUndockedEventArgs.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+
+namespace Dock.Model.Core.Events;
+
+/// <summary>
+/// Dockable undocked event args.
+/// </summary>
+public class DockableUndockedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets undocked dockable.
+    /// </summary>
+    public IDockable? Dockable { get; }
+
+    /// <summary>
+    /// Gets dock operation.
+    /// </summary>
+    public DockOperation Operation { get; }
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="DockableUndockedEventArgs"/> class.
+    /// </summary>
+    /// <param name="dockable">The undocked dockable.</param>
+    /// <param name="operation">Dock operation that was performed.</param>
+    public DockableUndockedEventArgs(IDockable? dockable, DockOperation operation)
+    {
+        Dockable = dockable;
+        Operation = operation;
+    }
+}

--- a/src/Dock.Model/Core/IFactory.Events.cs
+++ b/src/Dock.Model/Core/IFactory.Events.cs
@@ -46,6 +46,16 @@ public partial interface IFactory
     event EventHandler<DockableMovedEventArgs>? DockableMoved;
 
     /// <summary>
+    /// Dockable docked event handler.
+    /// </summary>
+    event EventHandler<DockableDockedEventArgs>? DockableDocked;
+
+    /// <summary>
+    /// Dockable undocked event handler.
+    /// </summary>
+    event EventHandler<DockableUndockedEventArgs>? DockableUndocked;
+
+    /// <summary>
     /// Dockable swapped event handler.
     /// </summary>
     event EventHandler<DockableSwappedEventArgs>? DockableSwapped;
@@ -151,6 +161,20 @@ public partial interface IFactory
     /// </summary>
     /// <param name="dockable">The moved dockable.</param>
     void OnDockableMoved(IDockable? dockable);
+
+    /// <summary>
+    /// Called when the dockable has been docked.
+    /// </summary>
+    /// <param name="dockable">The docked dockable.</param>
+    /// <param name="operation">The dock operation performed.</param>
+    void OnDockableDocked(IDockable? dockable, DockOperation operation);
+
+    /// <summary>
+    /// Called when the dockable has been undocked.
+    /// </summary>
+    /// <param name="dockable">The undocked dockable.</param>
+    /// <param name="operation">The dock operation performed.</param>
+    void OnDockableUndocked(IDockable? dockable, DockOperation operation);
 
     /// <summary>
     /// Called when the dockable has been swapped.

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -108,9 +108,11 @@ public abstract partial class FactoryBase
         {
             RemoveVisibleDockableAt(dock, sourceIndex);
             OnDockableRemoved(sourceDockable);
+            OnDockableUndocked(sourceDockable, DockOperation.Fill);
             InsertVisibleDockable(dock, targetIndex, sourceDockable);
             OnDockableAdded(sourceDockable);
             OnDockableMoved(sourceDockable);
+            OnDockableDocked(sourceDockable, DockOperation.Fill);
             dock.ActiveDockable = sourceDockable;
         }
     }
@@ -185,7 +187,9 @@ public abstract partial class FactoryBase
                     OnDockableAdded(sourceDockable);
                     RemoveVisibleDockableAt(targetDock, sourceIndex);
                     OnDockableRemoved(sourceDockable);
+                    OnDockableUndocked(sourceDockable, DockOperation.Fill);
                     OnDockableMoved(sourceDockable);
+                    OnDockableDocked(sourceDockable, DockOperation.Fill);
                 }
                 else
                 {
@@ -196,16 +200,20 @@ public abstract partial class FactoryBase
                         OnDockableAdded(sourceDockable);
                         RemoveVisibleDockableAt(targetDock, removeIndex);
                         OnDockableRemoved(sourceDockable);
+                        OnDockableUndocked(sourceDockable, DockOperation.Fill);
                         OnDockableMoved(sourceDockable);
+                        OnDockableDocked(sourceDockable, DockOperation.Fill);
                     }
                 }
             }
             else
             {
                 RemoveDockable(sourceDockable, true);
+                OnDockableUndocked(sourceDockable, DockOperation.Fill);
                 InsertVisibleDockable(targetDock, targetIndex, sourceDockable);
                 OnDockableAdded(sourceDockable);
                 OnDockableMoved(sourceDockable);
+                OnDockableDocked(sourceDockable, DockOperation.Fill);
                 InitDockable(sourceDockable, targetDock);
                 targetDock.ActiveDockable = sourceDockable;
             }

--- a/src/Dock.Model/FactoryBase.Events.cs
+++ b/src/Dock.Model/FactoryBase.Events.cs
@@ -33,6 +33,12 @@ public abstract partial class FactoryBase
     public event EventHandler<DockableMovedEventArgs>? DockableMoved;
 
     /// <inheritdoc />
+    public event EventHandler<DockableDockedEventArgs>? DockableDocked;
+
+    /// <inheritdoc />
+    public event EventHandler<DockableUndockedEventArgs>? DockableUndocked;
+
+    /// <inheritdoc />
     public event EventHandler<DockableSwappedEventArgs>? DockableSwapped;
 
     /// <inheritdoc />
@@ -105,6 +111,18 @@ public abstract partial class FactoryBase
     public virtual void OnDockableMoved(IDockable? dockable)
     {
         DockableMoved?.Invoke(this, new DockableMovedEventArgs(dockable));
+    }
+
+    /// <inheritdoc />
+    public virtual void OnDockableDocked(IDockable? dockable, DockOperation operation)
+    {
+        DockableDocked?.Invoke(this, new DockableDockedEventArgs(dockable, operation));
+    }
+
+    /// <inheritdoc />
+    public virtual void OnDockableUndocked(IDockable? dockable, DockOperation operation)
+    {
+        DockableUndocked?.Invoke(this, new DockableUndockedEventArgs(dockable, operation));
     }
 
     /// <inheritdoc />

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -240,10 +240,12 @@ public abstract partial class FactoryBase : IFactory
                         var layout = CreateSplitLayout(dock, dockable, operation);
                         RemoveVisibleDockableAt(ownerDock, index);
                         OnDockableRemoved(dockable);
+                        OnDockableUndocked(dockable, operation);
                         InsertVisibleDockable(ownerDock, index, layout);
                         OnDockableAdded(dockable);
                         InitDockable(layout, ownerDock);
                         ownerDock.ActiveDockable = layout;
+                        OnDockableDocked(dockable, operation);
                     }
                 }
                 break;
@@ -373,6 +375,7 @@ public abstract partial class FactoryBase : IFactory
         }
 
         RemoveDockable(dockable, true);
+        OnDockableUndocked(dockable, DockOperation.Window);
 
         var window = CreateWindowFrom(dockable);
         if (window is not null)
@@ -383,6 +386,8 @@ public abstract partial class FactoryBase : IFactory
             window.Width = width;
             window.Height = height;
             window.Present(false);
+
+            OnDockableDocked(dockable, DockOperation.Window);
 
             if (window.Layout is { })
             {


### PR DESCRIPTION
## Summary
- add new `DockableDockedEventArgs` for completed dock operations
- expose `DockableDocked` event on `IFactory`
- implement `OnDockableDocked` in `FactoryBase`
- raise `DockableDocked` when moving or splitting dockables
- document the new event
- add new `DockableUndocked` event for when dockables are removed for docking

## Testing
- `dotnet test --no-build`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68679c28dd60832197809948c4847781