### PR TITLE
Enable headless Avalonia tests

### DIFF
--- a/build/Avalonia.Headless.props
+++ b/build/Avalonia.Headless.props
@@ -1,0 +1,6 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.XUnit" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+  </ItemGroup>
+</Project>

--- a/tests/Dock.Avalonia.UnitTests/App.axaml
+++ b/tests/Dock.Avalonia.UnitTests/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Dock.Avalonia.UnitTests.App">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/tests/Dock.Avalonia.UnitTests/App.axaml.cs
+++ b/tests/Dock.Avalonia.UnitTests/App.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.UnitTests;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -6,20 +6,20 @@ using Avalonia.Layout;
 using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
 using Dock.Controls.ProportionalStackPanel;
-using Xunit;
+using Avalonia.Headless.XUnit;
 
 namespace Dock.Avalonia.UnitTests.Controls;
 
 public class ProportionalStackPanelTests
 {
-    [Fact]
+    [AvaloniaFact]
     public void ProportionalStackPanel_Ctor()
     {
         var actual = new ProportionalStackPanel();
         Assert.NotNull(actual);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Lays_Out_Children_Horizontal()
     {
         var target = new ProportionalStackPanel()
@@ -39,7 +39,7 @@ public class ProportionalStackPanelTests
         Assert.Equal(new Rect(152, 0, 148, 100), target.Children[2].Bounds);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Lays_Out_Children_Vertical()
     {
         var target = new ProportionalStackPanel()
@@ -67,7 +67,7 @@ public class ProportionalStackPanelTests
         yield return [0.3141592653589793238462643383279, 604, 188, 412];
     }
 
-    [Theory]
+    [AvaloniaTheory]
     [MemberData(nameof(GetBorderTestsData))]
     public void Should_Not_Trim_Borders_Horizontal(
         double proportion,
@@ -98,7 +98,7 @@ public class ProportionalStackPanelTests
         Assert.Equal(expectedWidth, width);
     }
 
-    [Theory]
+    [AvaloniaTheory]
     [MemberData(nameof(GetBorderTestsData))]
     public void Should_Not_Trim_Borders_Vertical(
         double proportion,
@@ -129,7 +129,7 @@ public class ProportionalStackPanelTests
         Assert.Equal(expectedHeight, height);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Lays_Out_Children_Default()
     {
         var target = new ProportionalStackPanel()
@@ -195,7 +195,7 @@ public class ProportionalStackPanelTests
         Assert.Equal(new Rect(669, 0, 331, 500), target.Children[4].Bounds);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Lays_Out_Children_ItemsControl()
     {
         var target1 = new ItemsControl()
@@ -253,7 +253,7 @@ public class ProportionalStackPanelTests
         Assert.Equal(new Rect(0, 0, 0, 0), items2?[3].Bounds);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Respects_MinWidth_When_Assigning_Proportion()
     {
         var target = new ProportionalStackPanel
@@ -282,7 +282,7 @@ public class ProportionalStackPanelTests
         Assert.True(target.Children[0].Bounds.Width >= 150);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Respects_MaxWidth_When_Assigning_Proportion()
     {
         var target = new ProportionalStackPanel
@@ -311,7 +311,7 @@ public class ProportionalStackPanelTests
         Assert.True(target.Children[0].Bounds.Width <= 100);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Respects_MinHeight_In_Vertical_Mode()
     {
         var target = new ProportionalStackPanel

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Markup.Xaml.Templates;
 using Avalonia.Media;
 using Dock.Controls.ProportionalStackPanel;
 using Avalonia.Headless.XUnit;
+using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls;
 

--- a/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Headless.props" />
   <Import Project="..\..\build\XUnit.props" />
 
   <ItemGroup>

--- a/tests/Dock.Avalonia.UnitTests/TestAppBuilder.cs
+++ b/tests/Dock.Avalonia.UnitTests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.Avalonia.UnitTests.TestAppBuilder))]
+
+namespace Dock.Avalonia.UnitTests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/Dock.Model.Avalonia.UnitTests/App.axaml
+++ b/tests/Dock.Model.Avalonia.UnitTests/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Dock.Model.Avalonia.UnitTests.App">
+  <Application.Styles>
+    <FluentTheme />
+  </Application.Styles>
+</Application>

--- a/tests/Dock.Model.Avalonia.UnitTests/App.axaml.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/App.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Model.Avalonia.UnitTests;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
@@ -10,6 +10,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Headless.props" />
   <Import Project="..\..\build\XUnit.props" />
 
   <ItemGroup>

--- a/tests/Dock.Model.Avalonia.UnitTests/TestAppBuilder.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.Model.Avalonia.UnitTests.TestAppBuilder))]
+
+namespace Dock.Model.Avalonia.UnitTests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}


### PR DESCRIPTION
## Summary
- add `Avalonia.Headless.XUnit` and `Avalonia.Themes.Fluent` props
- configure `Dock.Avalonia.UnitTests` for headless testing
- add simple headless `App` setup
- update tests to use `AvaloniaFact` and `AvaloniaTheory`

## Testing
- `dotnet test tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj -c Release` *(fails: Failed to retrieve information about 'Avalonia.Headless.XUnit')*

------
https://chatgpt.com/codex/tasks/task_e_6867abee08608321bde3129e9058a4af