### PR TITLE
Add headless Dock.Model.Avalonia tests

### DIFF
--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/DockControlsTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/DockControlsTests.cs
@@ -1,0 +1,141 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using System;
+using Dock.Model.Avalonia.Core;
+using Avalonia.Layout;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Model.Avalonia.UnitTests.Controls;
+
+public class DockControlsTests
+{
+    [AvaloniaFact]
+    public void DockDock_Default_LastChildFill_True()
+    {
+        var dock = new DockDock();
+        Assert.True(dock.LastChildFill);
+    }
+
+    [AvaloniaFact]
+    public void StackDock_Defaults()
+    {
+        var dock = new StackDock();
+        Assert.Equal(Dock.Model.Core.Orientation.Horizontal, dock.Orientation);
+        Assert.Equal(0, dock.Spacing);
+    }
+
+    [AvaloniaFact]
+    public void WrapDock_Defaults()
+    {
+        var dock = new WrapDock();
+        Assert.Equal(Dock.Model.Core.Orientation.Horizontal, dock.Orientation);
+    }
+
+    [AvaloniaFact]
+    public void UniformGridDock_Defaults()
+    {
+        var dock = new UniformGridDock();
+        Assert.Equal(0, dock.Rows);
+        Assert.Equal(0, dock.Columns);
+    }
+
+    [AvaloniaFact]
+    public void GridDock_Defaults()
+    {
+        var dock = new GridDock();
+        Assert.Null(dock.ColumnDefinitions);
+        Assert.Null(dock.RowDefinitions);
+    }
+
+    [AvaloniaFact]
+    public void ProportionalDock_Default_Orientation_Horizontal()
+    {
+        var dock = new ProportionalDock();
+        Assert.Equal(Dock.Model.Core.Orientation.Horizontal, dock.Orientation);
+    }
+
+    [AvaloniaFact]
+    public void ProportionalDockSplitter_CanResize_Default_True()
+    {
+        var splitter = new ProportionalDockSplitter();
+        Assert.True(splitter.CanResize);
+    }
+
+    [AvaloniaFact]
+    public void GridDockSplitter_Defaults()
+    {
+        var splitter = new GridDockSplitter();
+        Assert.Equal(0, splitter.Column);
+        Assert.Equal(0, splitter.Row);
+        Assert.Equal(Dock.Model.Core.GridResizeDirection.Columns, splitter.ResizeDirection);
+    }
+
+    [AvaloniaFact]
+    public void RootDock_Collections_NotNull()
+    {
+        var dock = new RootDock();
+        Assert.NotNull(dock.HiddenDockables);
+        Assert.NotNull(dock.LeftPinnedDockables);
+        Assert.NotNull(dock.RightPinnedDockables);
+        Assert.NotNull(dock.TopPinnedDockables);
+        Assert.NotNull(dock.BottomPinnedDockables);
+        Assert.NotNull(dock.Windows);
+    }
+
+    [AvaloniaFact]
+    public void ToolDock_Defaults()
+    {
+        var dock = new ToolDock();
+        Assert.Equal(Alignment.Unset, dock.Alignment);
+        Assert.False(dock.IsExpanded);
+        Assert.True(dock.AutoHide);
+        Assert.Equal(GripMode.Visible, dock.GripMode);
+    }
+
+    [AvaloniaFact]
+    public void DocumentDock_CreateDocumentFromTemplate_Creates_Document()
+    {
+        var factory = new Factory();
+        var dock = new DocumentDock
+        {
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>(),
+            CanCreateDocument = true,
+            DocumentTemplate = new DocumentTemplate { Content = (Func<IServiceProvider, object>)(_ => new TextBlock()) }
+        };
+
+        var document = dock.CreateDocumentFromTemplate();
+
+        Assert.NotNull(document);
+        Assert.IsType<Document>(document);
+        Assert.Single(dock.VisibleDockables!);
+    }
+
+    [AvaloniaFact]
+    public void Document_Match_Uses_DataType()
+    {
+        var doc = new Document { DataType = typeof(string) };
+        Assert.True(doc.Match("text"));
+        Assert.False(doc.Match(123));
+    }
+
+    [AvaloniaFact]
+    public void Tool_Match_Uses_DataType()
+    {
+        var tool = new Tool { DataType = typeof(int) };
+        Assert.True(tool.Match(42));
+        Assert.False(tool.Match("text"));
+    }
+
+    [AvaloniaFact]
+    public void DocumentTemplate_Match_Uses_DataType()
+    {
+        var template = new DocumentTemplate { DataType = typeof(TextBlock) };
+        Assert.True(template.Match(new TextBlock()));
+        Assert.False(template.Match("text"));
+    }
+}
+

--- a/tests/Dock.Model.Avalonia.UnitTests/FactoryTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/FactoryTests.cs
@@ -1,0 +1,163 @@
+using Avalonia.Headless.XUnit;
+using Avalonia.Collections;
+using System;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Model.Avalonia.UnitTests;
+
+public class FactoryTests
+{
+    [AvaloniaFact]
+    public void TestFactory_Ctor()
+    {
+        var actual = new TestFactory();
+        Assert.NotNull(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateList_Creates_AvaloniaList_Empty()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateList<IDockable>();
+        Assert.NotNull(actual);
+        Assert.IsType<AvaloniaList<IDockable>>(actual);
+        Assert.Empty(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateRootDock_Creates_RootDock_Type()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateRootDock();
+        Assert.NotNull(actual);
+        Assert.IsType<RootDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateProportionalDock_Creates_ProportionalDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateProportionalDock();
+        Assert.NotNull(actual);
+        Assert.IsType<ProportionalDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateDockDock_Creates_DockDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateDockDock();
+        Assert.NotNull(actual);
+        Assert.IsType<DockDock>(actual);
+        Assert.True(actual.LastChildFill);
+    }
+
+    [AvaloniaFact]
+    public void CreateStackDock_Creates_StackDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateStackDock();
+        Assert.NotNull(actual);
+        Assert.IsType<StackDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateGridDock_Creates_GridDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateGridDock();
+        Assert.NotNull(actual);
+        Assert.IsType<GridDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateWrapDock_Creates_WrapDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateWrapDock();
+        Assert.NotNull(actual);
+        Assert.IsType<WrapDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateUniformGridDock_Creates_UniformGridDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateUniformGridDock();
+        Assert.NotNull(actual);
+        Assert.IsType<UniformGridDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateProportionalDockSplitter_Creates_ProportionalDockSplitter()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateProportionalDockSplitter();
+        Assert.NotNull(actual);
+        Assert.IsType<ProportionalDockSplitter>(actual);
+        Assert.True(actual.CanResize);
+    }
+
+    [AvaloniaFact]
+    public void CreateGridDockSplitter_Creates_GridDockSplitter()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateGridDockSplitter();
+        Assert.NotNull(actual);
+        Assert.IsType<GridDockSplitter>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateToolDock_Creates_ToolDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateToolDock();
+        Assert.NotNull(actual);
+        Assert.IsType<ToolDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void Tool_Default_Sizes_Are_NaN()
+    {
+        var tool = new Tool();
+        Assert.True(double.IsNaN(tool.MinWidth));
+        Assert.True(double.IsNaN(tool.MaxWidth));
+        Assert.True(double.IsNaN(tool.MinHeight));
+        Assert.True(double.IsNaN(tool.MaxHeight));
+    }
+
+    [AvaloniaFact]
+    public void CreateDocumentDock_Creates_DocumentDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateDocumentDock();
+        Assert.NotNull(actual);
+        Assert.IsType<DocumentDock>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateDockWindow_Creates_DockWindow()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateDockWindow();
+        Assert.NotNull(actual);
+        Assert.IsType<DockWindow>(actual);
+    }
+
+    [AvaloniaFact]
+    public void CreateLayout_Creates_RootDock()
+    {
+        var factory = new TestFactory();
+        var actual = factory.CreateLayout();
+        Assert.NotNull(actual);
+        Assert.IsType<RootDock>(actual);
+    }
+}
+
+public class TestFactory : Factory
+{
+}


### PR DESCRIPTION
## Summary
- add FactoryTests verifying Dock.Model.Avalonia factory methods
- add DockControlsTests covering dockable controls and document creation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6867b49720c0832199c4d7e44d6b001f