### PR TITLE
option to prevent the user from closing the last dockable.

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -32,6 +32,7 @@
                             ItemsSource="{Binding VisibleDockables}"
                             SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
                             CanCreateItem="{Binding CanCreateDocument}"
+                            CanRemoveLastDockable="{Binding CanRemoveLastDockable}"
                             IsActive="{TemplateBinding IsActive}"
                             Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
                             DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -40,6 +40,12 @@ public class DocumentTabStrip : TabStrip
     /// </summary>
     public static readonly StyledProperty<bool> EnableWindowDragProperty = 
         AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(EnableWindowDrag));
+    
+    /// <summary>
+    /// Define the <see cref="CanRemoveLastDockable"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> CanRemoveLastDockableProperty =
+        AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(CanRemoveLastDockable));
 
     /// <summary>
     /// Defines the <see cref="Orientation"/> property.
@@ -72,6 +78,15 @@ public class DocumentTabStrip : TabStrip
     {
         get => GetValue(EnableWindowDragProperty);
         set => SetValue(EnableWindowDragProperty, value);
+    }
+
+    /// <summary>
+    /// Gets of sets if the last dockable can be removed.
+    /// </summary>
+    public bool CanRemoveLastDockable
+    {
+        get => GetValue(CanRemoveLastDockableProperty);
+        set => SetValue(CanRemoveLastDockableProperty, value);
     }
 
     /// <summary>
@@ -168,19 +183,31 @@ public class DocumentTabStrip : TabStrip
             return;
         }
 
-        // Check if we're clicking on an empty area of the tab strip
-        // (not on a tab item or button)
+        bool shouldAllowDrag = false;
         var source = e.Source as Control;
-        if (source == this || (source != null &&
-                               !(source is DocumentTabStripItem) &&
-                               !(source is Button) &&
-                               !IsChildOfType<DocumentTabStripItem>(source) &&
-                               !IsChildOfType<Button>(source)))
+
+        // Special case: if we have only one item and can't remove it, always allow dragging
+        if (ItemCount == 1 && !CanRemoveLastDockable)
+        {
+            shouldAllowDrag = true;
+        }
+        // Otherwise, check if we're clicking on an empty area of the tab strip
+        else if (source == this || (source != null &&
+                                    !(source is DocumentTabStripItem) &&
+                                    !(source is Button) &&
+                                    !IsChildOfType<DocumentTabStripItem>(source) &&
+                                    !IsChildOfType<Button>(source)))
+        {
+            shouldAllowDrag = true;
+        }
+
+        if (shouldAllowDrag)
         {
             _dragStartPoint = e.GetPosition(this);
             _pointerPressed = true;
             e.Handled = true;
         }
+
     }
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/src/Dock.Model.Mvvm/Core/DockBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockBase.cs
@@ -28,6 +28,7 @@ public abstract class DockBase : DockableBase, IDock
     private bool _isSharedSizeScope;
     private int _openedDockablesCount = 0;
     private bool _isActive;
+    private bool _canRemoveLastDockable = true;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockBase"/> class.
@@ -39,6 +40,14 @@ public abstract class DockBase : DockableBase, IDock
         GoForward = new RelayCommand(() => _navigateAdapter.GoForward());
         Navigate = new RelayCommand<object>(root => _navigateAdapter.Navigate(root, true));
         Close = new RelayCommand(() => _navigateAdapter.Close());
+    }
+    
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool CanRemoveLastDockable
+    {
+        get => _canRemoveLastDockable;
+        set => SetProperty(ref _canRemoveLastDockable, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Core/DockableBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockableBase.cs
@@ -28,6 +28,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private bool _canFloat = true;
     private bool _canDrag = true;
     private bool _canDrop = true;
+    private bool _isLastItem;
     private double _minWidth = double.NaN;
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
@@ -191,6 +192,14 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _canDrop;
         set => SetProperty(ref _canDrop, value);
+    }
+    
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool IsLastItem
+    {
+        get => _isLastItem;
+        set => SetProperty(ref _isLastItem, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Core/IDock.cs
+++ b/src/Dock.Model/Core/IDock.cs
@@ -79,6 +79,11 @@ public interface IDock : IDockable
     /// Gets a value that indicates whether there is at least one entry in forward navigation history.
     /// </summary>
     bool CanGoForward { get; }
+    
+    /// <summary>
+    /// Gets a value that indicates whether the last tab can be removed.
+    /// </summary>
+    bool CanRemoveLastDockable { get; set; }
 
     /// <summary>
     /// Navigates to the most recent entry in back navigation history, if there is one.

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -104,6 +104,11 @@ public interface IDockable : IControlRecyclingIdProvider
     /// Gets or sets if the dockable can be dropped on.
     /// </summary>
     bool CanDrop { get; set; }
+    
+    /// <summary>
+    /// Gets or sets if the dockable is the last item.
+    /// </summary>
+    bool IsLastItem { get; set; }
 
     /// <summary>
     /// Called when the dockable is closed.

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -759,6 +759,11 @@ public abstract partial class FactoryBase
                 CloseDockable(dock.VisibleDockables[i]);
             }
         }
+
+        if (!dock.CanRemoveLastDockable && dock.VisibleDockables.Count == 1)
+        {
+            dock.VisibleDockables[0].CanClose = false;
+        }
     }
 
     /// <inheritdoc/>
@@ -1058,6 +1063,31 @@ public abstract partial class FactoryBase
         }
 
         UpdateOpenedDockablesCount(dock);
+
+
+        if (dock is { VisibleDockables: not null, CanRemoveLastDockable: false })
+        {
+            if (dock.VisibleDockables.Count == 1)
+            {
+                dock.VisibleDockables[0].CanClose = false;
+                dock.VisibleDockables[0].CanDrag = false;
+                dock.VisibleDockables[0].CanFloat = false;
+                dock.VisibleDockables[0].IsLastItem = true;
+            }
+            else
+            {
+                foreach (var dockable in dock.VisibleDockables)
+                {
+                    if (dockable.IsLastItem)
+                    {
+                        dockable.IsLastItem = false;
+                        dock.VisibleDockables[0].CanClose = true;
+                        dock.VisibleDockables[0].CanDrag = true;
+                        dock.VisibleDockables[0].CanFloat = true;
+                    }
+                }
+            }
+        }
     }
 
     private void UpdateOpenedDockablesCount(IDockable dockable)


### PR DESCRIPTION
Adds a property to prevent the last dockable being closed (typical for browser style tabs on the main window)

Allow the main window to be dragged via the last tabstrip item in the main window.