### PR TITLE
Add CanCloseLastDockable menu checks

### DIFF
--- a/docs/dock-context-menus.md
+++ b/docs/dock-context-menus.md
@@ -13,6 +13,8 @@ Dock defines several built in context menus and flyouts that are attached to its
 
 Each dictionary also declares `x:String` resources used for menu item headers. For example `ToolTabStripItem.axaml` exposes keys such as `ToolTabStripItemFloatString`, `ToolTabStripItemDockString` and others.
 
+When a dock's `CanCloseLastDockable` property is set to `false` the built-in menus automatically disable commands like **Close** or **Float** if executing them would remove the final item from that dock.
+
 ## Localizing strings
 
 To translate the menu headers, add a resource dictionary to your application with the same string keys. Avalonia will resolve dynamic resources from the application scope first, so your localized values override the defaults:

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -7,7 +7,7 @@ This reference summarizes the most commonly used classes in Dock. It is based on
 | Type | Description |
 | --- | --- |
 | `IDockable` | Base interface for items that can be shown in a dock. Provides `Id`, `Title`, `Context`, optional size limits and lifecycle methods like `OnClose`. |
-| `IDock` | Extends `IDockable` with collections of visible dockables and commands such as `GoBack`, `GoForward`, `Navigate` or `Close`. |
+| `IDock` | Extends `IDockable` with collections of visible dockables and commands such as `GoBack`, `GoForward`, `Navigate` or `Close`. The `CanCloseLastDockable` flag controls whether the final item may be closed. |
 | `IRootDock` | The top level container. In addition to the `IDock` members it exposes pinned dock collections and commands to manage windows. |
 | `IProportionalDock` | A dock that lays out its children horizontally or vertically using a `Proportion` value. |
 | `IStackDock` | Dock based on `StackPanel` with `Orientation` and `Spacing`. |

--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -56,4 +56,10 @@ Both options are disabled by default. When enabled the `CloseDockable` command
 moves the dockable to the `IRootDock.HiddenDockables` collection instead of
 deleting it.
 
+## Prevent closing the last dockable
+
+Each dock exposes a `CanCloseLastDockable` property. When set to `false`
+the `CloseDockable` command ignores requests that would remove the final
+visible item from that dock.
+
 For more details on dockable properties see [Dockable Property Settings](dock-dockable-properties.md).

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -37,7 +37,7 @@
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
           </MultiBinding>
       </MenuItem.IsVisible>
@@ -50,7 +50,7 @@
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -61,7 +61,7 @@
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </Separator.IsVisible>
@@ -74,7 +74,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -87,7 +87,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -100,7 +100,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -113,7 +113,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -126,7 +126,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -137,7 +137,7 @@
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </Separator.IsVisible>
@@ -220,7 +220,7 @@
                       <Binding Path="CanClose" />
                       <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
                         <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-                        <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+                        <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
                       </MultiBinding>
                     </MultiBinding>
                   </Button.IsVisible>

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -31,83 +31,117 @@
   <ContextMenu x:Key="DocumentTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
-        </MultiBinding>
-      </MenuItem.IsEnabled>
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
+          </MultiBinding>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatAllString}"
               Command="{Binding Owner.Factory.FloatAllDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
-    <Separator />
+    <Separator>
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
+        </MultiBinding>
+      </MenuItem.IsVisible>
+    </Separator>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseOtherTabsString}"
               Command="{Binding Owner.Factory.CloseOtherDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseAllTabsString}"
               Command="{Binding Owner.Factory.CloseAllDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsLeftString}"
               Command="{Binding Owner.Factory.CloseLeftDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsRightString}"
               Command="{Binding Owner.Factory.CloseRightDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
-    <Separator />
+    <Separator>
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
+        </MultiBinding>
+      </MenuItem.IsVisible>
+    </Separator>
     <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
               Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"
               CommandParameter="{Binding}">
@@ -180,8 +214,16 @@
                 </Panel>
                 <Button x:Name="PART_CloseButton"
                         Command="{Binding Owner.Factory.CloseDockable}"
-                        CommandParameter="{Binding}"
-                        IsVisible="{Binding CanClose}">
+                        CommandParameter="{Binding}">
+                  <Button.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                      <Binding Path="CanClose" />
+                      <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+                        <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+                        <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+                      </MultiBinding>
+                    </MultiBinding>
+                  </Button.IsVisible>
                   <Button.Styles>
                     <Style Selector="Button">
                       <Setter Property="BorderThickness" Value="0" />

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -56,7 +56,7 @@
       </MenuItem.IsVisible>
     </MenuItem>
     <Separator>
-      <MenuItem.IsVisible>
+      <Separator.IsVisible>
         <MultiBinding Converter="{x:Static BoolConverters.And}">
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
@@ -64,7 +64,7 @@
             <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
           </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsVisible>
+      </Separator.IsVisible>
     </Separator>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
@@ -132,7 +132,7 @@
       </MenuItem.IsVisible>
     </MenuItem>
     <Separator>
-      <MenuItem.IsVisible>
+      <Separator.IsVisible>
         <MultiBinding Converter="{x:Static BoolConverters.And}">
           <Binding Path="CanClose" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
@@ -140,7 +140,7 @@
             <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
           </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsVisible>
+      </Separator.IsVisible>
     </Separator>
     <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
               Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -1,6 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
+                    xmlns:converters="using:Dock.Avalonia.Converters"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -31,32 +32,81 @@
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}"/>
+              IsVisible="{Binding CanFloat}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatAllString}"
               Command="{Binding Owner.Factory.FloatAllDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}"/>
+              IsVisible="{Binding CanFloat}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <Separator />
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseOtherTabsString}"
               Command="{Binding Owner.Factory.CloseOtherDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseAllTabsString}"
               Command="{Binding Owner.Factory.CloseAllDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsLeftString}"
               Command="{Binding Owner.Factory.CloseLeftDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource DocumentTabStripItemCloseTabsRightString}"
               Command="{Binding Owner.Factory.CloseRightDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <Separator />
     <MenuItem Header="{DynamicResource DocumentTabStripItemNewHorizontalDockString}"
               Command="{Binding Owner.Factory.NewHorizontalDocumentDock}"

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -1,5 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:core="using:Dock.Model.Core"
                     xmlns:controls="using:Dock.Model.Controls"
                     x:DataType="controls:IToolDock"
                     xmlns:converters="using:Dock.Avalonia.Converters"
@@ -17,14 +18,16 @@
   <MenuFlyout x:Key="ToolChromeControlContextMenu">
     <MenuItem Header="{DynamicResource ToolChromeControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
-              CommandParameter="{Binding ActiveDockable}"
-              IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding ActiveDockable}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="ActiveDockable.CanFloat" FallbackValue="{x:False}" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolChromeControlDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
@@ -52,8 +55,8 @@
               IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}">
       <MenuItem.IsEnabled>
         <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+          <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+          <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
         </MultiBinding>
       </MenuItem.IsEnabled>
     </MenuItem>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -23,8 +23,8 @@
         <MultiBinding Converter="{x:Static BoolConverters.And}">
           <Binding Path="ActiveDockable.CanFloat" FallbackValue="{x:False}" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="(core:IDock).OpenedDockablesCount" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -56,8 +56,8 @@
         <MultiBinding Converter="{x:Static BoolConverters.And}">
           <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="(core:IDock).OpenedDockablesCount" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -142,8 +142,16 @@
                   <Button x:Name="PART_CloseButton"
                           Command="{Binding Owner.Factory.CloseDockable}"
                           CommandParameter="{Binding ActiveDockable}"
-                          IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"
                           Theme="{StaticResource ChromeButton}">
+                    <Button.IsVisible>
+                      <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
+                        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+                          <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
+                          <Binding Path="(core:IDock).OpenedDockablesCount" />
+                        </MultiBinding>
+                      </MultiBinding>
+                    </Button.IsVisible>
                     <Viewbox>
                       <Path x:Name="PART_ClosePath" />
                     </Viewbox>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -24,7 +24,7 @@
           <Binding Path="ActiveDockable.CanFloat" FallbackValue="{x:False}" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="(core:IDock).OpenedDockablesCount" />
+            <Binding Path="(core:IDock).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -57,7 +57,7 @@
           <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="(core:IDock).OpenedDockablesCount" />
+            <Binding Path="(core:IDock).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -148,7 +148,7 @@
                         <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
                         <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
                           <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />
-                          <Binding Path="(core:IDock).OpenedDockablesCount" />
+                          <Binding Path="(core:IDock).VisibleDockables.Count" FallbackValue="0" />
                         </MultiBinding>
                       </MultiBinding>
                     </Button.IsVisible>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:controls="using:Dock.Model.Controls"
                     x:DataType="controls:IToolDock"
+                    xmlns:converters="using:Dock.Avalonia.Converters"
                     x:CompileBindings="True">
   <Design.PreviewWith>
   <ToolChromeControl Width="300" Height="400" />
@@ -17,7 +18,14 @@
     <MenuItem Header="{DynamicResource ToolChromeControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding ActiveDockable}"
-              IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}"/>
+              IsVisible="{Binding ActiveDockable.CanFloat, FallbackValue=False}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource ToolChromeControlDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding ActiveDockable}"
@@ -41,7 +49,14 @@
     <MenuItem Header="{DynamicResource ToolChromeControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding ActiveDockable}"
-              IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}"/>
+              IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
   </MenuFlyout>
 
   <ControlTheme x:Key="ChromeButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}" >

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -51,14 +51,16 @@
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolChromeControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
-              CommandParameter="{Binding ActiveDockable}"
-              IsVisible="{Binding ActiveDockable.CanClose, FallbackValue=False}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-          <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+              CommandParameter="{Binding ActiveDockable}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
   </MenuFlyout>
 

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -22,7 +22,7 @@
           <Binding Path="CanFloat"  />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -43,7 +43,7 @@
           <Binding Path="CanClose"  />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -17,7 +17,14 @@
     <MenuItem Header="{DynamicResource ToolPinItemControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}"/>
+              IsVisible="{Binding CanFloat}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource ToolPinItemControlShowString}"
               Command="{Binding Owner.Factory.PreviewPinnedDockable}"
               CommandParameter="{Binding}"
@@ -29,7 +36,14 @@
     <MenuItem Header="{DynamicResource ToolPinItemControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
   </ContextMenu>
 
   <ControlTheme x:Key="{x:Type ToolPinItemControl}" TargetType="ToolPinItemControl">

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -16,14 +16,16 @@
   <ContextMenu x:Key="ToolPinItemControlContextMenu">
     <MenuItem Header="{DynamicResource ToolPinItemControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat"  />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolPinItemControlShowString}"
               Command="{Binding Owner.Factory.PreviewPinnedDockable}"
@@ -35,14 +37,16 @@
               IsVisible="{Binding Owner, Converter={x:Static converters:OwnerIsToolDockConverter.Instance}}"/>
     <MenuItem Header="{DynamicResource ToolPinItemControlCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose"  />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
   </ContextMenu>
 

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -28,11 +28,25 @@
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}"/>
+              IsVisible="{Binding CanFloat}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatAllString}"
               Command="{Binding Owner.Factory.FloatAllDockables}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}"/>
+              IsVisible="{Binding CanFloat}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
     <MenuItem Header="{DynamicResource ToolTabStripItemDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding}"
@@ -56,7 +70,14 @@
     <MenuItem Header="{DynamicResource ToolTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
               CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}"/>
+              IsVisible="{Binding CanClose}">
+      <MenuItem.IsEnabled>
+        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+          <Binding Path="Owner.CanCloseLastDockable" />
+          <Binding Path="Owner.OpenedDockablesCount" />
+        </MultiBinding>
+      </MenuItem.IsEnabled>
+    </MenuItem>
   </ContextMenu>
   
   <ControlTheme x:Key="{x:Type ToolTabStripItem}" TargetType="ToolTabStripItem">

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -33,7 +33,7 @@
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -46,7 +46,7 @@
           <Binding Path="CanFloat" />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>
@@ -79,7 +79,7 @@
           <Binding Path="CanClose"  />
           <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
             <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
-            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+            <Binding Path="((core:IDock)Owner).VisibleDockables.Count" FallbackValue="0" />
           </MultiBinding>
         </MultiBinding>
       </MenuItem.IsVisible>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -27,25 +27,29 @@
   <ContextMenu x:Key="ToolTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatAllString}"
               Command="{Binding Owner.Factory.FloatAllDockables}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanFloat}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanFloat" />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolTabStripItemDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
@@ -69,14 +73,16 @@
     </MenuItem>
     <MenuItem Header="{DynamicResource ToolTabStripItemCloseString}"
               Command="{Binding Owner.Factory.CloseDockable}"
-              CommandParameter="{Binding}"
-              IsVisible="{Binding CanClose}">
-      <MenuItem.IsEnabled>
-        <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
-          <Binding Path="Owner.CanCloseLastDockable" />
-          <Binding Path="Owner.OpenedDockablesCount" />
+              CommandParameter="{Binding}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="CanClose"  />
+          <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
+            <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />
+            <Binding Path="((core:IDock)Owner).OpenedDockablesCount" />
+          </MultiBinding>
         </MultiBinding>
-      </MenuItem.IsEnabled>
+      </MenuItem.IsVisible>
     </MenuItem>
   </ContextMenu>
   

--- a/src/Dock.Avalonia/Converters/CanRemoveDockableConverter.cs
+++ b/src/Dock.Avalonia/Converters/CanRemoveDockableConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Avalonia.Data.Converters;
+using Dock.Model.Core;
 
 namespace Dock.Avalonia.Converters;
 
@@ -20,7 +21,7 @@ internal class CanRemoveDockableConverter : IMultiValueConverter
     /// <inheritdoc />
     public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (values.Count == 1 && values[0] is Dock.Model.Core.IDock dock)
+        if (values.Count == 1 && values[0] is IDock dock)
         {
             return dock.CanCloseLastDockable || dock.OpenedDockablesCount > 1;
         }
@@ -29,12 +30,6 @@ internal class CanRemoveDockableConverter : IMultiValueConverter
             return canCloseLast || count > 1;
         }
 
-        return false;
-    }
-
-    /// <inheritdoc />
-    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-    {
-        throw new NotImplementedException();
+        return true;
     }
 }

--- a/src/Dock.Avalonia/Converters/CanRemoveDockableConverter.cs
+++ b/src/Dock.Avalonia/Converters/CanRemoveDockableConverter.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Dock.Avalonia.Converters;
+
+/// <summary>
+/// Determines whether a dockable can be removed from its parent.
+/// Returns true if <c>CanCloseLastDockable</c> is true or there is more than one
+/// visible dockable.
+/// </summary>
+internal class CanRemoveDockableConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Gets the singleton instance.
+    /// </summary>
+    public static readonly CanRemoveDockableConverter Instance = new();
+
+    /// <inheritdoc />
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count == 1 && values[0] is Dock.Model.Core.IDock dock)
+        {
+            return dock.CanCloseLastDockable || dock.OpenedDockablesCount > 1;
+        }
+        if (values.Count >= 2 && values[0] is bool canCloseLast && values[1] is int count)
+        {
+            return canCloseLast || count > 1;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -101,6 +101,12 @@ public abstract class DockBase : DockableBase, IDock
         AvaloniaProperty.RegisterDirect<DockBase, int>(nameof(OpenedDockablesCount), o => o.OpenedDockablesCount, (o, v) => o.OpenedDockablesCount = v);
 
     /// <summary>
+    /// Defines the <see cref="CanCloseLastDockable"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockBase, bool> CanCloseLastDockableProperty =
+        AvaloniaProperty.RegisterDirect<DockBase, bool>(nameof(CanCloseLastDockable), o => o.CanCloseLastDockable, (o, v) => o.CanCloseLastDockable = v, true);
+
+    /// <summary>
     /// Defines the <see cref="CanGoBack"/> property.
     /// </summary>
     public static readonly DirectProperty<DockBase, bool> CanGoBackProperty =
@@ -127,6 +133,7 @@ public abstract class DockBase : DockableBase, IDock
     private bool _canGoBack;
     private bool _canGoForward;
     private int _openedDockablesCount;
+    private bool _canCloseLastDockable = true;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockBase"/> class.
@@ -261,6 +268,15 @@ public abstract class DockBase : DockableBase, IDock
     {
         get => _openedDockablesCount;
         set => SetAndRaise(OpenedDockablesCountProperty, ref _openedDockablesCount, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("CanCloseLastDockable")]
+    public bool CanCloseLastDockable
+    {
+        get => _canCloseLastDockable;
+        set => SetAndRaise(CanCloseLastDockableProperty, ref _canCloseLastDockable, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Avalonia/Core/DockBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockBase.cs
@@ -132,7 +132,7 @@ public abstract class DockBase : DockableBase, IDock
     private bool _isActive;
     private bool _canGoBack;
     private bool _canGoForward;
-    private int _openedDockablesCount;
+    private int _openedDockablesCount = 0;
     private bool _canCloseLastDockable = true;
 
     /// <summary>

--- a/src/Dock.Model.Avalonia/Json/AvaloniaDockSerializer.cs
+++ b/src/Dock.Model.Avalonia/Json/AvaloniaDockSerializer.cs
@@ -142,6 +142,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
             },
             [typeof(IDockDock)] = new List<string>
             {
@@ -166,6 +167,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IDockDock
                 "LastChildFill",
             },
@@ -192,6 +194,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IDocumentDock
                 "CanCreateDocument",
             },
@@ -218,6 +221,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
             },
             [typeof(IProportionalDock)] = new List<string>
             {
@@ -242,6 +246,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IProportionalDock
                 "Orientation",
             },
@@ -268,6 +273,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
             },
             [typeof(IRootDock)] = new List<string>
             {
@@ -292,6 +298,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IRootDock
                 "IsFocusableRoot",
                 "HiddenDockables",
@@ -325,6 +332,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IToolDock
                 "Alignment",
                 "IsExpanded",
@@ -368,6 +376,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
             },
             [typeof(Document)] = new List<string>
             {
@@ -420,6 +429,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IDockDock
                 "LastChildFill",
             },
@@ -446,6 +456,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IDocumentDock
                 "CanCreateDocument",
             },
@@ -472,6 +483,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IProportionalDock
                 "Orientation",
             },
@@ -522,6 +534,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IRootDock
                 "IsFocusableRoot",
                 "HiddenDockables",
@@ -555,6 +568,7 @@ public class AvaloniaDockSerializer : IDockSerializer
                 "IsActive",
                 "IsEmpty",
                 "IsCollapsable",
+                "CanCloseLastDockable",
                 // IToolDock
                 "Alignment",
                 "IsExpanded",

--- a/src/Dock.Model.Mvvm/Core/DockBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockBase.cs
@@ -28,6 +28,7 @@ public abstract class DockBase : DockableBase, IDock
     private bool _isSharedSizeScope;
     private int _openedDockablesCount = 0;
     private bool _isActive;
+    private bool _canCloseLastDockable = true;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockBase"/> class.
@@ -145,6 +146,14 @@ public abstract class DockBase : DockableBase, IDock
     {
         get => _openedDockablesCount;
         set => SetProperty(ref _openedDockablesCount, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool CanCloseLastDockable
+    {
+        get => _canCloseLastDockable;
+        set => SetProperty(ref _canCloseLastDockable, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -25,6 +25,8 @@ public abstract partial class DockBase : DockableBase, IDock
     {
         _navigateAdapter = new NavigateAdapter(this);
         _dock = DockMode.Center;
+        _canCloseLastDockable = true;
+        _openedDockablesCount = 0;
         GoBack = ReactiveCommand.Create(() => _navigateAdapter.GoBack());
         GoForward = ReactiveCommand.Create(() => _navigateAdapter.GoForward());
         Navigate = ReactiveCommand.Create<object>(root => _navigateAdapter.Navigate(root, true));

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -94,6 +94,10 @@ public abstract partial class DockBase : DockableBase, IDock
     public partial int OpenedDockablesCount { get; set; }
 
     /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial bool CanCloseLastDockable { get; set; }
+
+    /// <inheritdoc/>
     [IgnoreDataMember]
     public bool CanGoBack => _navigateAdapter.CanGoBack;
 

--- a/src/Dock.Model/Core/IDock.cs
+++ b/src/Dock.Model/Core/IDock.cs
@@ -71,6 +71,11 @@ public interface IDock : IDockable
     int OpenedDockablesCount { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the last remaining dockable can be closed.
+    /// </summary>
+    bool CanCloseLastDockable { get; set; }
+
+    /// <summary>
     /// Gets a value that indicates whether there is at least one entry in back navigation history.
     /// </summary>
     bool CanGoBack { get; }

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -1018,8 +1018,8 @@ public abstract partial class FactoryBase
         if (dock.VisibleDockables != null)
         {
             dock.VisibleDockables.Remove(dockable);
-            UpdateIsEmpty(dock);
         }
+        UpdateIsEmpty(dock);
     }
 
     /// <summary>
@@ -1032,9 +1032,9 @@ public abstract partial class FactoryBase
             if (dock.VisibleDockables.Count > 0)
             {
                 dock.VisibleDockables.Clear();
-                UpdateIsEmpty(dock);
             }
         }
+        UpdateIsEmpty(dock);
     }
 
     /// <summary>
@@ -1045,8 +1045,9 @@ public abstract partial class FactoryBase
         if (dock.VisibleDockables != null)
         {
             dock.VisibleDockables.RemoveAt(index);
-            UpdateIsEmpty(dock);
         }
+
+        UpdateIsEmpty(dock);
     }
 
     private void UpdateIsEmpty(IDock dock)
@@ -1061,7 +1062,9 @@ public abstract partial class FactoryBase
         {
             dock.IsEmpty = newIsEmpty;
             if (dock.Owner is IDock parent)
+            {
                 UpdateIsEmpty(parent);
+            }
         }
 
         UpdateOpenedDockablesCount(dock);
@@ -1078,7 +1081,7 @@ public abstract partial class FactoryBase
                 rootDock.OpenedDockablesCount = rootDock.VisibleDockables?.Sum(x => (x as IDock)?.OpenedDockablesCount ?? 0) ?? 0;
                 break;
             case IDock dock:
-                dock.OpenedDockablesCount = 1;
+                dock.OpenedDockablesCount = dock.VisibleDockables?.Count ?? 0;
                 break;
             default:
                 break;

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -1075,10 +1075,10 @@ public abstract partial class FactoryBase
         switch (dockable)
         {
             case IProportionalDock proportionalDock:
-                proportionalDock.OpenedDockablesCount = proportionalDock.VisibleDockables?.Sum(x => (x as IDock)?.OpenedDockablesCount ?? 0) ?? 0;
+                proportionalDock.OpenedDockablesCount = proportionalDock.VisibleDockables?.Count ?? 0;
                 break;
             case IRootDock rootDock:
-                rootDock.OpenedDockablesCount = rootDock.VisibleDockables?.Sum(x => (x as IDock)?.OpenedDockablesCount ?? 0) ?? 0;
+                rootDock.OpenedDockablesCount = rootDock.VisibleDockables?.Count ?? 0;
                 break;
             case IDock dock:
                 dock.OpenedDockablesCount = dock.VisibleDockables?.Count ?? 0;

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -1075,13 +1075,13 @@ public abstract partial class FactoryBase
         switch (dockable)
         {
             case IProportionalDock proportionalDock:
-                proportionalDock.OpenedDockablesCount = proportionalDock.VisibleDockables?.Count ?? 0;
+                proportionalDock.OpenedDockablesCount = proportionalDock.VisibleDockables?.Sum(x => (x as IDock)?.OpenedDockablesCount ?? 0) ?? 0;
                 break;
             case IRootDock rootDock:
-                rootDock.OpenedDockablesCount = rootDock.VisibleDockables?.Count ?? 0;
+                rootDock.OpenedDockablesCount = rootDock.VisibleDockables?.Sum(x => (x as IDock)?.OpenedDockablesCount ?? 0) ?? 0;
                 break;
             case IDock dock:
-                dock.OpenedDockablesCount = dock.VisibleDockables?.Count ?? 0;
+                dock.OpenedDockablesCount = 1;
                 break;
             default:
                 break;

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -1088,6 +1088,8 @@ public abstract partial class FactoryBase
         }
 
         if (dockable.Owner != null)
+        {
             UpdateOpenedDockablesCount(dockable.Owner);
+        }
     }
 }

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -727,6 +727,13 @@ public abstract partial class FactoryBase
     /// <inheritdoc/>
     public virtual void CloseDockable(IDockable dockable)
     {
+        if (dockable.Owner is IDock dock &&
+            !dock.CanCloseLastDockable &&
+            dock.VisibleDockables?.Count <= 1)
+        {
+            return;
+        }
+
         if (dockable.CanClose && dockable.OnClose())
         {
             var hide = (dockable is ITool && HideToolsOnClose)

--- a/src/Dock.Model/FactoryBase.Init.cs
+++ b/src/Dock.Model/FactoryBase.Init.cs
@@ -54,9 +54,9 @@ public abstract partial class FactoryBase
             if (dock.VisibleDockables is not null)
             {
                 InitDockables(dockable, dock.VisibleDockables);
-
-                UpdateIsEmpty(dock);
             }
+
+            UpdateIsEmpty(dock);
         }
 
         if (dockable is IRootDock rootDock)


### PR DESCRIPTION
## Summary
- add `CanRemoveDockableConverter` to check dock item removal
- disable float/close context menu items when last dockable can't be closed
- document new behavior in menu guide

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6867cdc4336083219ce0d616178a2c6d