### PR TITLE
Add global docking support

### DIFF
--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -79,8 +79,7 @@ public class GlobalDockTarget : TemplatedControl
         {
             if (selector.InputHitTest(selectorPoint.Value) is { } inputElement && Equals(inputElement, selector))
             {
-                // TODO: Implement the validate function for global dock.
-                // if (validate(point, operation, dragAction, relativeTo))
+                if (validate(point, operation, dragAction, relativeTo))
                 {
                     indicator.Opacity = 0.5;
                     return true;


### PR DESCRIPTION
## Summary
- implement validation in `GlobalDockTarget`
- handle global dock operations in `DockControlState`
- add helpers to validate and execute global docking

## Testing
- `dotnet test Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -v m`
- `dotnet test Dock.sln -v m`

------
https://chatgpt.com/codex/tasks/task_e_686956e91a5c8321ae8e9525893e0399