### PR TITLE
Add global docking control option

### DIFF
--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -38,6 +38,12 @@ DockSettings.MinimumVerticalDragDistance = 4;
 
 Increase these values if small pointer movements should not initiate dragging.
 
+## Global docking
+
+`DockSettings.EnableGlobalDocking` controls whether dockables can be dropped
+onto other `DockControl` instances. If set to `false` the global dock target is
+hidden and drags are limited to the originating control.
+
 ## Hide on close
 
 `FactoryBase` exposes two properties that control whether closing a tool or

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -13,6 +13,8 @@ internal abstract class DockManagerState : IDockManagerState
 {
     private readonly IDockManager _dockManager;
 
+    protected IDockManager DockManager => _dockManager;
+
     protected Control? DropControl { get; set; }
 
     protected AdornerHelper<DockTarget> LocalAdornerHelper { get; }
@@ -39,7 +41,7 @@ internal abstract class DockManagerState : IDockManagerState
         }
 
         // Global dock target
-        if (isGlobalValid && DropControl is { } dropControl)
+        if (DockSettings.EnableGlobalDocking && isGlobalValid && DropControl is { } dropControl)
         {
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
             if (dockControl is not null)
@@ -58,7 +60,7 @@ internal abstract class DockManagerState : IDockManagerState
         }
 
         // Global dock target
-        if (DropControl is { } dropControl)
+        if (DockSettings.EnableGlobalDocking && DropControl is { } dropControl)
         {
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
             if (dockControl is not null)

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -27,6 +27,11 @@ public static class DockSettings
     public static bool UseFloatingDockAdorner = false;
 
     /// <summary>
+    /// Allow docking between different <see cref="DockControl"/> instances.
+    /// </summary>
+    public static bool EnableGlobalDocking = true;
+
+    /// <summary>
     /// Checks if the drag distance is greater than the minimum required distance to initiate a drag operation.
     /// </summary>
     /// <param name="diff">The drag delta.</param>

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -27,7 +27,7 @@ public static class DockSettings
     public static bool UseFloatingDockAdorner = false;
 
     /// <summary>
-    /// Allow docking between different <see cref="DockControl"/> instances.
+    /// Allow docking between different dock control instances.
     /// </summary>
     public static bool EnableGlobalDocking = true;
 


### PR DESCRIPTION
## Summary
- add `EnableGlobalDocking` option in `DockSettings`
- respect setting when showing global dock target
- implement global docking validation
- document the new option

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: The argument .dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686b8cd10a0c832190decfee71d48b46