### PR TITLE
Enable localization for drag preview statuses

### DIFF
--- a/src/Dock.Avalonia/Controls/ControlStrings.axaml
+++ b/src/Dock.Avalonia/Controls/ControlStrings.axaml
@@ -1,0 +1,61 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <!-- DragPreviewControl -->
+  <x:String x:Key="DragPreviewControlDockString">Dock</x:String>
+  <x:String x:Key="DragPreviewControlFloatString">Float</x:String>
+  <x:String x:Key="DragPreviewControlNoneString">None</x:String>
+
+  <!-- DocumentTabStripItem -->
+  <x:String x:Key="DocumentTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="DocumentTabStripItemFloatAllString">Float all</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseString">_Close</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseOtherTabsString">Close other tabs</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Close all tabs</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseTabsLeftString">_Close tabs to the left</x:String>
+  <x:String x:Key="DocumentTabStripItemCloseTabsRightString">_Close tabs to the right</x:String>
+  <x:String x:Key="DocumentTabStripItemNewHorizontalDockString">New Horizontal Document Dock</x:String>
+  <x:String x:Key="DocumentTabStripItemNewVerticalDockString">New Vertical Document Dock</x:String>
+  <x:String x:Key="DocumentTabStripItemTabLayoutString">Tab Layout</x:String>
+  <x:String x:Key="DocumentTabStripItemTabLayoutLeftString">_Place Tabs on the Left</x:String>
+  <x:String x:Key="DocumentTabStripItemTabLayoutTopString">_Place Tabs on the Top</x:String>
+  <x:String x:Key="DocumentTabStripItemTabLayoutRightString">_Place Tabs on the Right</x:String>
+
+  <!-- ToolPinItemControl -->
+  <x:String x:Key="ToolPinItemControlFloatString">_Float</x:String>
+  <x:String x:Key="ToolPinItemControlShowString">_Show</x:String>
+  <x:String x:Key="ToolPinItemControlDockAsDocumentString">Dock as Tabbed Document</x:String>
+  <x:String x:Key="ToolPinItemControlCloseString">_Close</x:String>
+
+  <!-- ToolChromeControl -->
+  <x:String x:Key="ToolChromeControlFloatString">_Float</x:String>
+  <x:String x:Key="ToolChromeControlDockString">_Dock</x:String>
+  <x:String x:Key="ToolChromeControlAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolChromeControlDockAsDocumentString">Dock as Tabbed Document</x:String>
+  <x:String x:Key="ToolChromeControlCloseString">_Close</x:String>
+
+  <!-- ToolTabStripItem -->
+  <x:String x:Key="ToolTabStripItemFloatString">_Float</x:String>
+  <x:String x:Key="ToolTabStripItemFloatAllString">Float all</x:String>
+  <x:String x:Key="ToolTabStripItemDockString">_Dock</x:String>
+  <x:String x:Key="ToolTabStripItemAutoHideString">_Auto Hide</x:String>
+  <x:String x:Key="ToolTabStripItemDockAsDocumentString">Dock as Tabbed Document</x:String>
+  <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
+
+  <!-- RootDockDebug -->
+  <x:String x:Key="RootDockDebugIdString">Id</x:String>
+  <x:String x:Key="RootDockDebugTitleString">Title</x:String>
+  <x:String x:Key="RootDockDebugContextString">Context</x:String>
+  <x:String x:Key="RootDockDebugOwnerString">Owner</x:String>
+  <x:String x:Key="RootDockDebugActiveDockableString">ActiveDockable:</x:String>
+  <x:String x:Key="RootDockDebugDefaultDockableString">DefaultDockable:</x:String>
+  <x:String x:Key="RootDockDebugFocusedDockableString">FocusedDockable:</x:String>
+  <x:String x:Key="RootDockDebugProportionString">Proportion:</x:String>
+  <x:String x:Key="RootDockDebugIsActiveString">IsActive:</x:String>
+  <x:String x:Key="RootDockDebugIsCollapsableString">IsCollapsable:</x:String>
+  <x:String x:Key="RootDockDebugCanGoBackString">CanGoBack:</x:String>
+  <x:String x:Key="RootDockDebugCanGoForwardString">CanGoForward:</x:String>
+  <x:String x:Key="RootDockDebugLayoutTabString">Layout</x:String>
+  <x:String x:Key="RootDockDebugSelectedTabString">Selected</x:String>
+  <x:String x:Key="RootDockDebugWindowsTabString">Windows</x:String>
+  <x:String x:Key="RootDockDebugRootTabString">Root</x:String>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -14,19 +14,6 @@
     </Border>
   </Design.PreviewWith>
 
-  <x:String x:Key="DocumentTabStripItemFloatString">_Float</x:String>
-  <x:String x:Key="DocumentTabStripItemFloatAllString">Float all</x:String>
-  <x:String x:Key="DocumentTabStripItemCloseString">_Close</x:String>
-  <x:String x:Key="DocumentTabStripItemCloseOtherTabsString">Close other tabs</x:String>
-  <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Close all tabs</x:String>
-  <x:String x:Key="DocumentTabStripItemCloseTabsLeftString">_Close tabs to the left</x:String>
-  <x:String x:Key="DocumentTabStripItemCloseTabsRightString">_Close tabs to the right</x:String>
-  <x:String x:Key="DocumentTabStripItemNewHorizontalDockString">New Horizontal Document Dock</x:String>
-  <x:String x:Key="DocumentTabStripItemNewVerticalDockString">New Vertical Document Dock</x:String>
-  <x:String x:Key="DocumentTabStripItemTabLayoutString">Tab Layout</x:String>
-  <x:String x:Key="DocumentTabStripItemTabLayoutLeftString">_Place Tabs on the Left</x:String>
-  <x:String x:Key="DocumentTabStripItemTabLayoutTopString">_Place Tabs on the Top</x:String>
-  <x:String x:Key="DocumentTabStripItemTabLayoutRightString">_Place Tabs on the Right</x:String>
 
   <ContextMenu x:Key="DocumentTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource DocumentTabStripItemFloatString}"

--- a/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
+++ b/src/Dock.Avalonia/Controls/DragPreviewControl.axaml
@@ -12,7 +12,10 @@
                               Content="{TemplateBinding DataContext}" VerticalAlignment="Center" VerticalContentAlignment="Center" />
             <StackPanel Orientation="Horizontal" Spacing="2" VerticalAlignment="Center">
               <Path x:Name="PART_StatusIcon" />
-              <TextBlock Text="{TemplateBinding Status}" FontSize="{DynamicResource DockDragPreviewFontSize}" VerticalAlignment="Center"/>
+              <TextBlock x:Name="PART_StatusText"
+                         Text="{TemplateBinding Status}"
+                         FontSize="{DynamicResource DockDragPreviewFontSize}"
+                         VerticalAlignment="Center"/>
             </StackPanel>
           </StackPanel>
         </Border>
@@ -36,13 +39,22 @@
     <Style Selector="^[Status=Dock]/template/ Path#PART_StatusIcon">
       <Setter Property="Data" Value="{DynamicResource DockIconStatusDockGeometry}" />
     </Style>
+    <Style Selector="^[Status=Dock]/template/ TextBlock#PART_StatusText">
+      <Setter Property="Text" Value="{DynamicResource DragPreviewControlDockString}" />
+    </Style>
 
     <Style Selector="^[Status=Float]/template/ Path#PART_StatusIcon">
       <Setter Property="Data" Value="{DynamicResource DockIconStatusFloatGeometry}" />
     </Style>
+    <Style Selector="^[Status=Float]/template/ TextBlock#PART_StatusText">
+      <Setter Property="Text" Value="{DynamicResource DragPreviewControlFloatString}" />
+    </Style>
 
     <Style Selector="^[Status=None]/template/ Path#PART_StatusIcon">
       <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="^[Status=None]/template/ TextBlock#PART_StatusText">
+      <Setter Property="Text" Value="{DynamicResource DragPreviewControlNoneString}" />
     </Style>
   </ControlTheme>
 </ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/RootDockDebug.axaml
+++ b/src/Dock.Avalonia/Controls/RootDockDebug.axaml
@@ -12,29 +12,29 @@
   <UserControl.DataTemplates>
     <DataTemplate DataType="core:IDock">
       <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Id" Grid.Row="0" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugIdString}" Grid.Row="0" Grid.Column="0" />
         <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="Title" Grid.Row="1" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugTitleString}" Grid.Row="1" Grid.Column="0" />
         <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="Context" Grid.Row="2" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugContextString}" Grid.Row="2" Grid.Column="0" />
         <TextBox Text="{Binding Context, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="Owner" Grid.Row="3" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugOwnerString}" Grid.Row="3" Grid.Column="0" />
         <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
-        <TextBlock Text="ActiveDockable:" Grid.Row="4" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugActiveDockableString}" Grid.Row="4" Grid.Column="0" />
         <TextBox Text="{Binding ActiveDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
-        <TextBlock Text="DefaultDockable:" Grid.Row="5" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugDefaultDockableString}" Grid.Row="5" Grid.Column="0" />
         <TextBox Text="{Binding DefaultDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
-        <TextBlock Text="FocusedDockable:" Grid.Row="6" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugFocusedDockableString}" Grid.Row="6" Grid.Column="0" />
         <TextBox Text="{Binding FocusedDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="6" Grid.Column="1" />
-        <TextBlock Text="Proportion:" Grid.Row="7" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugProportionString}" Grid.Row="7" Grid.Column="0" />
         <TextBox Text="{Binding Proportion, Mode=TwoWay}" Margin="2" Grid.Row="7" Grid.Column="1" />
-        <TextBlock Text="IsActive:" Grid.Row="8" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugIsActiveString}" Grid.Row="8" Grid.Column="0" />
         <CheckBox IsChecked="{Binding IsActive, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="8" Grid.Column="1" />
-        <TextBlock Text="IsCollapsable:" Grid.Row="9" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugIsCollapsableString}" Grid.Row="9" Grid.Column="0" />
         <CheckBox IsChecked="{Binding IsCollapsable, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="9" Grid.Column="1" />
-        <TextBlock Text="CanGoBack:" Grid.Row="10" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugCanGoBackString}" Grid.Row="10" Grid.Column="0" />
         <CheckBox IsChecked="{Binding CanGoBack, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="10" Grid.Column="1" />
-        <TextBlock Text="CanGoForward:" Grid.Row="11" Grid.Column="0" />
+        <TextBlock Text="{DynamicResource RootDockDebugCanGoForwardString}" Grid.Row="11" Grid.Column="0" />
         <CheckBox IsChecked="{Binding CanGoForward, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="11" Grid.Column="1" />
       </Grid>
     </DataTemplate>
@@ -52,7 +52,7 @@
     </DataTemplate>
   </UserControl.DataTemplates>
   <TabControl>
-    <TabItem Header="Layout">
+    <TabItem Header="{DynamicResource RootDockDebugLayoutTabString}">
       <TreeView x:Name="Visible" 
                 ItemsSource="{Binding VisibleDockables}">
         <TreeView.Styles>
@@ -87,10 +87,10 @@
         </TreeView.DataTemplates>
       </TreeView>
     </TabItem>
-    <TabItem Header="Selected">
+    <TabItem Header="{DynamicResource RootDockDebugSelectedTabString}">
       <ContentControl Content="{Binding #Visible.SelectedItem}" />
     </TabItem>
-    <TabItem Header="Windows">
+    <TabItem Header="{DynamicResource RootDockDebugWindowsTabString}">
       <TreeView x:Name="Windows" 
                 DataContext="{Binding #Visible.SelectedItem}" 
                 ItemsSource="{Binding Windows}"
@@ -131,7 +131,7 @@
         </TreeView.DataTemplates>
       </TreeView>
     </TabItem>
-    <TabItem Header="Root">
+    <TabItem Header="{DynamicResource RootDockDebugRootTabString}">
       <ContentControl Content="{Binding}" />
     </TabItem>
   </TabControl>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -9,11 +9,6 @@
   <ToolChromeControl Width="300" Height="400" />
   </Design.PreviewWith>
 
-  <x:String x:Key="ToolChromeControlFloatString">_Float</x:String>
-  <x:String x:Key="ToolChromeControlDockString">_Dock</x:String>
-  <x:String x:Key="ToolChromeControlAutoHideString">_Auto Hide</x:String>
-  <x:String x:Key="ToolChromeControlDockAsDocumentString">Dock as Tabbed Document</x:String>
-  <x:String x:Key="ToolChromeControlCloseString">_Close</x:String>
 
   <MenuFlyout x:Key="ToolChromeControlContextMenu">
     <MenuItem Header="{DynamicResource ToolChromeControlFloatString}"

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -8,10 +8,6 @@
     <ToolPinItemControl Width="30" Height="400" />
   </Design.PreviewWith>
 
-  <x:String x:Key="ToolPinItemControlFloatString">_Float</x:String>
-  <x:String x:Key="ToolPinItemControlShowString">_Show</x:String>
-  <x:String x:Key="ToolPinItemControlDockAsDocumentString">Dock as Tabbed Document</x:String>
-  <x:String x:Key="ToolPinItemControlCloseString">_Close</x:String>
 
   <ContextMenu x:Key="ToolPinItemControlContextMenu">
     <MenuItem Header="{DynamicResource ToolPinItemControlFloatString}"

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -17,12 +17,6 @@
   <x:Double x:Key="TabStripItemMinHeight">48</x:Double>
   <x:Double x:Key="TabStripItemPipeThickness">2</x:Double>
 
-  <x:String x:Key="ToolTabStripItemFloatString">_Float</x:String>
-  <x:String x:Key="ToolTabStripItemFloatAllString">Float all</x:String>
-  <x:String x:Key="ToolTabStripItemDockString">_Dock</x:String>
-  <x:String x:Key="ToolTabStripItemAutoHideString">_Auto Hide</x:String>
-  <x:String x:Key="ToolTabStripItemDockAsDocumentString">Dock as Tabbed Document</x:String>
-  <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
 
   <ContextMenu x:Key="ToolTabStripItemContextMenu">
     <MenuItem Header="{DynamicResource ToolTabStripItemFloatString}"

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -5,6 +5,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml" />
+        <ResourceInclude Source="/Controls/ControlStrings.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStripItem.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStrip.axaml" />
         <ResourceInclude Source="/Controls/ToolTabStripItem.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -5,6 +5,7 @@
     <ResourceDictionary>
       <ResourceDictionary.MergedDictionaries>
         <ResourceInclude Source="avares://Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml" />
+        <ResourceInclude Source="/Controls/ControlStrings.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStripItem.axaml" />
         <ResourceInclude Source="/Controls/DocumentTabStrip.axaml" />
         <ResourceInclude Source="/Controls/ToolTabStripItem.axaml" />


### PR DESCRIPTION
## Summary
- add resource dictionary with string resources for all controls
- remove inline string resources from controls
- merge `ControlStrings.axaml` in both themes
- expose RootDockDebug labels for localization

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686b9e0150bc8321a0835f09609168fd