### PR TITLE
when EnableWindowDrag: true, and we are not in a host window, just ca…

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -238,14 +238,18 @@ public class DocumentTabStrip : TabStrip
         _isDragging = true;
         _pointerPressed = false;
 
-        // Find the window that contains this tab strip
-        if (VisualRoot is not HostWindow hostWindow)
+        if (_lastPointerPressedArgs is null)
         {
             return;
         }
-
-        if (_lastPointerPressedArgs is null)
+        
+        // Find the window that contains this tab strip
+        if (VisualRoot is not HostWindow hostWindow)
         {
+            if (VisualRoot is Window window)
+            {
+                window.BeginMoveDrag(_lastPointerPressedArgs);
+            }
             return;
         }
 


### PR DESCRIPTION
…ll BeginMoveDrag();

Otherwise the users mainwindow, which is likely not a hostwindow… will not be dragable via the tab strip.