### PR TITLE
Fix drop area handling with window drag

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Dock.Settings;
 using Dock.Avalonia.Internal;
+using Avalonia.VisualTree;
 
 namespace Dock.Avalonia.Controls;
 
@@ -159,6 +160,12 @@ public class DocumentTabStrip : TabStrip
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (!EnableWindowDrag)
+        {
+            return;
+        }
+
+        var dockControl = this.FindAncestorOfType<DockControl>();
+        if (dockControl?.IsDraggingDock == true)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- allow DocumentTabStrip drops even when `EnableWindowDrag` is enabled by exiting early when a dock drag is active

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686ba68677ac8321b58842fd84a1721b