### PR TITLE
Fix global docking to find proportional dock

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -8,6 +8,7 @@ using Avalonia.VisualTree;
 using Dock.Avalonia.Controls;
 using Dock.Avalonia.Contract;
 using Dock.Model.Core;
+using Dock.Model.Controls;
 using Dock.Settings;
 
 namespace Dock.Avalonia.Internal;
@@ -128,11 +129,12 @@ internal class DockControlState : DockManagerState, IDockControlState
                 return;
             }
 
-            if (_context.DragControl.DataContext is IDockable sourceDockable 
-                && dockControl.Layout is { } dockControlLayout 
+            if (_context.DragControl.DataContext is IDockable sourceDockable
+                && dockControl.Layout is { } dockControlLayout
                 && dockControlLayout.ActiveDockable is IDock dockControlActiveDock)
             {
-                Execute(point, globalOperation, dragAction, relativeTo, sourceDockable, dockControlActiveDock);
+                var targetDock = DockHelpers.FindProportionalDock(dockControlActiveDock) ?? dockControlActiveDock;
+                Execute(point, globalOperation, dragAction, relativeTo, sourceDockable, targetDock);
             }
         }
         else

--- a/src/Dock.Avalonia/Internal/DockHelpers.cs
+++ b/src/Dock.Avalonia/Internal/DockHelpers.cs
@@ -82,4 +82,14 @@ internal static class DockHelpers
             }
         }
     }
+
+    public static IProportionalDock? FindProportionalDock(IDock dock)
+    {
+        if (dock.Factory is { } factory)
+        {
+            return factory.FindDockable(dock, d => d is IProportionalDock) as IProportionalDock;
+        }
+
+        return null;
+    }
 }

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.VisualTree;
 using Dock.Avalonia.Controls;
 using Dock.Model.Core;
+using Dock.Model.Controls;
 using Dock.Settings;
 
 namespace Dock.Avalonia.Internal;
@@ -127,10 +128,11 @@ internal class HostWindowState : DockManagerState, IHostWindowState
             }
 
             if (layout?.ActiveDockable is { } sourceDockable
-                && dockControl.Layout is { } dockControlLayout 
+                && dockControl.Layout is { } dockControlLayout
                 && dockControlLayout.ActiveDockable is IDock dockControlActiveDock)
             {
-                Execute(point, globalOperation, dragAction, relativeTo, sourceDockable, dockControlActiveDock);
+                var targetDock = DockHelpers.FindProportionalDock(dockControlActiveDock) ?? dockControlActiveDock;
+                Execute(point, globalOperation, dragAction, relativeTo, sourceDockable, targetDock);
             }
         }
         else


### PR DESCRIPTION
## Summary
- search for a proportional dock when executing global docking
- implement helper to recursively find proportional docks

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686bcb4d2e048321be1a64789ee05fb0