### PR TITLE
Refactor DocumentTabStrip drag

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -21,7 +21,7 @@ public class DocumentTabStrip : TabStrip
 {
     private HostWindow? _attachedWindow;
     private Control? _grip;
-    private DocumentTabStripDragHelper? _linuxDragHelper;
+    private WindowDragHelper? _linuxDragHelper;
     
     /// <summary>
     /// Defines the <see cref="CanCreateItem"/> property.
@@ -110,7 +110,21 @@ public class DocumentTabStrip : TabStrip
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && EnableWindowDrag)
         {
-            _linuxDragHelper = new DocumentTabStripDragHelper(this);
+            _linuxDragHelper = new WindowDragHelper(
+                this,
+                () => EnableWindowDrag,
+                source =>
+                {
+                    if (source == this)
+                        return true;
+
+                    return source is { } s &&
+                           s != null &&
+                           !(s is DocumentTabStripItem) &&
+                           !(s is Button) &&
+                           !WindowDragHelper.IsChildOfType<DocumentTabStripItem>(this, s) &&
+                           !WindowDragHelper.IsChildOfType<Button>(this, s);
+                });
             _linuxDragHelper.Attach();
         }
 
@@ -163,7 +177,20 @@ public class DocumentTabStrip : TabStrip
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && _linuxDragHelper == null)
                 {
-                    _linuxDragHelper = new DocumentTabStripDragHelper(this);
+                    _linuxDragHelper = new WindowDragHelper(
+                        this,
+                        () => EnableWindowDrag,
+                        source =>
+                        {
+                            if (source == this)
+                                return true;
+
+                            return source is { } s &&
+                                   !(s is DocumentTabStripItem) &&
+                                   !(s is Button) &&
+                                   !WindowDragHelper.IsChildOfType<DocumentTabStripItem>(this, s) &&
+                                   !WindowDragHelper.IsChildOfType<Button>(this, s);
+                        });
                     _linuxDragHelper.Attach();
                 }
             }

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -225,7 +225,7 @@ public class DocumentTabStrip : TabStrip
         if (VisualRoot is HostWindow window &&
             (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
         {
-            window.AttachGrip(_grip);
+            window.AttachGrip(_grip, ":documentwindow");
             _attachedWindow = window;
         }
     }
@@ -234,7 +234,7 @@ public class DocumentTabStrip : TabStrip
     {
         if (_attachedWindow is { } host && _grip is { })
         {
-            host.DetachGrip(_grip);
+            host.DetachGrip(_grip, ":documentwindow");
         }
 
         _attachedWindow = null;

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using System.Runtime.InteropServices;
+using Dock.Avalonia.Internal;
 using Avalonia.Layout;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -20,6 +21,7 @@ public class DocumentTabStrip : TabStrip
 {
     private HostWindow? _attachedWindow;
     private Control? _grip;
+    private DocumentTabStripDragHelper? _linuxDragHelper;
     
     /// <summary>
     /// Defines the <see cref="CanCreateItem"/> property.
@@ -106,6 +108,12 @@ public class DocumentTabStrip : TabStrip
     {
         base.OnAttachedToVisualTree(e);
 
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && EnableWindowDrag)
+        {
+            _linuxDragHelper = new DocumentTabStripDragHelper(this);
+            _linuxDragHelper.Attach();
+        }
+
         AttachGrip();
     }
 
@@ -115,6 +123,9 @@ public class DocumentTabStrip : TabStrip
         base.OnDetachedFromVisualTree(e);
 
         DetachGrip();
+
+        _linuxDragHelper?.Detach();
+        _linuxDragHelper = null;
     }
 
     /// <inheritdoc/>
@@ -149,10 +160,22 @@ public class DocumentTabStrip : TabStrip
             if (change.GetNewValue<bool>())
             {
                 AttachGrip();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && _linuxDragHelper == null)
+                {
+                    _linuxDragHelper = new DocumentTabStripDragHelper(this);
+                    _linuxDragHelper.Attach();
+                }
             }
             else
             {
                 DetachGrip();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    _linuxDragHelper?.Detach();
+                    _linuxDragHelper = null;
+                }
             }
         }
     }

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml
@@ -57,6 +57,10 @@
       </Template>
     </Setter>
 
+    <Style Selector="^:documentwindow">
+      <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+    </Style>
+
     <Style Selector="^:toolwindow">
 
       <Setter Property="SystemDecorations" Value="Full" />

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -216,8 +216,10 @@ public class HostWindow : Window, IHostWindow
     /// Attaches a grip control to enable window dragging.
     /// </summary>
     /// <param name="grip">The grip control.</param>
-    public void AttachGrip(Control grip)
+    /// <param name="pseudoClass">The grip pseudo class.</param>
+    public void AttachGrip(Control grip, string pseudoClass)
     {
+        PseudoClasses.Set(pseudoClass, true);
         _chromeGrips.Add(grip);
     }
 
@@ -242,8 +244,10 @@ public class HostWindow : Window, IHostWindow
     /// Detaches a grip control from window dragging.
     /// </summary>
     /// <param name="grip">The grip control.</param>
-    public void DetachGrip(Control grip)
+    /// <param name="pseudoClass">The grip pseudo class.</param>
+    public void DetachGrip(Control grip, string pseudoClass)
     {
+        PseudoClasses.Set(pseudoClass, false);
         _chromeGrips.Remove(grip);
     }
 

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -213,6 +213,15 @@ public class HostWindow : Window, IHostWindow
     }
 
     /// <summary>
+    /// Attaches a grip control to enable window dragging.
+    /// </summary>
+    /// <param name="grip">The grip control.</param>
+    public void AttachGrip(Control grip)
+    {
+        _chromeGrips.Add(grip);
+    }
+
+    /// <summary>
     /// Detaches grip to chrome.
     /// </summary>
     /// <param name="chromeControl">The chrome control.</param>
@@ -227,6 +236,15 @@ public class HostWindow : Window, IHostWindow
         {
             chromeControl.CloseButton.Click -= ChromeCloseClick;
         }
+    }
+
+    /// <summary>
+    /// Detaches a grip control from window dragging.
+    /// </summary>
+    /// <param name="grip">The grip control.</param>
+    public void DetachGrip(Control grip)
+    {
+        _chromeGrips.Remove(grip);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Internal/DocumentTabStripDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/DocumentTabStripDragHelper.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Dock.Avalonia.Controls;
+using Dock.Settings;
+using Avalonia.VisualTree;
+
+namespace Dock.Avalonia.Internal;
+
+internal class DocumentTabStripDragHelper
+{
+    private readonly DocumentTabStrip _owner;
+    private Point _dragStartPoint;
+    private bool _pointerPressed;
+    private bool _isDragging;
+    private PointerPressedEventArgs? _lastPointerPressedArgs;
+    private HostWindow? _dragHostWindow;
+    private EventHandler<PixelPointEventArgs>? _positionChangedHandler;
+
+    public DocumentTabStripDragHelper(DocumentTabStrip owner)
+    {
+        _owner = owner;
+    }
+
+    public void Attach()
+    {
+        _owner.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
+        _owner.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
+        _owner.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel);
+    }
+
+    public void Detach()
+    {
+        _owner.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
+        _owner.RemoveHandler(InputElement.PointerReleasedEvent, OnPointerReleased);
+        _owner.RemoveHandler(InputElement.PointerMovedEvent, OnPointerMoved);
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!_owner.EnableWindowDrag)
+        {
+            return;
+        }
+
+        _lastPointerPressedArgs = e;
+
+        if (!e.GetCurrentPoint(_owner).Properties.IsLeftButtonPressed)
+        {
+            return;
+        }
+
+        var source = e.Source as Control;
+        if (source == _owner || (source != null &&
+                                   !(source is DocumentTabStripItem) &&
+                                   !(source is Button) &&
+                                   !IsChildOfType<DocumentTabStripItem>(source) &&
+                                   !IsChildOfType<Button>(source)))
+        {
+            _dragStartPoint = e.GetPosition(_owner);
+            _pointerPressed = true;
+            e.Handled = true;
+        }
+    }
+
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_pointerPressed && !_isDragging)
+        {
+            return;
+        }
+
+        _pointerPressed = false;
+        _isDragging = false;
+
+        if (_dragHostWindow is { } host)
+        {
+            if (_positionChangedHandler is { })
+            {
+                host.PositionChanged -= _positionChangedHandler;
+                _positionChangedHandler = null;
+            }
+
+            if (host.HostWindowState is HostWindowState state)
+            {
+                var point = host.PointToScreen(e.GetPosition(host)) - host.PointToScreen(new Point(0, 0));
+                state.Process(new PixelPoint((int)point.X, (int)point.Y), EventType.Released);
+            }
+
+            host.Window?.Factory?.OnWindowMoveDragEnd(host.Window);
+        }
+
+        _dragHostWindow = null;
+
+        e.Handled = true;
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_pointerPressed || _isDragging)
+        {
+            return;
+        }
+
+        var currentPoint = e.GetPosition(_owner);
+        var delta = currentPoint - _dragStartPoint;
+
+        if (!(Math.Abs(delta.X) > DockSettings.MinimumHorizontalDragDistance)
+            && !(Math.Abs(delta.Y) > DockSettings.MinimumVerticalDragDistance))
+        {
+            return;
+        }
+
+        _isDragging = true;
+        _pointerPressed = false;
+
+        if (_lastPointerPressedArgs is null)
+        {
+            return;
+        }
+
+        var root = _owner.GetVisualRoot();
+
+        if (root is not HostWindow hostWindow)
+        {
+            if (root is Window window)
+            {
+                window.BeginMoveDrag(_lastPointerPressedArgs);
+            }
+            return;
+        }
+
+        var dockWindow = hostWindow.Window;
+        if (dockWindow?.Factory?.OnWindowMoveDragBegin(dockWindow) != true)
+        {
+            _isDragging = false;
+            return;
+        }
+
+        if (hostWindow.HostWindowState is HostWindowState state)
+        {
+            var start = hostWindow.PointToScreen(_lastPointerPressedArgs.GetPosition(hostWindow)) - hostWindow.PointToScreen(new Point(0, 0));
+            state.Process(new PixelPoint((int)start.X, (int)start.Y), EventType.Pressed);
+        }
+
+        _dragHostWindow = hostWindow;
+
+        _positionChangedHandler = (_, args) =>
+        {
+            if (_dragHostWindow?.Window is { } dw)
+            {
+                dw.Factory?.OnWindowMoveDrag(dw);
+            }
+
+            if (_dragHostWindow?.HostWindowState is HostWindowState st)
+            {
+                st.Process(_dragHostWindow.Position, EventType.Moved);
+            }
+        };
+
+        hostWindow.PositionChanged += _positionChangedHandler;
+
+        hostWindow.BeginMoveDrag(_lastPointerPressedArgs);
+        e.Handled = true;
+    }
+
+    private bool IsChildOfType<T>(Control control) where T : Control
+    {
+        var parent = control;
+        while (parent != null && parent != _owner)
+        {
+            if (parent is T)
+            {
+                return true;
+            }
+
+            parent = parent.Parent as Control;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `DocumentTabStrip` window drag handling
- expose generic `AttachGrip`/`DetachGrip` on `HostWindow`

## Testing
- `./build.sh --target Test --verbosity minimal` *(fails: Build failed)*

------
https://chatgpt.com/codex/tasks/task_e_686bdf880918832181782d0800f85446