### PR TITLE
Annotate template parts and pseudo classes

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -3,6 +3,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.VisualTree;
@@ -13,6 +14,16 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="DockTarget"/> xaml.
 /// </summary>
+[TemplatePart("PART_TopIndicator", typeof(Panel))]
+[TemplatePart("PART_BottomIndicator", typeof(Panel))]
+[TemplatePart("PART_LeftIndicator", typeof(Panel))]
+[TemplatePart("PART_RightIndicator", typeof(Panel))]
+[TemplatePart("PART_CenterIndicator", typeof(Panel))]
+[TemplatePart("PART_TopSelector", typeof(Control))]
+[TemplatePart("PART_BottomSelector", typeof(Control))]
+[TemplatePart("PART_LeftSelector", typeof(Control))]
+[TemplatePart("PART_RightSelector", typeof(Control))]
+[TemplatePart("PART_CenterSelector", typeof(Control))]
 public class DockTarget : TemplatedControl
 {
     private Panel? _topIndicator;

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -3,6 +3,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.VisualTree;
@@ -13,6 +14,14 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="GlobalDockTarget"/> xaml.
 /// </summary>
+[TemplatePart("PART_TopIndicator", typeof(Panel))]
+[TemplatePart("PART_BottomIndicator", typeof(Panel))]
+[TemplatePart("PART_LeftIndicator", typeof(Panel))]
+[TemplatePart("PART_RightIndicator", typeof(Panel))]
+[TemplatePart("PART_TopSelector", typeof(Control))]
+[TemplatePart("PART_BottomSelector", typeof(Control))]
+[TemplatePart("PART_LeftSelector", typeof(Control))]
+[TemplatePart("PART_RightSelector", typeof(Control))]
 public class GlobalDockTarget : TemplatedControl
 {
     private Panel? _topIndicator;

--- a/src/Dock.Avalonia/Controls/GridDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GridDockControl.axaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Dock.Model.Controls;
@@ -11,6 +12,7 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="GridDockControl"/> xaml.
 /// </summary>
+[TemplatePart("PART_ItemsControl", typeof(ItemsControl))]
 public class GridDockControl : TemplatedControl
 {
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -22,7 +22,8 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="HostWindow"/> xaml.
 /// </summary>
-[PseudoClasses(":toolwindow", ":dragging")]
+[PseudoClasses(":toolwindow", ":dragging", ":toolchromecontrolswindow")]
+[TemplatePart("PART_TitleBar", typeof(HostWindowTitleBar))]
 public class HostWindow : Window, IHostWindow
 {
     private readonly DockManager _dockManager;

--- a/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
@@ -3,6 +3,7 @@
 using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Chrome;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
@@ -12,6 +13,7 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="HostWindowTitleBar"/> xaml.
 /// </summary>
+[TemplatePart("PART_Background", typeof(Control))]
 public class HostWindowTitleBar : TitleBar
 {
     internal Control? BackgroundControl { get; private set; }

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -15,6 +15,9 @@ namespace Dock.Avalonia.Controls;
 /// Dock tool chrome content control.
 /// </summary>
 [PseudoClasses(":floating", ":active", ":pinned", ":maximized")]
+[TemplatePart("PART_Grip", typeof(Control))]
+[TemplatePart("PART_CloseButton", typeof(Button))]
+[TemplatePart("PART_MaximizeRestoreButton", typeof(Button))]
 public class ToolChromeControl : ContentControl
 {
     private HostWindow? _attachedWindow;


### PR DESCRIPTION
## Summary
- added TemplatePart annotations to all templated controls that look up template parts
- expanded HostWindow pseudo-classes to include :toolchromecontrolswindow

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686be3b6ddf883219f9deef0daf7315d