### PR TITLE
Fix document tab strip drag offset

### DIFF
--- a/src/Dock.Avalonia/Internal/DefaultDragOffsetCalculator.cs
+++ b/src/Dock.Avalonia/Internal/DefaultDragOffsetCalculator.cs
@@ -18,6 +18,12 @@ internal class DefaultDragOffsetCalculator : IDragOffsetCalculator
             return corner - screenPoint;
         }
 
+        if (dragControl is DocumentTabStrip documentTabStrip)
+        {
+            var corner = documentTabStrip.PointToScreen(new Point());
+            return corner - screenPoint;
+        }
+
         return default;
     }
 }


### PR DESCRIPTION
## Summary
- adjust `DefaultDragOffsetCalculator` to handle drags starting from `DocumentTabStrip`

## Testing
- `dotnet test Dock.sln --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686c305685388321ab22c5a368a02c46