### PR TITLE
dont set _isDragging too early.

### DIFF
--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -122,8 +122,7 @@ internal class WindowDragHelper
             return;
         }
 
-        _isDragging = true;
-        _pointerPressed = false;
+  
 
         if (_lastPointerPressedArgs is null)
         {
@@ -140,6 +139,9 @@ internal class WindowDragHelper
             }
             return;
         }
+        
+        _isDragging = true;
+        _pointerPressed = false;
 
         var dockWindow = hostWindow.Window;
         if (dockWindow?.Factory?.OnWindowMoveDragBegin(dockWindow) != true)


### PR DESCRIPTION
This was preventing custom windows from being dragged a second time, on win32 due to missing PointerReleased event.