### PR TITLE
Implement dock target visibility API

### DIFF
--- a/docs/dock-manager-guide.md
+++ b/docs/dock-manager-guide.md
@@ -63,7 +63,8 @@ The manager is a small but critical part of Dock. By tailoring it you can adapt 
 
 `DockManager` exposes `IsDockTargetVisible` which determines whether a drop
 indicator is shown. The default implementation hides the center indicator when
-the dragged dockable equals the potential target. Override this method to apply
-your own rules.
+the dragged dockable equals the potential target or when the potential target is
+the current owner of the dragged dockable. Override this method to apply your
+own rules.
 
 For an overview of other concepts see the [documentation index](README.md).

--- a/docs/dock-manager-guide.md
+++ b/docs/dock-manager-guide.md
@@ -59,4 +59,11 @@ Assign the subclass to the control as shown earlier. All other methods will cont
 
 The manager is a small but critical part of Dock. By tailoring it you can adapt the docking behaviour to suit almost any workflow.
 
+## Dock target visibility
+
+`DockManager` exposes `IsDockTargetVisible` which determines whether a drop
+indicator is shown. The default implementation hides the center indicator when
+the dragged dockable equals the potential target. Override this method to apply
+your own rules.
+
 For an overview of other concepts see the [documentation index](README.md).

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -102,8 +102,11 @@ public class DockTarget : TemplatedControl
         if (visible is { } && !visible(point, operation, dragAction, relativeTo))
         {
             indicator.Opacity = 0;
+            selector.Opacity = 0;
             return false;
         }
+
+        selector.Opacity = 1;
 
         var selectorPoint = relativeTo.TranslatePoint(point, selector);
         if (selectorPoint is null)

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -55,31 +55,33 @@ public class DockTarget : TemplatedControl
         _centerSelector = e.NameScope.Find<Control>("PART_CenterSelector");
     }
 
-    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction, Func<Point, DockOperation, DragAction, Visual, bool> validate)
+    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
+        Func<Point, DockOperation, DragAction, Visual, bool> validate,
+        Func<Point, DockOperation, DragAction, Visual, bool>? visible = null)
     {
         var result = DockOperation.Window;
 
-        if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate))
+        if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate, visible))
         {
             result = DockOperation.Left;
         }
 
-        if (InvalidateIndicator(_rightSelector, _rightIndicator, point, relativeTo, DockOperation.Right, dragAction, validate))
+        if (InvalidateIndicator(_rightSelector, _rightIndicator, point, relativeTo, DockOperation.Right, dragAction, validate, visible))
         {
             result = DockOperation.Right;
         }
 
-        if (InvalidateIndicator(_topSelector, _topIndicator, point, relativeTo, DockOperation.Top, dragAction, validate))
+        if (InvalidateIndicator(_topSelector, _topIndicator, point, relativeTo, DockOperation.Top, dragAction, validate, visible))
         {
             result = DockOperation.Top;
         }
 
-        if (InvalidateIndicator(_bottomSelector, _bottomIndicator, point, relativeTo, DockOperation.Bottom, dragAction, validate))
+        if (InvalidateIndicator(_bottomSelector, _bottomIndicator, point, relativeTo, DockOperation.Bottom, dragAction, validate, visible))
         {
             result = DockOperation.Bottom;
         }
 
-        if (InvalidateIndicator(_centerSelector, _centerIndicator, point, relativeTo, DockOperation.Fill, dragAction, validate))
+        if (InvalidateIndicator(_centerSelector, _centerIndicator, point, relativeTo, DockOperation.Fill, dragAction, validate, visible))
         {
             result = DockOperation.Fill;
         }
@@ -87,10 +89,19 @@ public class DockTarget : TemplatedControl
         return result;
     }
 
-    private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo, DockOperation operation, DragAction dragAction, Func<Point, DockOperation, DragAction, Visual, bool> validate)
+    private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo,
+        DockOperation operation, DragAction dragAction,
+        Func<Point, DockOperation, DragAction, Visual, bool> validate,
+        Func<Point, DockOperation, DragAction, Visual, bool>? visible)
     {
         if (selector is null || indicator is null)
         {
+            return false;
+        }
+
+        if (visible is { } && !visible(point, operation, dragAction, relativeTo))
+        {
+            indicator.Opacity = 0;
             return false;
         }
 

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -49,26 +49,28 @@ public class GlobalDockTarget : TemplatedControl
         _rightSelector = e.NameScope.Find<Control>("PART_RightSelector");
     }
 
-    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction, Func<Point, DockOperation, DragAction, Visual, bool> validate)
+    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
+        Func<Point, DockOperation, DragAction, Visual, bool> validate,
+        Func<Point, DockOperation, DragAction, Visual, bool>? visible = null)
     {
         var result = DockOperation.None;
 
-        if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate))
+        if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate, visible))
         {
             result = DockOperation.Left;
         }
 
-        if (InvalidateIndicator(_rightSelector, _rightIndicator, point, relativeTo, DockOperation.Right, dragAction, validate))
+        if (InvalidateIndicator(_rightSelector, _rightIndicator, point, relativeTo, DockOperation.Right, dragAction, validate, visible))
         {
             result = DockOperation.Right;
         }
 
-        if (InvalidateIndicator(_topSelector, _topIndicator, point, relativeTo, DockOperation.Top, dragAction, validate))
+        if (InvalidateIndicator(_topSelector, _topIndicator, point, relativeTo, DockOperation.Top, dragAction, validate, visible))
         {
             result = DockOperation.Top;
         }
 
-        if (InvalidateIndicator(_bottomSelector, _bottomIndicator, point, relativeTo, DockOperation.Bottom, dragAction, validate))
+        if (InvalidateIndicator(_bottomSelector, _bottomIndicator, point, relativeTo, DockOperation.Bottom, dragAction, validate, visible))
         {
             result = DockOperation.Bottom;
         }
@@ -76,10 +78,19 @@ public class GlobalDockTarget : TemplatedControl
         return result;
     }
 
-    private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo, DockOperation operation, DragAction dragAction, Func<Point, DockOperation, DragAction, Visual, bool> validate)
+    private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo,
+        DockOperation operation, DragAction dragAction,
+        Func<Point, DockOperation, DragAction, Visual, bool> validate,
+        Func<Point, DockOperation, DragAction, Visual, bool>? visible)
     {
         if (selector is null || indicator is null)
         {
+            return false;
+        }
+
+        if (visible is { } && !visible(point, operation, dragAction, relativeTo))
+        {
+            indicator.Opacity = 0;
             return false;
         }
 

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -91,8 +91,11 @@ public class GlobalDockTarget : TemplatedControl
         if (visible is { } && !visible(point, operation, dragAction, relativeTo))
         {
             indicator.Opacity = 0;
+            selector.Opacity = 0;
             return false;
         }
+
+        selector.Opacity = 1;
 
         var selectorPoint = relativeTo.TranslatePoint(point, selector);
         if (selectorPoint is { })

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -76,12 +76,12 @@ internal class DockControlState : DockManagerState, IDockControlState
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal);
+            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal);
+            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         if (globalOperation != DockOperation.None)
@@ -101,12 +101,12 @@ internal class DockControlState : DockManagerState, IDockControlState
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal);
+            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal);
+            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         RemoveAdorners();
@@ -196,6 +196,21 @@ internal class DockControlState : DockManagerState, IDockControlState
         DockManager.ScreenPosition = DockHelpers.ToDockPoint(screenPoint);
 
         return DockManager.ValidateDockable(sourceDockable, dock, dragAction, operation, bExecute: false);
+    }
+
+    private bool IsDockTargetVisible(Point point, DockOperation operation, DragAction dragAction, Visual relativeTo)
+    {
+        if (_context.DragControl?.DataContext is not IDockable sourceDockable)
+        {
+            return true;
+        }
+
+        if (DropControl?.DataContext is not IDockable targetDockable)
+        {
+            return true;
+        }
+
+        return DockManager.IsDockTargetVisible(sourceDockable, targetDockable, operation);
     }
 
     protected override void Execute(Point point, DockOperation operation, DragAction dragAction, Visual relativeTo, IDockable sourceDockable, IDockable targetDockable)
@@ -383,11 +398,11 @@ internal class DockControlState : DockManagerState, IDockControlState
                             }
 
                             var globalOperation = GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget
-                                ? globalDockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateGlobal)
+                                ? globalDockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateGlobal, IsDockTargetVisible)
                                 : DockOperation.None;
-                            
+
                             var localOperation = LocalAdornerHelper.Adorner is DockTarget dockTarget
-                                ? dockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateLocal)
+                                ? dockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateLocal, IsDockTargetVisible)
                                 : DockOperation.Fill;
 
                             if (globalOperation != DockOperation.None)

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -70,12 +70,12 @@ internal class HostWindowState : DockManagerState, IHostWindowState
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal);
+            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal);
+            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         if (globalOperation != DockOperation.None)
@@ -98,12 +98,12 @@ internal class HostWindowState : DockManagerState, IHostWindowState
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal);
+            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal);
+            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         RemoveAdorners();
@@ -200,6 +200,22 @@ internal class HostWindowState : DockManagerState, IHostWindowState
         DockManager.ScreenPosition = DockHelpers.ToDockPoint(screenPoint);
 
         return DockManager.ValidateDockable(sourceDockable, dock, dragAction, operation, bExecute: false);
+    }
+
+    private bool IsDockTargetVisible(Point point, DockOperation operation, DragAction dragAction, Visual relativeTo)
+    {
+        var layout = _hostWindow.Window?.Layout;
+        if (layout?.FocusedDockable is not IDockable sourceDockable)
+        {
+            return true;
+        }
+
+        if (DropControl?.DataContext is not IDockable targetDockable)
+        {
+            return true;
+        }
+
+        return DockManager.IsDockTargetVisible(sourceDockable, targetDockable, operation);
     }
 
     /// <summary>

--- a/src/Dock.Model/Core/IDockManager.cs
+++ b/src/Dock.Model/Core/IDockManager.cs
@@ -67,4 +67,13 @@ public interface IDockManager
     /// <param name="bExecute">The flag indicating whether to execute.</param>
     /// <returns>True if docking operation can be executed otherwise false.</returns>
     bool ValidateDockable(IDockable sourceDockable, IDockable targetDockable, DragAction action, DockOperation operation, bool bExecute);
+
+    /// <summary>
+    /// Determines if a dock target indicator should be visible.
+    /// </summary>
+    /// <param name="sourceDockable">The source dockable being dragged.</param>
+    /// <param name="targetDockable">The dockable under the pointer.</param>
+    /// <param name="operation">The dock operation represented by the indicator.</param>
+    /// <returns>True to show the indicator, false to hide it.</returns>
+    bool IsDockTargetVisible(IDockable sourceDockable, IDockable targetDockable, DockOperation operation);
 }

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -569,4 +569,15 @@ public class DockManager : IDockManager
             _ => false
         };
     }
+
+    /// <inheritdoc/>
+    public virtual bool IsDockTargetVisible(IDockable sourceDockable, IDockable targetDockable, DockOperation operation)
+    {
+        if (operation == DockOperation.Fill && ReferenceEquals(sourceDockable, targetDockable))
+        {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -573,9 +573,17 @@ public class DockManager : IDockManager
     /// <inheritdoc/>
     public virtual bool IsDockTargetVisible(IDockable sourceDockable, IDockable targetDockable, DockOperation operation)
     {
-        if (operation == DockOperation.Fill && ReferenceEquals(sourceDockable, targetDockable))
+        if (operation == DockOperation.Fill)
         {
-            return false;
+            if (ReferenceEquals(sourceDockable, targetDockable))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(sourceDockable.Owner, targetDockable))
+            {
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
## Summary
- add IsDockTargetVisible to IDockManager and DockManager
- use new API in DockTarget and GlobalDockTarget
- hide center indicator when source equals target
- document custom dock target visibility

## Testing
- `dotnet test --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686d192b99708321a7a47bfde305c84d