### PR TITLE
Fix docking over existing tabstrip

### DIFF
--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -31,10 +31,12 @@ public class DockManager : IDockManager
 
     private bool MoveDockable(IDockable sourceDockable, IDock sourceDockableOwner, IDock targetDock, bool bExecute)
     {
-        if (ReferenceEquals(sourceDockableOwner, targetDock) &&
-            targetDock.VisibleDockables?.Contains(sourceDockable) == true)
+        if (ReferenceEquals(sourceDockableOwner, targetDock))
         {
-            return false;
+            if (targetDock.VisibleDockables?.Count == 1)
+            {
+                return false;
+            }
         }
         var targetDockable = targetDock.VisibleDockables?.LastOrDefault();
         if (targetDockable is null)


### PR DESCRIPTION
## Summary
- prevent docking onto the same tab strip

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686d29a2c8a08321b4a5d6d02fc768ba