### PR TITLE
Refactor dock target validation delegates

### DIFF
--- a/src/Dock.Avalonia/Contract/DockOperationHandler.cs
+++ b/src/Dock.Avalonia/Contract/DockOperationHandler.cs
@@ -1,0 +1,15 @@
+using Avalonia;
+using Avalonia.VisualTree;
+using Dock.Model.Core;
+
+namespace Dock.Avalonia.Contract;
+
+/// <summary>
+/// Represents a delegate used to evaluate dock operations.
+/// </summary>
+/// <param name="point">Pointer location relative to <paramref name="relativeTo"/>.</param>
+/// <param name="operation">The dock operation being evaluated.</param>
+/// <param name="dragAction">Current drag action.</param>
+/// <param name="relativeTo">The visual relative to which the point is measured.</param>
+/// <returns><c>true</c> when the operation is valid.</returns>
+public delegate bool DockOperationHandler(Point point, DockOperation operation, DragAction dragAction, Visual relativeTo);

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.VisualTree;
 using Dock.Model.Core;
+using Dock.Avalonia.Contract;
 
 namespace Dock.Avalonia.Controls;
 
@@ -56,8 +57,8 @@ public class DockTarget : TemplatedControl
     }
 
     internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
-        Func<Point, DockOperation, DragAction, Visual, bool> validate,
-        Func<Point, DockOperation, DragAction, Visual, bool>? visible = null)
+        DockOperationHandler validate,
+        DockOperationHandler? visible = null)
     {
         var result = DockOperation.Window;
 
@@ -91,8 +92,8 @@ public class DockTarget : TemplatedControl
 
     private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo,
         DockOperation operation, DragAction dragAction,
-        Func<Point, DockOperation, DragAction, Visual, bool> validate,
-        Func<Point, DockOperation, DragAction, Visual, bool>? visible)
+        DockOperationHandler validate,
+        DockOperationHandler? visible)
     {
         if (selector is null || indicator is null)
         {

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.VisualTree;
 using Dock.Model.Core;
+using Dock.Avalonia.Contract;
 
 namespace Dock.Avalonia.Controls;
 
@@ -50,8 +51,8 @@ public class GlobalDockTarget : TemplatedControl
     }
 
     internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
-        Func<Point, DockOperation, DragAction, Visual, bool> validate,
-        Func<Point, DockOperation, DragAction, Visual, bool>? visible = null)
+        DockOperationHandler validate,
+        DockOperationHandler? visible = null)
     {
         var result = DockOperation.None;
 
@@ -80,8 +81,8 @@ public class GlobalDockTarget : TemplatedControl
 
     private bool InvalidateIndicator(Control? selector, Panel? indicator, Point point, Visual relativeTo,
         DockOperation operation, DragAction dragAction,
-        Func<Point, DockOperation, DragAction, Visual, bool> validate,
-        Func<Point, DockOperation, DragAction, Visual, bool>? visible)
+        DockOperationHandler validate,
+        DockOperationHandler? visible)
     {
         if (selector is null || indicator is null)
         {

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -7,6 +7,7 @@ using Avalonia.VisualTree;
 using Dock.Avalonia.Controls;
 using Dock.Model.Core;
 using Dock.Model.Controls;
+using Dock.Avalonia.Contract;
 using Dock.Settings;
 
 namespace Dock.Avalonia.Internal;


### PR DESCRIPTION
## Summary
- introduce `DockOperationHandler` delegate
- use `DockOperationHandler` in `DockTarget` and `GlobalDockTarget`
- update `HostWindowState` to include new contract

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_686d3dc1e8f48321891bc48ec1dfe134