### PR TITLE
Fix WebViewSample package conditions

### DIFF
--- a/samples/WebViewSample/WebViewSample.csproj
+++ b/samples/WebViewSample/WebViewSample.csproj
@@ -43,15 +43,15 @@
   </ItemGroup>
    -->
 
-  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == x86_64">
+  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'x86_64'">
     <PackageReference Include="WebViewControl-Avalonia" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == X64">
+  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'X64'">
     <PackageReference Include="WebViewControl-Avalonia" />
   </ItemGroup>
 
-  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == Arm64">
+  <ItemGroup Condition="$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) == 'Arm64'">
     <PackageReference Include="WebViewControl-Avalonia-ARM64" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- quote architecture strings in WebViewSample's package reference conditions

## Testing
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj --no-build --verbosity minimal` *(fails: invalid argument)*
- `./build.sh` *(fails to download dependencies due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686d424bd7008321a95fb901346d174a