### PR TITLE
Add more headless tests

### DIFF
--- a/tests/Dock.Avalonia.HeadlessTests/DockHelpersTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockHelpersTests.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Internal;
+using Dock.Model.Core;
+using Xunit;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class DockHelpersTests
+{
+    [AvaloniaFact]
+    public void ToDockPoint_Returns_Correct_Point()
+    {
+        var point = new Point(10, 20);
+        var dockPoint = DockHelpers.ToDockPoint(point);
+
+        Assert.Equal(10, dockPoint.X);
+        Assert.Equal(20, dockPoint.Y);
+        Assert.Equal("10, 20", dockPoint.ToString());
+    }
+
+    [AvaloniaFact]
+    public void FindProportionalDock_Finds_Child_Dock()
+    {
+        var factory = new Factory();
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>() };
+        root.Factory = factory;
+        var docDock = new DocumentDock { Factory = factory, VisibleDockables = factory.CreateList<IDockable>() };
+        factory.AddDockable(root, docDock);
+        var proportional = new ProportionalDock { VisibleDockables = factory.CreateList<IDockable>() };
+        factory.AddDockable(docDock, proportional);
+
+        var result = DockHelpers.FindProportionalDock(docDock);
+
+        Assert.Same(proportional, result);
+    }
+}

--- a/tests/Dock.Avalonia.HeadlessTests/DockManagerDocumentTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockManagerDocumentTests.cs
@@ -1,0 +1,70 @@
+using Avalonia.Collections;
+using Avalonia.Headless.XUnit;
+using Dock.Model;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class DockManagerDocumentTests
+{
+    [AvaloniaFact]
+    public void ValidateDocument_ReturnsFalse_When_SourceCannotDrag()
+    {
+        var manager = new DockManager();
+        var source = new Document { CanDrag = false };
+        var target = new DocumentDock { VisibleDockables = new AvaloniaList<IDockable>(), CanDrop = true };
+
+        var result = manager.ValidateDocument(source, target, DragAction.Move, DockOperation.Fill, false);
+
+        Assert.False(result);
+    }
+
+    [AvaloniaFact]
+    public void ValidateDocument_ReturnsFalse_When_TargetCannotDrop()
+    {
+        var manager = new DockManager();
+        var source = new Document();
+        var target = new DocumentDock { VisibleDockables = new AvaloniaList<IDockable>(), CanDrop = false };
+
+        var result = manager.ValidateDocument(source, target, DragAction.Move, DockOperation.Fill, false);
+
+        Assert.False(result);
+    }
+
+    [AvaloniaFact]
+    public void IsDockTargetVisible_ReturnsFalse_For_Same_Dockable()
+    {
+        var manager = new DockManager();
+        var doc = new Document();
+
+        var result = manager.IsDockTargetVisible(doc, doc, DockOperation.Fill);
+
+        Assert.False(result);
+    }
+
+    [AvaloniaFact]
+    public void IsDockTargetVisible_ReturnsFalse_When_Target_Is_Owner()
+    {
+        var manager = new DockManager();
+        var dock = new DocumentDock();
+        var doc = new Document { Owner = dock };
+
+        var result = manager.IsDockTargetVisible(doc, dock, DockOperation.Fill);
+
+        Assert.False(result);
+    }
+
+    [AvaloniaFact]
+    public void IsDockTargetVisible_ReturnsTrue_For_Different_Dockables()
+    {
+        var manager = new DockManager();
+        var doc1 = new Document();
+        var doc2 = new Document();
+
+        var result = manager.IsDockTargetVisible(doc1, doc2, DockOperation.Fill);
+
+        Assert.True(result);
+    }
+}

--- a/tests/Dock.Avalonia.HeadlessTests/DockWindowTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockWindowTests.cs
@@ -1,0 +1,23 @@
+using Avalonia.Headless.XUnit;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class DockWindowTests
+{
+    [AvaloniaFact]
+    public void DockWindow_Defaults_Are_Correct()
+    {
+        var window = new DockWindow();
+
+        Assert.Equal(nameof(IDockWindow), window.Id);
+        Assert.Equal(nameof(IDockWindow), window.Title);
+        Assert.Equal(0, window.X);
+        Assert.Equal(0, window.Y);
+        Assert.Equal(0, window.Width);
+        Assert.Equal(0, window.Height);
+        Assert.False(window.Topmost);
+    }
+}

--- a/tests/Dock.Avalonia.HeadlessTests/DocumentDockCommandTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DocumentDockCommandTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class DocumentDockCommandTests
+{
+    [AvaloniaFact]
+    public void CreateDocumentCommand_Creates_Document()
+    {
+        var factory = new Factory();
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>() };
+        root.Factory = factory;
+        var dock = new DocumentDock
+        {
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>(),
+            CanCreateDocument = true,
+            DocumentTemplate = new DocumentTemplate { Content = (Func<IServiceProvider, object>)(_ => new TextBlock()) }
+        };
+        factory.AddDockable(root, dock);
+
+        dock.CreateDocument!.Execute(null);
+
+        Assert.Single(dock.VisibleDockables!);
+        Assert.IsType<Document>(dock.VisibleDockables[0]);
+    }
+
+    [AvaloniaFact]
+    public void CreateDocumentCommand_DoesNothing_When_Disabled()
+    {
+        var factory = new Factory();
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>() };
+        root.Factory = factory;
+        var dock = new DocumentDock
+        {
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>(),
+            CanCreateDocument = false,
+            DocumentTemplate = new DocumentTemplate { Content = (Func<IServiceProvider, object>)(_ => new TextBlock()) }
+        };
+        factory.AddDockable(root, dock);
+
+        dock.CreateDocument!.Execute(null);
+
+        Assert.Empty(dock.VisibleDockables!);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for DocumentDock commands
- cover DockHelpers.ToDockPoint and FindProportionalDock
- improve DockManager validations
- verify DockWindow defaults

## Testing
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686d6fac103c8321859e6edd943d1c1b