### PR TITLE
Add DockAdornerHost property

### DIFF
--- a/docs/dock-properties.md
+++ b/docs/dock-properties.md
@@ -15,6 +15,7 @@ The available properties are:
 | `IsDropArea` | `bool` | Identifies an element that can accept dropped dockables. |
 | `IsDragEnabled` | `bool` | Enables or disables dragging of dockables contained within the control. |
 | `IsDropEnabled` | `bool` | Enables or disables dropping of dockables onto the control. |
+| `DockAdornerHost` | `Control` | Specifies which control should display the dock adorner when this element is targeted. |
 
 ## Using the properties in control themes
 
@@ -28,7 +29,9 @@ Every control template that participates in docking should set the appropriate `
 
 <!-- Parts of the template that accept drops -->
 <Border x:Name="PART_BorderFill"
-        DockProperties.IsDropArea="True" />
+        DockProperties.IsDropArea="True"
+        DockProperties.IsDockTarget="True"
+        DockProperties.DockAdornerHost="{Binding #PART_Border}" />
 ```
 
 Without the attached properties above the drag logic would not detect the border as a valid drop area and documents could not be rearranged.

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -36,10 +36,13 @@
                             IsActive="{TemplateBinding IsActive}"
                             Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
                             DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"
-                            DockProperties.IsDropArea="True">
+                            DockProperties.IsDropArea="True"
+                            DockProperties.IsDockTarget="True"
+                            DockProperties.DockAdornerHost="{Binding #PART_Border}">
             <DocumentTabStrip.Styles>
               <Style Selector="DocumentTabStripItem">
                 <Setter Property="IsActive" Value="{Binding $parent[DocumentTabStrip].IsActive}" />
+                <Setter Property="(DockProperties.DockAdornerHost)" Value="{Binding #PART_Border}" />
               </Style>
             </DocumentTabStrip.Styles>
           </DocumentTabStrip>

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -65,7 +65,10 @@
           </Button>
           <ItemsPresenter x:Name="PART_ItemsPresenter"
                           ItemsPanel="{TemplateBinding ItemsPanel}" />
-          <Border Name="PART_BorderFill" DockProperties.IsDropArea="True" />
+          <Border Name="PART_BorderFill"
+                 DockProperties.IsDropArea="True"
+                 DockProperties.IsDockTarget="True"
+                 DockProperties.DockAdornerHost="{TemplateBinding DockProperties.DockAdornerHost}" />
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -194,7 +194,9 @@
                           Orientation="Horizontal"
                           Spacing="2"
                           DockProperties.IsDragArea="True"
-                          DockProperties.IsDropArea="True">
+                          DockProperties.IsDropArea="True"
+                          DockProperties.IsDockTarget="True"
+                          DockProperties.DockAdornerHost="{TemplateBinding DockProperties.DockAdornerHost}">
                 <Panel Margin="2">
                   <ContentPresenter ContentTemplate="{Binding $parent[DocumentControl].HeaderTemplate}"
                                     Content="{Binding}" />

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -37,7 +37,8 @@ internal abstract class DockManagerState : IDockManagerState
         // Local dock target
         if (isLocalValid && DropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
         {
-            LocalAdornerHelper.AddAdorner(control);
+            var host = DockProperties.GetDockAdornerHost(control) ?? control;
+            LocalAdornerHelper.AddAdorner(host);
         }
 
         // Global dock target
@@ -46,7 +47,8 @@ internal abstract class DockManagerState : IDockManagerState
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
             if (dockControl is not null)
             {
-                GlobalAdornerHelper.AddAdorner(dockControl);
+                var host = DockProperties.GetDockAdornerHost(dockControl) ?? dockControl;
+                GlobalAdornerHelper.AddAdorner(host);
             }
         }
     }
@@ -56,7 +58,8 @@ internal abstract class DockManagerState : IDockManagerState
         // Local dock target
         if (DropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
         {
-            LocalAdornerHelper.RemoveAdorner(control);
+            var host = DockProperties.GetDockAdornerHost(control) ?? control;
+            LocalAdornerHelper.RemoveAdorner(host);
         }
 
         // Global dock target
@@ -65,7 +68,8 @@ internal abstract class DockManagerState : IDockManagerState
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
             if (dockControl is not null)
             {
-                GlobalAdornerHelper.RemoveAdorner(dockControl);
+                var host = DockProperties.GetDockAdornerHost(dockControl) ?? dockControl;
+                GlobalAdornerHelper.RemoveAdorner(host);
             }
         }
     }

--- a/src/Dock.Settings/DockProperties.cs
+++ b/src/Dock.Settings/DockProperties.cs
@@ -42,6 +42,32 @@ public class DockProperties : AvaloniaObject
         AvaloniaProperty.RegisterAttached<DockProperties, Control, bool>("IsDropEnabled", true, true, BindingMode.TwoWay);
 
     /// <summary>
+    /// Defines the DockAdornerHost attached property.
+    /// </summary>
+    public static readonly AttachedProperty<Control?> DockAdornerHostProperty =
+        AvaloniaProperty.RegisterAttached<DockProperties, Control, Control?>("DockAdornerHost", null, false, BindingMode.TwoWay);
+
+    /// <summary>
+    /// Gets the control where the dock adorner should be displayed.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <returns>The adorner host control.</returns>
+    public static Control? GetDockAdornerHost(AvaloniaObject control)
+    {
+        return control.GetValue(DockAdornerHostProperty);
+    }
+
+    /// <summary>
+    /// Sets the control where the dock adorner should be displayed.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <param name="value">The host control.</param>
+    public static void SetDockAdornerHost(AvaloniaObject control, Control? value)
+    {
+        control.SetValue(DockAdornerHostProperty, value);
+    }
+
+    /// <summary>
     /// Gets the value of the IsDockTarget attached property on the specified control.
     /// </summary>
     /// <param name="control">The control.</param>


### PR DESCRIPTION
## Summary
- add DockAdornerHost attached property
- show adorners on host controls in DockManager
- use DockAdornerHost in document templates
- document the new property

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ac41d908321bf79f43279ab6db6