### PR TITLE
Add menu extensibility

### DIFF
--- a/docs/dock-context-menus.md
+++ b/docs/dock-context-menus.md
@@ -46,9 +46,16 @@ Because the controls refer to their menus using `DynamicResource`, you can suppl
 
 This approach allows you to customize the menu structure or attach your own commands without modifying Dock's source.
 
-## Extensibility analysis
+## Runtime extensibility
 
-The current design relies on static resources. Replacing or localizing items is straightforward by overriding resource keys, but adding items dynamically requires providing a completely new menu. There are no hooks to inject menu items at runtime.
+Dock now exposes an `IMenuDockable` interface implemented by all dockable view models. It provides a `MenuItems` collection where applications can register additional context menu entries from code.
 
-If extensibility is important for your application, consider wrapping the default menus in your own `ContextMenu` definitions so you can append items in XAML. Alternatively you could fork the resource dictionaries and modify them to expose extension points via data templates or bindings.
+Use the `DockMenuItemTemplate` resource to render these items inside your custom menus:
+
+```xaml
+<MenuFlyout Items="{Binding MenuItems}"
+           ItemTemplate="{StaticResource DockMenuItemTemplate}" />
+```
+
+Because the built-in menus are referenced via `DynamicResource`, you can still replace them entirely in application resources. The `MenuItems` collection lets you append or remove items dynamically without modifying Dock's XAML files.
 

--- a/src/Dock.Avalonia/Controls/DockMenuItemTemplates.axaml
+++ b/src/Dock.Avalonia/Controls/DockMenuItemTemplates.axaml
@@ -1,0 +1,15 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:core="using:Dock.Model.Core"
+                    x:CompileBindings="True">
+  <DataTemplate x:Key="DockMenuItemTemplate" DataType="core:IMenuItem">
+    <MenuItem Header="{Binding Header}"
+              Command="{Binding Command}"
+              CommandParameter="{Binding CommandParameter}"
+              IsVisible="{Binding IsVisible}"
+              IsEnabled="{Binding IsEnabled}"
+              Items="{Binding Items}"
+              ItemTemplate="{StaticResource DockMenuItemTemplate}" />
+  </DataTemplate>
+</ResourceDictionary>
+

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -157,10 +157,12 @@
       <MenuItem Header="{DynamicResource DocumentTabStripItemTabLayoutTopString}"
                 Command="{Binding Owner.Factory.SetDocumentDockTabsLayoutTop}"
                 CommandParameter="{Binding Owner}" />
-      <MenuItem Header="{DynamicResource DocumentTabStripItemTabLayoutRightString}"
+    <MenuItem Header="{DynamicResource DocumentTabStripItemTabLayoutRightString}"
                 Command="{Binding Owner.Factory.SetDocumentDockTabsLayoutRight}"
                 CommandParameter="{Binding Owner}" />
     </MenuItem>
+    <ItemsControl Items="{Binding MenuItems}"
+                  ItemTemplate="{StaticResource DockMenuItemTemplate}" />
   </ContextMenu>
   
   <ControlTheme x:Key="{x:Type DocumentTabStripItem}" TargetType="DocumentTabStripItem">

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -57,6 +57,8 @@
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
+    <ItemsControl Items="{Binding ActiveDockable.MenuItems}"
+                  ItemTemplate="{StaticResource DockMenuItemTemplate}" />
   </MenuFlyout>
 
   <ControlTheme x:Key="ChromeButton" TargetType="Button" BasedOn="{StaticResource {x:Type Button}}" >

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -44,6 +44,8 @@
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
+    <ItemsControl Items="{Binding MenuItems}"
+                  ItemTemplate="{StaticResource DockMenuItemTemplate}" />
   </ContextMenu>
 
   <ControlTheme x:Key="{x:Type ToolPinItemControl}" TargetType="ToolPinItemControl">

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -78,6 +78,8 @@
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
+    <ItemsControl Items="{Binding MenuItems}"
+                  ItemTemplate="{StaticResource DockMenuItemTemplate}" />
   </ContextMenu>
   
   <ControlTheme x:Key="{x:Type ToolTabStripItem}" TargetType="ToolTabStripItem">

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -15,6 +15,7 @@
         <ResourceInclude Source="/Controls/DocumentControl.axaml" />
         <ResourceInclude Source="/Controls/ToolChromeControl.axaml" />
         <ResourceInclude Source="/Controls/ToolControl.axaml" />
+        <ResourceInclude Source="/Controls/DockMenuItemTemplates.axaml" />
         <ResourceInclude Source="/Controls/ToolPinItemControl.axaml" />
         <ResourceInclude Source="/Controls/ToolPinnedControl.axaml" />
         <ResourceInclude Source="/Controls/DockDockControl.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -15,6 +15,7 @@
         <ResourceInclude Source="/Controls/DocumentControl.axaml" />
         <ResourceInclude Source="/Controls/ToolChromeControl.axaml" />
         <ResourceInclude Source="/Controls/ToolControl.axaml" />
+        <ResourceInclude Source="/Controls/DockMenuItemTemplates.axaml" />
         <ResourceInclude Source="/Controls/ToolPinItemControl.axaml" />
         <ResourceInclude Source="/Controls/ToolPinnedControl.axaml" />
         <ResourceInclude Source="/Controls/DockDockControl.axaml" />

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -7,6 +7,8 @@ using Avalonia.Controls;
 using Dock.Model.Adapters;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Core;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace Dock.Model.Avalonia.Core;
 
@@ -24,7 +26,7 @@ namespace Dock.Model.Avalonia.Core;
 [JsonDerivedType(typeof(Tool), typeDiscriminator: "Tool")]
 [JsonDerivedType(typeof(ToolDock), typeDiscriminator: "ToolDock")]
 [JsonDerivedType(typeof(DockBase), typeDiscriminator: "DockBase")]
-public abstract class DockableBase : ReactiveBase, IDockable
+public abstract class DockableBase : ReactiveBase, IDockable, IMenuDockable
 {
     /// <summary>
     /// Defines the <see cref="Id"/> property.
@@ -202,6 +204,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
     private double _maxHeight = double.NaN;
+    private ObservableCollection<IMenuItem> _menuItems = new();
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockableBase"/> class.
@@ -437,6 +440,10 @@ public abstract class DockableBase : ReactiveBase, IDockable
         get => _canDrop;
         set => SetAndRaise(CanDropProperty, ref _canDrop, value);
     }
+
+    /// <inheritdoc cref="IMenuDockable.MenuItems"/>
+    [IgnoreDataMember]
+    public IList<IMenuItem> MenuItems => _menuItems;
 
     /// <inheritdoc/>
     public string? GetControlRecyclingId() => _id;

--- a/src/Dock.Model.Mvvm/Core/DockableBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockableBase.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Runtime.Serialization;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using Dock.Model.Adapters;
 using Dock.Model.Core;
 
@@ -10,7 +12,7 @@ namespace Dock.Model.Mvvm.Core;
 /// Dockable base class.
 /// </summary>
 [DataContract(IsReference = true)]
-public abstract class DockableBase : ReactiveBase, IDockable
+public abstract class DockableBase : ReactiveBase, IDockable, IMenuDockable
 {
     private readonly TrackingAdapter _trackingAdapter;
     private string _id = string.Empty;
@@ -38,6 +40,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
     private double _maxHeight = double.NaN;
+    private ObservableCollection<IMenuItem> _menuItems = new();
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockableBase"/> class.
@@ -246,6 +249,10 @@ public abstract class DockableBase : ReactiveBase, IDockable
         get => _canDrop;
         set => SetProperty(ref _canDrop, value);
     }
+
+    /// <inheritdoc cref="IMenuDockable.MenuItems"/>
+    [IgnoreDataMember]
+    public IList<IMenuItem> MenuItems => _menuItems;
 
     /// <inheritdoc/>
     public string? GetControlRecyclingId() => _id;

--- a/src/Dock.Model/Core/IMenuDockable.cs
+++ b/src/Dock.Model/Core/IMenuDockable.cs
@@ -1,0 +1,13 @@
+namespace Dock.Model.Core;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// Provides a collection of menu items for context menus.
+/// </summary>
+public interface IMenuDockable
+{
+    /// <summary>Gets collection of menu items.</summary>
+    IList<IMenuItem> MenuItems { get; }
+}
+

--- a/src/Dock.Model/Core/MenuItem.cs
+++ b/src/Dock.Model/Core/MenuItem.cs
@@ -1,0 +1,53 @@
+namespace Dock.Model.Core;
+
+using System.Collections.Generic;
+using System.Windows.Input;
+
+/// <summary>
+/// Represents a menu item used for context menus and flyouts.
+/// </summary>
+public interface IMenuItem
+{
+    /// <summary>Gets or sets item header.</summary>
+    string Header { get; set; }
+
+    /// <summary>Gets or sets command executed by the item.</summary>
+    ICommand? Command { get; set; }
+
+    /// <summary>Gets or sets command parameter.</summary>
+    object? CommandParameter { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the item is enabled.</summary>
+    bool IsEnabled { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the item is visible.</summary>
+    bool IsVisible { get; set; }
+
+    /// <summary>Gets collection of child menu items.</summary>
+    IList<IMenuItem>? Items { get; set; }
+}
+
+/// <summary>
+/// Default implementation of <see cref="IMenuItem"/>.
+/// </summary>
+public class MenuItem : IMenuItem
+{
+    /// <inheritdoc />
+    public string Header { get; set; } = string.Empty;
+
+    /// <inheritdoc />
+    public ICommand? Command { get; set; }
+
+    /// <inheritdoc />
+    public object? CommandParameter { get; set; }
+
+    /// <inheritdoc />
+    public bool IsEnabled { get; set; } = true;
+
+    /// <inheritdoc />
+    public bool IsVisible { get; set; } = true;
+
+    /// <inheritdoc />
+    public IList<IMenuItem>? Items { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- introduce `IMenuDockable` and `IMenuItem` to expose menu items from view models
- implement the interface in Mvvm and Avalonia dockable bases
- add `DockMenuItemTemplate` and wire menu item bindings in built-in context menus
- update themes to include the new resource dictionary
- document runtime menu extensibility

## Testing
- `dotnet test` *(fails: Repository has no remote, network calls blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b3c31f8832199d2a31759a3d3a8