### PR TITLE
Add proportional splitter context menu

### DIFF
--- a/docs/dock-context-menus.md
+++ b/docs/dock-context-menus.md
@@ -10,6 +10,7 @@ Dock defines several built in context menus and flyouts that are attached to its
 | `ToolPinItemControl.axaml` | `ToolPinItemControlContextMenu` | Menu for pinned tool tabs. |
 | `DocumentTabStripItem.axaml` | `DocumentTabStripItemContextMenu` | Menu for document tab items. |
 | `ToolTabStripItem.axaml` | `ToolTabStripItemContextMenu` | Menu for tool tab items. |
+| `ProportionalStackPanelSplitter.axaml` | `ProportionalStackPanelSplitterContextMenu` | Splitter menu for adjusting proportions. |
 
 Each dictionary also declares `x:String` resources used for menu item headers. For example `ToolTabStripItem.axaml` exposes keys such as `ToolTabStripItemFloatString`, `ToolTabStripItemDockString` and others.
 

--- a/src/Dock.Avalonia/Controls/ControlStrings.axaml
+++ b/src/Dock.Avalonia/Controls/ControlStrings.axaml
@@ -41,6 +41,16 @@
   <x:String x:Key="ToolTabStripItemDockAsDocumentString">Dock as Tabbed Document</x:String>
   <x:String x:Key="ToolTabStripItemCloseString">_Close</x:String>
 
+  <!-- ProportionalStackPanelSplitter -->
+  <x:String x:Key="ProportionalStackPanelSplitterResetString">Reset</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter10String">10%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter25String">25%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter33String">33%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter50String">50%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter66String">66%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter75String">75%</x:String>
+  <x:String x:Key="ProportionalStackPanelSplitter90String">90%</x:String>
+
   <!-- RootDockDebug -->
   <x:String x:Key="RootDockDebugIdString">Id</x:String>
   <x:String x:Key="RootDockDebugTitleString">Title</x:String>

--- a/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml
+++ b/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml
@@ -1,9 +1,21 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <ContextMenu x:Key="ProportionalStackPanelSplitterContextMenu">
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitterResetString}" Click="ResetProportion" />
+    <Separator />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter10String}" Tag="0.1" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter25String}" Tag="0.25" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter33String}" Tag="0.3333" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter50String}" Tag="0.5" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter66String}" Tag="0.6667" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter75String}" Tag="0.75" Click="SetProportion" />
+    <MenuItem Header="{DynamicResource ProportionalStackPanelSplitter90String}" Tag="0.9" Click="SetProportion" />
+  </ContextMenu>
 
   <ControlTheme x:Key="{x:Type ProportionalStackPanelSplitter}" TargetType="ProportionalStackPanelSplitter">
 
     <Setter Property="Background" Value="Transparent" />
+    <Setter Property="ContextMenu" Value="{DynamicResource ProportionalStackPanelSplitterContextMenu}" />
     
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml.cs
+++ b/src/Dock.Controls.ProportionalStackPanel/ProportionalStackPanelSplitter.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 
 namespace Dock.Controls.ProportionalStackPanel;
@@ -326,5 +327,40 @@ public class ProportionalStackPanelSplitter : Thumb
     private Control? GetTargetElement(ProportionalStackPanel panel)
     {
         return GetSiblingInDirection(panel, -1);
+    }
+
+    private void ResetProportion(object? sender, RoutedEventArgs e)
+    {
+        if (GetPanel() is { } panel)
+        {
+            var target = GetTargetElement(panel);
+            var neighbour = FindNextChild(panel);
+            if (target is null || neighbour is null)
+                return;
+
+            ProportionalStackPanel.SetProportion(target, double.NaN);
+            ProportionalStackPanel.SetProportion(neighbour, double.NaN);
+        }
+    }
+
+    private void SetProportion(object? sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { Tag: var tag } && double.TryParse(tag?.ToString(), out var proportion))
+        {
+            if (GetPanel() is { } panel)
+            {
+                var target = GetTargetElement(panel);
+                var neighbour = FindNextChild(panel);
+                if (target is null || neighbour is null)
+                    return;
+
+                var neighbourProp = ProportionalStackPanel.GetProportion(neighbour);
+                var current = ProportionalStackPanel.GetProportion(target);
+                var delta = proportion - current;
+
+                ProportionalStackPanel.SetProportion(target, proportion);
+                ProportionalStackPanel.SetProportion(neighbour, neighbourProp - delta);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add string resources for proportional splitter context menu
- implement context menu and add event handlers to set/reset proportions
- document new menu in docs

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b8fb6e88321a374e1bc2123cda8