### PR TITLE
Rename ShowIndicatorsOnly to ShowSelectorsOnly

### DIFF
--- a/docs/dock-properties.md
+++ b/docs/dock-properties.md
@@ -15,7 +15,7 @@ The available properties are:
 | `IsDropArea` | `bool` | Identifies an element that can accept dropped dockables. |
 | `IsDragEnabled` | `bool` | Enables or disables dragging of dockables contained within the control. |
 | `IsDropEnabled` | `bool` | Enables or disables dropping of dockables onto the control. |
-| `ShowDockIndicatorOnly` | `bool` | Hides the dock target visuals and displays only drop indicators. |
+| `ShowDockSelectorOnly` | `bool` | Hides the drop indicators and displays only dock selectors. |
 | `DockAdornerHost` | `Control` | Specifies the element that should display the dock target adorner. |
 
 ## Using the properties in control themes
@@ -32,7 +32,7 @@ Every control template that participates in docking should set the appropriate `
 <Border x:Name="PART_BorderFill"
         DockProperties.IsDropArea="True"
         DockProperties.IsDockTarget="True"
-        DockProperties.ShowDockIndicatorOnly="True"
+        DockProperties.ShowDockSelectorOnly="True"
         DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
 ```
 

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml
@@ -108,29 +108,20 @@
       <Setter Property="Height" Value="40" />
     </Style>
 
-    <!-- Hide side indicators when only the center operation is required -->
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_TopIndicator">
+    <!-- Hide all indicators when only selectors should be shown -->
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_TopIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_BottomIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_BottomIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_LeftIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_LeftIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_RightIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_RightIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_TopSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_BottomSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_LeftSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_RightSelector">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_CenterIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
 

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -39,18 +39,18 @@ public class DockTarget : TemplatedControl
     private Control? _centerSelector;
 
     /// <summary>
-    /// Gets or sets whether only drop indicators should be shown.
+    /// Gets or sets whether only drop selectors should be shown.
     /// </summary>
-    public static readonly StyledProperty<bool> ShowIndicatorsOnlyProperty =
-        AvaloniaProperty.Register<DockTarget, bool>(nameof(ShowIndicatorsOnly));
+    public static readonly StyledProperty<bool> ShowSelectorsOnlyProperty =
+        AvaloniaProperty.Register<DockTarget, bool>(nameof(ShowSelectorsOnly));
 
     /// <summary>
-    /// Gets or sets whether only drop indicators should be shown.
+    /// Gets or sets whether only drop selectors should be shown.
     /// </summary>
-    public bool ShowIndicatorsOnly
+    public bool ShowSelectorsOnly
     {
-        get => GetValue(ShowIndicatorsOnlyProperty);
-        set => SetValue(ShowIndicatorsOnlyProperty, value);
+        get => GetValue(ShowSelectorsOnlyProperty);
+        set => SetValue(ShowSelectorsOnlyProperty, value);
     }
 
     /// <inheritdoc/>
@@ -138,13 +138,27 @@ public class DockTarget : TemplatedControl
             {
                 if (validate(point, operation, dragAction, relativeTo))
                 {
-                    indicator.Opacity = 0.5;
+                    if (ShowSelectorsOnly)
+                    {
+                        selector.Opacity = 0.5;
+                    }
+                    else
+                    {
+                        indicator.Opacity = 0.5;
+                    }
                     return true;
                 }
             }
         }
 
-        indicator.Opacity = 0;
+        if (!ShowSelectorsOnly)
+        {
+            indicator.Opacity = 0;
+        }
+        else
+        {
+            selector.Opacity = 1;
+        }
         return false;
     }
 }

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -68,7 +68,7 @@
           <Border Name="PART_BorderFill"
                   DockProperties.IsDropArea="True"
                   DockProperties.IsDockTarget="True"
-                  DockProperties.ShowDockIndicatorOnly="True"
+                  DockProperties.ShowDockSelectorOnly="True"
                   DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
         </DockPanel>
       </ControlTemplate>

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml
@@ -91,29 +91,20 @@
       <Setter Property="Height" Value="40" />
     </Style>
 
-    <!-- Hide side indicators when only the center operation is required -->
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_TopIndicator">
+    <!-- Hide all indicators when only selectors should be shown -->
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_TopIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_BottomIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_BottomIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_LeftIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_LeftIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Panel#PART_RightIndicator">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_RightIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_TopSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_BottomSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_LeftSelector">
-      <Setter Property="IsVisible" Value="False" />
-    </Style>
-    <Style Selector="^[ShowIndicatorsOnly=True] /template/ Image#PART_RightSelector">
+    <Style Selector="^[ShowSelectorsOnly=True] /template/ Panel#PART_CenterIndicator">
       <Setter Property="IsVisible" Value="False" />
     </Style>
 

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -35,18 +35,18 @@ public class GlobalDockTarget : TemplatedControl
     private Control? _rightSelector;
 
     /// <summary>
-    /// Gets or sets whether only drop indicators should be shown.
+    /// Gets or sets whether only drop selectors should be shown.
     /// </summary>
-    public static readonly StyledProperty<bool> ShowIndicatorsOnlyProperty =
-        AvaloniaProperty.Register<GlobalDockTarget, bool>(nameof(ShowIndicatorsOnly));
+    public static readonly StyledProperty<bool> ShowSelectorsOnlyProperty =
+        AvaloniaProperty.Register<GlobalDockTarget, bool>(nameof(ShowSelectorsOnly));
 
     /// <summary>
-    /// Gets or sets whether only drop indicators should be shown.
+    /// Gets or sets whether only drop selectors should be shown.
     /// </summary>
-    public bool ShowIndicatorsOnly
+    public bool ShowSelectorsOnly
     {
-        get => GetValue(ShowIndicatorsOnlyProperty);
-        set => SetValue(ShowIndicatorsOnlyProperty, value);
+        get => GetValue(ShowSelectorsOnlyProperty);
+        set => SetValue(ShowSelectorsOnlyProperty, value);
     }
 
     /// <inheritdoc/>
@@ -127,13 +127,27 @@ public class GlobalDockTarget : TemplatedControl
             {
                 if (validate(point, operation, dragAction, relativeTo))
                 {
-                    indicator.Opacity = 0.5;
+                    if (ShowSelectorsOnly)
+                    {
+                        selector.Opacity = 0.5;
+                    }
+                    else
+                    {
+                        indicator.Opacity = 0.5;
+                    }
                     return true;
                 }
             }
         }
 
-        indicator.Opacity = 0;
+        if (!ShowSelectorsOnly)
+        {
+            indicator.Opacity = 0;
+        }
+        else
+        {
+            selector.Opacity = 1;
+        }
         return false;
     }
 }

--- a/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
@@ -39,7 +39,7 @@
           <Border Name="PART_BorderFill"
                  DockProperties.IsDropArea="True"
                  DockProperties.IsDockTarget="True"
-                 DockProperties.ShowDockIndicatorOnly="True"
+                 DockProperties.ShowDockSelectorOnly="True"
                  DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
         </DockPanel>
       </ControlTemplate>

--- a/src/Dock.Avalonia/Internal/AdornerHelper.cs
+++ b/src/Dock.Avalonia/Internal/AdornerHelper.cs
@@ -20,19 +20,19 @@ internal class AdornerHelper<T> where T : Control, new()
         _useFloatingDockAdorner = useFloatingDockAdorner;
     }
 
-    public void AddAdorner(Visual visual, bool indicatorsOnly)
+    public void AddAdorner(Visual visual, bool selectorsOnly)
     {
         if (_useFloatingDockAdorner)
         {
-            AddFloatingAdorner(visual, indicatorsOnly);
+            AddFloatingAdorner(visual, selectorsOnly);
         }
         else
         {
-            AddRegularAdorner(visual, indicatorsOnly);
+            AddRegularAdorner(visual, selectorsOnly);
         }
     }
 
-    private void AddFloatingAdorner(Visual visual, bool indicatorsOnly)
+    private void AddFloatingAdorner(Visual visual, bool selectorsOnly)
     {
         if (_window is not null)
         {
@@ -46,11 +46,11 @@ internal class AdornerHelper<T> where T : Control, new()
         {
             if (adorner is DockTarget dockTarget)
             {
-                dockTarget.ShowIndicatorsOnly = indicatorsOnly;
+                dockTarget.ShowSelectorsOnly = selectorsOnly;
             }
             else if (adorner is GlobalDockTarget globalDockTarget)
             {
-                globalDockTarget.ShowIndicatorsOnly = indicatorsOnly;
+                globalDockTarget.ShowSelectorsOnly = selectorsOnly;
             }
         }
 
@@ -82,7 +82,7 @@ internal class AdornerHelper<T> where T : Control, new()
         _window.Show(root);
     }
 
-    private void AddRegularAdorner(Visual visual, bool indicatorsOnly)
+    private void AddRegularAdorner(Visual visual, bool selectorsOnly)
     {
         var layer = AdornerLayer.GetAdornerLayer(visual);
         if (layer is null)
@@ -105,11 +105,11 @@ internal class AdornerHelper<T> where T : Control, new()
         {
             if (adorner is DockTarget dockTarget)
             {
-                dockTarget.ShowIndicatorsOnly = indicatorsOnly;
+                dockTarget.ShowSelectorsOnly = selectorsOnly;
             }
             else if (adorner is GlobalDockTarget globalDockTarget)
             {
-                globalDockTarget.ShowIndicatorsOnly = indicatorsOnly;
+                globalDockTarget.ShowSelectorsOnly = selectorsOnly;
             }
         }
         ((ISetLogicalParent) Adorner).SetParent(visual);

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -38,8 +38,8 @@ internal abstract class DockManagerState : IDockManagerState
         if (isLocalValid && DropControl is { } control && control.GetValue(DockProperties.IsDockTargetProperty))
         {
             var host = DockProperties.GetDockAdornerHost(control) ?? control;
-            var indicatorsOnly = DockProperties.GetShowDockIndicatorOnly(control);
-            LocalAdornerHelper.AddAdorner(host, indicatorsOnly);
+            var selectorsOnly = DockProperties.GetShowDockSelectorOnly(control);
+            LocalAdornerHelper.AddAdorner(host, selectorsOnly);
         }
 
         // Global dock target
@@ -48,8 +48,8 @@ internal abstract class DockManagerState : IDockManagerState
             var dockControl = dropControl.FindAncestorOfType<DockControl>();
             if (dockControl is not null)
             {
-                var indicatorsOnly = DockProperties.GetShowDockIndicatorOnly(dropControl);
-                GlobalAdornerHelper.AddAdorner(dockControl, indicatorsOnly);
+                var selectorsOnly = DockProperties.GetShowDockSelectorOnly(dropControl);
+                GlobalAdornerHelper.AddAdorner(dockControl, selectorsOnly);
             }
         }
     }

--- a/src/Dock.Settings/DockProperties.cs
+++ b/src/Dock.Settings/DockProperties.cs
@@ -42,12 +42,12 @@ public class DockProperties : AvaloniaObject
         AvaloniaProperty.RegisterAttached<DockProperties, Control, bool>("IsDropEnabled", true, true, BindingMode.TwoWay);
 
     /// <summary>
-    /// Defines the ShowDockIndicatorOnly attached property.
+    /// Defines the ShowDockSelectorOnly attached property.
     /// When set to true the dock adorner displays only
-    /// drop indicators and hides the dock target visuals.
+    /// drop selectors and hides the drop indicators.
     /// </summary>
-    public static readonly AttachedProperty<bool> ShowDockIndicatorOnlyProperty =
-        AvaloniaProperty.RegisterAttached<DockProperties, Control, bool>("ShowDockIndicatorOnly", false, false, BindingMode.TwoWay);
+    public static readonly AttachedProperty<bool> ShowDockSelectorOnlyProperty =
+        AvaloniaProperty.RegisterAttached<DockProperties, Control, bool>("ShowDockSelectorOnly", false, false, BindingMode.TwoWay);
 
     /// <summary>
     /// Defines the DockAdornerHost attached property.
@@ -158,23 +158,23 @@ public class DockProperties : AvaloniaObject
     }
 
     /// <summary>
-    /// Gets the value of the ShowDockIndicatorOnly attached property on the specified control.
+    /// Gets the value of the ShowDockSelectorOnly attached property on the specified control.
     /// </summary>
     /// <param name="control">The control.</param>
-    /// <returns>The ShowDockIndicatorOnly attached property.</returns>
-    public static bool GetShowDockIndicatorOnly(AvaloniaObject control)
+    /// <returns>The ShowDockSelectorOnly attached property.</returns>
+    public static bool GetShowDockSelectorOnly(AvaloniaObject control)
     {
-        return control.GetValue(ShowDockIndicatorOnlyProperty);
+        return control.GetValue(ShowDockSelectorOnlyProperty);
     }
 
     /// <summary>
-    /// Sets the value of the ShowDockIndicatorOnly attached property on the specified control.
+    /// Sets the value of the ShowDockSelectorOnly attached property on the specified control.
     /// </summary>
     /// <param name="control">The control.</param>
-    /// <param name="value">The value of the ShowDockIndicatorOnly property.</param>
-    public static void SetShowDockIndicatorOnly(AvaloniaObject control, bool value)
+    /// <param name="value">The value of the ShowDockSelectorOnly property.</param>
+    public static void SetShowDockSelectorOnly(AvaloniaObject control, bool value)
     {
-        control.SetValue(ShowDockIndicatorOnlyProperty, value);
+        control.SetValue(ShowDockSelectorOnlyProperty, value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- rename `ShowIndicatorsOnly` to `ShowSelectorsOnly`
- adjust attached property and docs to match
- highlight selectors when `ShowSelectorsOnly` is enabled

## Testing
- `dotnet test` *(fails: Repository has no remote)*

------
https://chatgpt.com/codex/tasks/task_e_686f71268b90832196325f4ab41c8184