### PR TITLE
Add IndicatorDockOperation property

### DIFF
--- a/docs/dock-properties.md
+++ b/docs/dock-properties.md
@@ -16,6 +16,7 @@ The available properties are:
 | `IsDragEnabled` | `bool` | Enables or disables dragging of dockables contained within the control. |
 | `IsDropEnabled` | `bool` | Enables or disables dropping of dockables onto the control. |
 | `ShowDockIndicatorOnly` | `bool` | Hides the dock target visuals and displays only drop indicators. |
+| `IndicatorDockOperation` | `DockOperation` | Specifies which dock operation a control represents when only indicators are shown. |
 | `DockAdornerHost` | `Control` | Specifies the element that should display the dock target adorner. |
 
 ## Using the properties in control themes
@@ -33,6 +34,7 @@ Every control template that participates in docking should set the appropriate `
         DockProperties.IsDropArea="True"
         DockProperties.IsDockTarget="True"
         DockProperties.ShowDockIndicatorOnly="True"
+        DockProperties.IndicatorDockOperation="Fill"
         DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
 ```
 

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -96,7 +96,7 @@ public class DockTarget : TemplatedControl
             if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
             if (_centerIndicator is { } && indicator != _centerIndicator) _centerIndicator.Opacity = 0;
 
-            return InvalidateIndicator(this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+            return InvalidateIndicator(relativeTo as Control ?? this, indicator, point, relativeTo, operation, dragAction, validate, visible)
                 ? operation
                 : DockOperation.Window;
         }

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -72,13 +72,14 @@ public class DockTarget : TemplatedControl
         _centerSelector = e.NameScope.Find<Control>("PART_CenterSelector");
     }
 
-    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
+    internal DockOperation GetDockOperation(Point point, Control dropControl, Visual relativeTo,
+        DragAction dragAction,
         DockOperationHandler validate,
         DockOperationHandler? visible = null)
     {
         if (ShowIndicatorsOnly)
         {
-            var operation = DockProperties.GetIndicatorDockOperation(this);
+            var operation = DockProperties.GetIndicatorDockOperation(dropControl);
             var indicator = operation switch
             {
                 DockOperation.Left => _leftIndicator,
@@ -96,7 +97,7 @@ public class DockTarget : TemplatedControl
             if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
             if (_centerIndicator is { } && indicator != _centerIndicator) _centerIndicator.Opacity = 0;
 
-            return InvalidateIndicator(relativeTo as Control ?? this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+            return InvalidateIndicator(dropControl, indicator, point, relativeTo, operation, dragAction, validate, visible)
                 ? operation
                 : DockOperation.Window;
         }

--- a/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockTarget.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.VisualTree;
 using Dock.Model.Core;
 using Dock.Avalonia.Contract;
+using Dock.Settings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -75,6 +76,31 @@ public class DockTarget : TemplatedControl
         DockOperationHandler validate,
         DockOperationHandler? visible = null)
     {
+        if (ShowIndicatorsOnly)
+        {
+            var operation = DockProperties.GetIndicatorDockOperation(this);
+            var indicator = operation switch
+            {
+                DockOperation.Left => _leftIndicator,
+                DockOperation.Right => _rightIndicator,
+                DockOperation.Top => _topIndicator,
+                DockOperation.Bottom => _bottomIndicator,
+                DockOperation.Fill => _centerIndicator,
+                _ => null
+            };
+
+            // hide unused indicators
+            if (_leftIndicator is { } && indicator != _leftIndicator) _leftIndicator.Opacity = 0;
+            if (_rightIndicator is { } && indicator != _rightIndicator) _rightIndicator.Opacity = 0;
+            if (_topIndicator is { } && indicator != _topIndicator) _topIndicator.Opacity = 0;
+            if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
+            if (_centerIndicator is { } && indicator != _centerIndicator) _centerIndicator.Opacity = 0;
+
+            return InvalidateIndicator(this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+                ? operation
+                : DockOperation.Window;
+        }
+
         var result = DockOperation.Window;
 
         if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate, visible))

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -69,6 +69,7 @@
                   DockProperties.IsDropArea="True"
                   DockProperties.IsDockTarget="True"
                   DockProperties.ShowDockIndicatorOnly="True"
+                  DockProperties.IndicatorDockOperation="Fill"
                   DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
         </DockPanel>
       </ControlTemplate>

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -66,13 +66,14 @@ public class GlobalDockTarget : TemplatedControl
         _rightSelector = e.NameScope.Find<Control>("PART_RightSelector");
     }
 
-    internal DockOperation GetDockOperation(Point point, Visual relativeTo, DragAction dragAction,
+    internal DockOperation GetDockOperation(Point point, Control dropControl, Visual relativeTo,
+        DragAction dragAction,
         DockOperationHandler validate,
         DockOperationHandler? visible = null)
     {
         if (ShowIndicatorsOnly)
         {
-            var operation = DockProperties.GetIndicatorDockOperation(this);
+            var operation = DockProperties.GetIndicatorDockOperation(dropControl);
             var indicator = operation switch
             {
                 DockOperation.Left => _leftIndicator,
@@ -87,7 +88,7 @@ public class GlobalDockTarget : TemplatedControl
             if (_topIndicator is { } && indicator != _topIndicator) _topIndicator.Opacity = 0;
             if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
 
-            return InvalidateIndicator(relativeTo as Control ?? this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+            return InvalidateIndicator(dropControl, indicator, point, relativeTo, operation, dragAction, validate, visible)
                 ? operation
                 : DockOperation.None;
         }

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -9,6 +9,7 @@ using Avalonia.Input;
 using Avalonia.VisualTree;
 using Dock.Model.Core;
 using Dock.Avalonia.Contract;
+using Dock.Settings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -69,6 +70,28 @@ public class GlobalDockTarget : TemplatedControl
         DockOperationHandler validate,
         DockOperationHandler? visible = null)
     {
+        if (ShowIndicatorsOnly)
+        {
+            var operation = DockProperties.GetIndicatorDockOperation(this);
+            var indicator = operation switch
+            {
+                DockOperation.Left => _leftIndicator,
+                DockOperation.Right => _rightIndicator,
+                DockOperation.Top => _topIndicator,
+                DockOperation.Bottom => _bottomIndicator,
+                _ => null
+            };
+
+            if (_leftIndicator is { } && indicator != _leftIndicator) _leftIndicator.Opacity = 0;
+            if (_rightIndicator is { } && indicator != _rightIndicator) _rightIndicator.Opacity = 0;
+            if (_topIndicator is { } && indicator != _topIndicator) _topIndicator.Opacity = 0;
+            if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
+
+            return InvalidateIndicator(this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+                ? operation
+                : DockOperation.None;
+        }
+
         var result = DockOperation.None;
 
         if (InvalidateIndicator(_leftSelector, _leftIndicator, point, relativeTo, DockOperation.Left, dragAction, validate, visible))

--- a/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
+++ b/src/Dock.Avalonia/Controls/GlobalDockTarget.axaml.cs
@@ -87,7 +87,7 @@ public class GlobalDockTarget : TemplatedControl
             if (_topIndicator is { } && indicator != _topIndicator) _topIndicator.Opacity = 0;
             if (_bottomIndicator is { } && indicator != _bottomIndicator) _bottomIndicator.Opacity = 0;
 
-            return InvalidateIndicator(this, indicator, point, relativeTo, operation, dragAction, validate, visible)
+            return InvalidateIndicator(relativeTo as Control ?? this, indicator, point, relativeTo, operation, dragAction, validate, visible)
                 ? operation
                 : DockOperation.None;
         }

--- a/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
@@ -36,10 +36,11 @@
             <ItemsPresenter Name="PART_ItemsPresenter"
                             ItemsPanel="{TemplateBinding ItemsPanel}"/>
           </Border>
-          <Border Name="PART_BorderFill"
+         <Border Name="PART_BorderFill"
                  DockProperties.IsDropArea="True"
                  DockProperties.IsDockTarget="True"
                  DockProperties.ShowDockIndicatorOnly="True"
+                 DockProperties.IndicatorDockOperation="Fill"
                  DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
         </DockPanel>
       </ControlTemplate>

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -69,19 +69,19 @@ internal class DockControlState : DockManagerState, IDockControlState
         AddAdorners(isLocalValid, isGlobalValid);
     }
 
-    private void Over(Point point, DragAction dragAction, Visual relativeTo)
+    private void Over(Point point, DragAction dragAction, Control dropControl, Visual relativeTo)
     {
         var localOperation = DockOperation.Fill;
         var globalOperation = DockOperation.None;
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
+            localOperation = dockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
+            globalOperation = globalDockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         if (globalOperation != DockOperation.None)
@@ -94,19 +94,19 @@ internal class DockControlState : DockManagerState, IDockControlState
         }
     }
 
-    private void Drop(Point point, DragAction dragAction, Visual relativeTo)
+    private void Drop(Point point, DragAction dragAction, Control dropControl, Visual relativeTo)
     {
         var localOperation = DockOperation.Fill;
         var globalOperation = DockOperation.None;
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
+            localOperation = dockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
+            globalOperation = globalDockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         RemoveAdorners();
@@ -118,12 +118,12 @@ internal class DockControlState : DockManagerState, IDockControlState
 
         if (globalOperation != DockOperation.None)
         {
-            if (DropControl is not { } dropControl)
+            if (DropControl is not { } dropCtrl)
             {
                 return;
             }
-            
-            var dockControl = dropControl.FindAncestorOfType<DockControl>();
+
+            var dockControl = dropCtrl.FindAncestorOfType<DockControl>();
             if (dockControl is null)
             {
                 return;
@@ -174,12 +174,12 @@ internal class DockControlState : DockManagerState, IDockControlState
             return false;
         }
 
-        if (DropControl is not { } dropControl)
+        if (DropControl is not { } dropCtrl)
         {
             return false;
         }
 
-        var dockControl = dropControl.FindAncestorOfType<DockControl>();
+        var dockControl = dropCtrl.FindAncestorOfType<DockControl>();
         if (dockControl?.Layout is not { ActiveDockable: IDock dock })
         {
             return false;
@@ -284,7 +284,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                         var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);
                         if (isDropEnabled)
                         {
-                            Drop(_context.TargetPoint, dragAction, _context.TargetDockControl);
+                            Drop(_context.TargetPoint, dragAction, dropControl, _context.TargetDockControl);
                             executed = true;
                         }
                     }
@@ -381,7 +381,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                             {
                                 _context.TargetPoint = targetPoint;
                                 _context.TargetDockControl = targetDockControl;
-                                Over(targetPoint, dragAction, targetDockControl);
+                                Over(targetPoint, dragAction, dropControl, targetDockControl);
                             }
                             else
                             {
@@ -398,11 +398,11 @@ internal class DockControlState : DockManagerState, IDockControlState
                             }
 
                             var globalOperation = GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget
-                                ? globalDockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateGlobal, IsDockTargetVisible)
+                                ? globalDockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateGlobal, IsDockTargetVisible)
                                 : DockOperation.None;
 
                             var localOperation = LocalAdornerHelper.Adorner is DockTarget dockTarget
-                                ? dockTarget.GetDockOperation(targetPoint, targetDockControl, dragAction, ValidateLocal, IsDockTargetVisible)
+                                ? dockTarget.GetDockOperation(targetPoint, dropControl, targetDockControl, dragAction, ValidateLocal, IsDockTargetVisible)
                                 : DockOperation.Fill;
 
                             if (globalOperation != DockOperation.None)

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -64,19 +64,19 @@ internal class HostWindowState : DockManagerState, IHostWindowState
         AddAdorners(isLocalValid, isGlobalValid);
     }
 
-    private void Over(Point point, DragAction dragAction, Visual relativeTo)
+    private void Over(Point point, DragAction dragAction, Control dropControl, Visual relativeTo)
     {
         var localOperation = DockOperation.Fill;
         var globalOperation = DockOperation.None;
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
+            localOperation = dockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
+            globalOperation = globalDockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         if (globalOperation != DockOperation.None)
@@ -92,19 +92,19 @@ internal class HostWindowState : DockManagerState, IHostWindowState
         }
     }
 
-    private void Drop(Point point, DragAction dragAction, Visual relativeTo)
+    private void Drop(Point point, DragAction dragAction, Control dropControl, Visual relativeTo)
     {
         var localOperation = DockOperation.Window;
         var globalOperation = DockOperation.None;
 
         if (LocalAdornerHelper.Adorner is DockTarget dockTarget)
         {
-            localOperation = dockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
+            localOperation = dockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateLocal, IsDockTargetVisible);
         }
 
         if (GlobalAdornerHelper.Adorner is GlobalDockTarget globalDockTarget)
         {
-            globalOperation = globalDockTarget.GetDockOperation(point, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
+            globalOperation = globalDockTarget.GetDockOperation(point, dropControl, relativeTo, dragAction, ValidateGlobal, IsDockTargetVisible);
         }
 
         RemoveAdorners();
@@ -118,12 +118,12 @@ internal class HostWindowState : DockManagerState, IHostWindowState
 
         if (globalOperation != DockOperation.None)
         {
-            if (DropControl is not { } dropControl)
+            if (DropControl is not { } dropCtrl)
             {
                 return;
             }
-            
-            var dockControl = dropControl.FindAncestorOfType<DockControl>();
+
+            var dockControl = dropCtrl.FindAncestorOfType<DockControl>();
             if (dockControl is null)
             {
                 return;
@@ -179,12 +179,12 @@ internal class HostWindowState : DockManagerState, IHostWindowState
             return false;
         }
 
-        if (DropControl is not { } dropControl)
+        if (DropControl is not { } dropCtrl)
         {
             return false;
         }
 
-        var dockControl = dropControl.FindAncestorOfType<DockControl>();
+        var dockControl = dropCtrl.FindAncestorOfType<DockControl>();
         if (dockControl?.Layout is not { ActiveDockable: IDock dock })
         {
             return false;
@@ -260,7 +260,7 @@ internal class HostWindowState : DockManagerState, IHostWindowState
 
                         if (isDropEnabled)
                         {
-                            Drop(_context.TargetPoint, _context.DragAction, _context.TargetDockControl);
+                            Drop(_context.TargetPoint, _context.DragAction, DropControl, _context.TargetDockControl);
                         }
                     } 
                 }
@@ -326,7 +326,7 @@ internal class HostWindowState : DockManagerState, IHostWindowState
                                 _context.TargetPoint = dockControlPoint;
                                 DropControl = dropControl;
                                 _context.DragAction = DragAction.Move;
-                                Over(_context.TargetPoint, _context.DragAction, _context.TargetDockControl);
+                                Over(_context.TargetPoint, _context.DragAction, dropControl, _context.TargetDockControl);
                                 break;
                             }
 

--- a/src/Dock.Settings/DockProperties.cs
+++ b/src/Dock.Settings/DockProperties.cs
@@ -50,6 +50,15 @@ public class DockProperties : AvaloniaObject
         AvaloniaProperty.RegisterAttached<DockProperties, Control, bool>("ShowDockIndicatorOnly", false, false, BindingMode.TwoWay);
 
     /// <summary>
+    /// Defines the IndicatorDockOperation attached property.
+    /// When <see cref="ShowDockIndicatorOnlyProperty"/> is true this value
+    /// specifies which dock operation the entire control represents.
+    /// </summary>
+    public static readonly AttachedProperty<Dock.Model.Core.DockOperation> IndicatorDockOperationProperty =
+        AvaloniaProperty.RegisterAttached<DockProperties, Control, Dock.Model.Core.DockOperation>(
+            "IndicatorDockOperation", Dock.Model.Core.DockOperation.Fill, false, BindingMode.TwoWay);
+
+    /// <summary>
     /// Defines the DockAdornerHost attached property.
     /// When set it specifies the element that will host
     /// the dock target adorner instead of the adorned control itself.
@@ -175,6 +184,26 @@ public class DockProperties : AvaloniaObject
     public static void SetShowDockIndicatorOnly(AvaloniaObject control, bool value)
     {
         control.SetValue(ShowDockIndicatorOnlyProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the value of the IndicatorDockOperation attached property on the specified control.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <returns>The IndicatorDockOperation attached property.</returns>
+    public static Dock.Model.Core.DockOperation GetIndicatorDockOperation(AvaloniaObject control)
+    {
+        return control.GetValue(IndicatorDockOperationProperty);
+    }
+
+    /// <summary>
+    /// Sets the value of the IndicatorDockOperation attached property on the specified control.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <param name="value">The dock operation value.</param>
+    public static void SetIndicatorDockOperation(AvaloniaObject control, Dock.Model.Core.DockOperation value)
+    {
+        control.SetValue(IndicatorDockOperationProperty, value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- introduce `IndicatorDockOperation` attached property for Dock
- support the property in `DockTarget` and `GlobalDockTarget`
- expose the property in tab strip templates
- document the new property

## Testing
- `./build.sh compile`
- `./build.sh test` *(fails: Solution has active build configurations)*

------
https://chatgpt.com/codex/tasks/task_e_686f7fdf13348321aeb8b815d6742573