### PR TITLE
Add floating window owner setting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Drag offset calculator](dock-drag-offset-calculator.md) – Control where the drag preview window appears.
 - [Floating dock adorners](dock-floating-adorners.md) – Display drop indicators in a transparent window.
 - [Pinned dock window](dock-pinned-window.md) – Show auto-hidden tools in a floating window.
+- [Floating window owner](dock-window-owner.md) – Keep floating windows in front of the main window.
 - [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
 - [Custom Dock.Model implementations](dock-custom-model.md) – Integrate Dock with other MVVM frameworks.
 

--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -44,6 +44,10 @@ Increase these values if small pointer movements should not initiate dragging.
 onto other `DockControl` instances. If set to `false` the global dock target is
 hidden and drags are limited to the originating control.
 
+## Floating window owner
+
+`DockSettings.UseOwnerForFloatingWindows` keeps floating windows above the main window by setting it as their owner.
+
 ## App builder integration
 
 You can configure the settings when building your Avalonia application:
@@ -54,6 +58,7 @@ using Dock.Settings;
 AppBuilder.Configure<App>()
     .UsePlatformDetect()
     .UseFloatingDockAdorner()
+    .UseOwnerForFloatingWindows()
     .EnableGlobalDocking(false)
     .WithDockSettings(new DockSettingsOptions
     {

--- a/docs/dock-window-owner.md
+++ b/docs/dock-window-owner.md
@@ -1,0 +1,19 @@
+# Floating window owner
+
+`DockSettings` exposes an option to make floating windows owned by the main window so they stay in front.
+
+```csharp
+// Keep floating windows above the main window
+DockSettings.UseOwnerForFloatingWindows = true;
+```
+
+```csharp
+// Via the app builder
+using Dock.Settings;
+
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .UseOwnerForFloatingWindows();
+```
+
+When enabled Dock sets the main window as the owner for floating windows, preventing them from appearing behind it. Disable this if you want windows to be independent.

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -16,6 +16,7 @@ using Dock.Avalonia.Internal;
 using Dock.Model;
 using Dock.Model.Controls;
 using Dock.Model.Core;
+using Dock.Settings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -390,7 +391,7 @@ public class HostWindow : Window, IHostWindow
                 }
 
                 var ownerDockControl = Window?.Layout?.Factory?.DockControls.FirstOrDefault();
-                if (ownerDockControl is Control control && control.GetVisualRoot() is Window parentWindow)
+                if (ownerDockControl is Control control && control.GetVisualRoot() is Window parentWindow && DockSettings.UseOwnerForFloatingWindows)
                 {
                     Title = parentWindow.Title;
                     Icon = parentWindow.Icon;

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -50,6 +50,11 @@ public static class AppBuilderExtensions
             DockSettings.EnableGlobalDocking = options.EnableGlobalDocking.Value;
         }
 
+        if (options.UseOwnerForFloatingWindows != null)
+        {
+            DockSettings.UseOwnerForFloatingWindows = options.UseOwnerForFloatingWindows.Value;
+        }
+
         return builder;
     }
 
@@ -92,6 +97,20 @@ public static class AppBuilderExtensions
         bool enable = true)
     {
         DockSettings.EnableGlobalDocking = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.UseOwnerForFloatingWindows"/> to the given value.
+    /// </summary>
+    /// <param name="builder">The app builder.</param>
+    /// <param name="enable">Whether floating windows should be owned by the main window.</param>
+    /// <returns>The app builder instance.</returns>
+    public static AppBuilder UseOwnerForFloatingWindows(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.UseOwnerForFloatingWindows = enable;
         return builder;
     }
 }

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -35,6 +35,11 @@ public static class DockSettings
     /// Allow docking between different dock control instances.
     /// </summary>
     public static bool EnableGlobalDocking = true;
+    
+    /// <summary>
+    /// Floating windows use the main window as their owner so they stay in front.
+    /// </summary>
+    public static bool UseOwnerForFloatingWindows = true;
 
     /// <summary>
     /// Checks if the drag distance is greater than the minimum required distance to initiate a drag operation.

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -32,5 +32,10 @@ public class DockSettingsOptions
     /// Optional global docking flag.
     /// </summary>
     public bool? EnableGlobalDocking { get; set; }
+
+    /// <summary>
+    /// Optional floating window owner flag.
+    /// </summary>
+    public bool? UseOwnerForFloatingWindows { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- introduce `UseOwnerForFloatingWindows` in `DockSettings`
- update `AppBuilderExtensions` to expose `UseOwnerForFloatingWindows`
- add support in `DockSettingsOptions`
- keep HostWindow floating windows above the main window
- document the new option and list it in docs index

## Testing
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release -f net6.0`
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -c Release -f net9.0` *(fails: No test is available)*

------
https://chatgpt.com/codex/tasks/task_e_686fba95c66883218326c3f9b696c41f