### PR TITLE
Handle tabstrip docking

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -449,6 +449,11 @@ internal class DockControlState : DockManagerState, IDockControlState
             }
             case EventType.Leave:
             {
+                _dragPreviewHelper.Hide();
+                Leave();
+                _context.TargetPoint = default;
+                _context.TargetDockControl = null;
+                DropControl = null;
                 break;
             }
             case EventType.CaptureLost:

--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -92,6 +92,7 @@ internal class WindowDragHelper
             {
                 if (hostWindow.HostWindowState is HostWindowState state)
                 {
+                    state.IsDragFromTabStrip = false;
                     var point = hostWindow.PointToScreen(e.GetPosition(hostWindow)) -
                                 hostWindow.PointToScreen(new Point(0, 0));
                     state.Process(new PixelPoint(point.X, point.Y), EventType.Released);
@@ -152,6 +153,7 @@ internal class WindowDragHelper
 
         if (hostWindow.HostWindowState is HostWindowState state)
         {
+            state.IsDragFromTabStrip = _owner is DocumentTabStrip;
             var start = hostWindow.PointToScreen(_lastPointerPressedArgs.GetPosition(hostWindow)) - hostWindow.PointToScreen(new Point(0, 0));
             state.Process(new PixelPoint(start.X, start.Y), EventType.Pressed);
         }


### PR DESCRIPTION
## Summary
- restrict floating window docking to parent tab strip when started from a tab strip
- cancel dock preview when pointer leaves docking area
- track when dragging originates from a tab strip

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686fd5a3dc5c832184b754c106946697