### PR TITLE
Add Dock.Model unit tests

### DIFF
--- a/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
+++ b/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Mvvm\Dock.Model.Mvvm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dock.Model.UnitTests/DockManagerTests.cs
+++ b/tests/Dock.Model.UnitTests/DockManagerTests.cs
@@ -1,0 +1,45 @@
+using Dock.Model;
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class DockManagerTests
+{
+    [Fact]
+    public void IsDockTargetVisible_NonFill_AlwaysTrue()
+    {
+        var manager = new DockManager();
+        var source = new Document();
+        var target = new Document();
+        Assert.True(manager.IsDockTargetVisible(source, target, DockOperation.Left));
+    }
+
+    [Fact]
+    public void IsDockTargetVisible_SameDockable_ReturnsFalse()
+    {
+        var manager = new DockManager();
+        var doc = new Document();
+        Assert.False(manager.IsDockTargetVisible(doc, doc, DockOperation.Fill));
+    }
+
+    [Fact]
+    public void IsDockTargetVisible_TargetIsOwner_ReturnsFalse()
+    {
+        var manager = new DockManager();
+        var owner = new DocumentDock();
+        var doc = new Document { Owner = owner };
+        Assert.False(manager.IsDockTargetVisible(doc, owner, DockOperation.Fill));
+    }
+
+    [Fact]
+    public void IsDockTargetVisible_Default_ReturnsTrue()
+    {
+        var manager = new DockManager();
+        var owner = new DocumentDock();
+        var doc1 = new Document { Owner = owner };
+        var doc2 = new Document();
+        Assert.True(manager.IsDockTargetVisible(doc1, doc2, DockOperation.Fill));
+    }
+}

--- a/tests/Dock.Model.UnitTests/DockOperationExtensionsTests.cs
+++ b/tests/Dock.Model.UnitTests/DockOperationExtensionsTests.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class DockOperationExtensionsTests
+{
+    [Fact(Skip="Not accessible - internal methods")] public void Placeholder() { }
+}

--- a/tests/Dock.Model.UnitTests/FactoryExtensionsTests.cs
+++ b/tests/Dock.Model.UnitTests/FactoryExtensionsTests.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class FactoryExtensionsTests
+{
+    [Fact(Skip="Not accessible - internal methods")] public void Placeholder() { }
+}

--- a/tests/Dock.Model.UnitTests/NavigateAdapterTests.cs
+++ b/tests/Dock.Model.UnitTests/NavigateAdapterTests.cs
@@ -1,0 +1,34 @@
+using Dock.Model.Adapters;
+using Dock.Model.Mvvm;
+using Dock.Model.Mvvm.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class NavigateAdapterTests
+{
+    [Fact]
+    public void Navigate_Back_Forward_Works()
+    {
+        var factory = new Factory();
+        var doc1 = new Document { Id = "1" };
+        var doc2 = new Document { Id = "2" };
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>(doc1, doc2), ActiveDockable = doc1, IsActive = true };
+        var control = new TestDockControl { Layout = root, Factory = factory };
+        factory.DockControls.Add(control);
+
+        var adapter = new NavigateAdapter(root);
+        adapter.Navigate(doc2, true);
+
+        Assert.True(adapter.CanGoBack);
+        Assert.Same(doc2, root.ActiveDockable);
+
+        adapter.GoBack();
+        Assert.Same(doc1, root.ActiveDockable);
+        Assert.True(adapter.CanGoForward);
+
+        adapter.GoForward();
+        Assert.Same(doc2, root.ActiveDockable);
+    }
+}

--- a/tests/Dock.Model.UnitTests/TestHelpers.cs
+++ b/tests/Dock.Model.UnitTests/TestHelpers.cs
@@ -1,0 +1,19 @@
+using Dock.Model.Core;
+using Dock.Model.Mvvm.Controls;
+
+namespace Dock.Model.UnitTests;
+
+internal class TestDockControlState : IDockControlState
+{
+}
+
+internal class TestDockControl : IDockControl
+{
+    public IDockManager DockManager { get; } = new DockManager();
+    public IDockControlState DockControlState { get; } = new TestDockControlState();
+    public IDock? Layout { get; set; }
+    public object? DefaultContext { get; set; }
+    public bool InitializeLayout { get; set; }
+    public bool InitializeFactory { get; set; }
+    public IFactory? Factory { get; set; }
+}

--- a/tests/Dock.Model.UnitTests/TrackingAdapterTests.cs
+++ b/tests/Dock.Model.UnitTests/TrackingAdapterTests.cs
@@ -1,0 +1,58 @@
+using Dock.Model.Adapters;
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class TrackingAdapterTests
+{
+    [Fact]
+    public void SetAndGetVisibleBounds_RoundTrip()
+    {
+        var adapter = new TrackingAdapter();
+        adapter.SetVisibleBounds(1, 2, 3, 4);
+        adapter.GetVisibleBounds(out var x, out var y, out var w, out var h);
+        Assert.Equal(1, x);
+        Assert.Equal(2, y);
+        Assert.Equal(3, w);
+        Assert.Equal(4, h);
+    }
+
+    [Fact]
+    public void SetAndGetPinnedBounds_RoundTrip()
+    {
+        var adapter = new TrackingAdapter();
+        adapter.SetPinnedBounds(5, 6, 7, 8);
+        adapter.GetPinnedBounds(out var x, out var y, out var w, out var h);
+        Assert.Equal(5, x);
+        Assert.Equal(6, y);
+        Assert.Equal(7, w);
+        Assert.Equal(8, h);
+    }
+
+    [Fact]
+    public void SetAndGetTabBounds_RoundTrip()
+    {
+        var adapter = new TrackingAdapter();
+        adapter.SetTabBounds(9, 10, 11, 12);
+        adapter.GetTabBounds(out var x, out var y, out var w, out var h);
+        Assert.Equal(9, x);
+        Assert.Equal(10, y);
+        Assert.Equal(11, w);
+        Assert.Equal(12, h);
+    }
+
+    [Fact]
+    public void SetAndGetPointerPositions_RoundTrip()
+    {
+        var adapter = new TrackingAdapter();
+        adapter.SetPointerPosition(13, 14);
+        adapter.GetPointerPosition(out var x, out var y);
+        Assert.Equal(13, x);
+        Assert.Equal(14, y);
+
+        adapter.SetPointerScreenPosition(15, 16);
+        adapter.GetPointerScreenPosition(out var sx, out var sy);
+        Assert.Equal(15, sx);
+        Assert.Equal(16, sy);
+    }
+}


### PR DESCRIPTION
## Summary
- add Dock.Model unit tests with stubs where internals are not visible
- reference Dock.Model.Mvvm for helper types

## Testing
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -v minimal`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687026c70c30832183e6e8a7268b1a31