### PR TITLE
Add tests for proportional stack panels

### DIFF
--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelSplitterTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelSplitterTests.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless.XUnit;
+using Dock.Controls.ProportionalStackPanel;
+using Xunit;
+
+namespace Dock.Avalonia.UnitTests.Controls;
+
+public class ProportionalStackPanelSplitterTests
+{
+    [AvaloniaFact]
+    public void Splitter_Ctor()
+    {
+        var splitter = new ProportionalStackPanelSplitter();
+        Assert.NotNull(splitter);
+    }
+
+    [AvaloniaFact]
+    public void IsSplitter_Returns_True_For_ContentPresenter()
+    {
+        var splitter = new ProportionalStackPanelSplitter();
+        var presenter = new ContentPresenter { Content = splitter };
+
+        var result = ProportionalStackPanelSplitter.IsSplitter(presenter, out var actual);
+
+        Assert.True(result);
+        Assert.Equal(splitter, actual);
+    }
+
+    [AvaloniaFact]
+    public void MeasureOverride_Uses_Panel_Orientation()
+    {
+        var panel = new ProportionalStackPanel { Orientation = Orientation.Vertical };
+        var before = new Border();
+        var splitter = new ProportionalStackPanelSplitter { Thickness = 8 };
+        panel.Children.Add(before);
+        panel.Children.Add(splitter);
+
+        panel.Measure(Size.Infinity);
+
+        Assert.Equal(new Size(0, 8), splitter.DesiredSize);
+    }
+}

--- a/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ProportionalStackPanelTests.cs
@@ -340,4 +340,42 @@ public class ProportionalStackPanelTests
 
         Assert.True(target.Children[0].Bounds.Height >= 200);
     }
+
+    [AvaloniaFact]
+    public void Collapsed_Child_Occupies_No_Space()
+    {
+        var first = new Border { [ProportionalStackPanel.ProportionProperty] = 0.5 };
+        var splitter = new ProportionalStackPanelSplitter();
+        var second = new Border { [ProportionalStackPanel.ProportionProperty] = 0.5 };
+        var target = new ProportionalStackPanel
+        {
+            Width = 300,
+            Height = 100,
+            Orientation = Orientation.Horizontal,
+            Children = { first, splitter, second }
+        };
+
+        ProportionalStackPanel.SetIsCollapsed(first, true);
+        target.Measure(Size.Infinity);
+        target.Arrange(new Rect(target.DesiredSize));
+
+        Assert.Equal(0, first.Bounds.Width);
+        Assert.Equal(296, second.Bounds.Width);
+        Assert.Equal(0, ProportionalStackPanel.GetProportion(first));
+        Assert.Equal(0.5, ProportionalStackPanel.GetCollapsedProportion(first));
+
+        ProportionalStackPanel.SetIsCollapsed(first, false);
+        target.Measure(Size.Infinity);
+        target.Arrange(new Rect(target.DesiredSize));
+
+        Assert.Equal(148, first.Bounds.Width);
+        Assert.Equal(148, second.Bounds.Width);
+    }
+
+    [AvaloniaFact]
+    public void MeasureOverride_Throws_On_Infinite_Size()
+    {
+        var target = new ProportionalStackPanel { Orientation = Orientation.Horizontal };
+        Assert.Throws<Exception>(() => target.Measure(Size.Infinity));
+    }
 }


### PR DESCRIPTION
## Summary
- test ProportionalStackPanelSplitter behavior
- test collapsing behavior and infinite size check for ProportionalStackPanel

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687026ff45988321aee1b3cdb17d31e8