### PR TITLE
Add unit tests for Dock.MarkupExtension

### DIFF
--- a/Dock.sln
+++ b/Dock.sln
@@ -106,6 +106,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.Prism", "src\Doc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.Prism.UnitTests", "tests\Dock.Model.Prism.UnitTests\Dock.Model.Prism.UnitTests.csproj", "{E882EAE4-97D4-47EB-AC9B-56DB746DE40C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.MarkupExtension.UnitTests", "tests\Dock.MarkupExtension.UnitTests\Dock.MarkupExtension.UnitTests.csproj", "{C44C8D3B-2F49-4B3D-AE63-D6D1088684DC}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Controls.ProportionalStackPanel", "src\Dock.Controls.ProportionalStackPanel\Dock.Controls.ProportionalStackPanel.csproj", "{CCA814C4-8369-4AD6-A2DA-59F54D01CE26}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Controls.Recycling", "src\Dock.Controls.Recycling\Dock.Controls.Recycling.csproj", "{9FF95B40-ECA7-440B-9342-688C53F1AE8E}"
@@ -253,6 +255,10 @@ Global
 																{E882EAE4-97D4-47EB-AC9B-56DB746DE40C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 																{E882EAE4-97D4-47EB-AC9B-56DB746DE40C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 																{E882EAE4-97D4-47EB-AC9B-56DB746DE40C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C44C8D3B-2F49-4B3D-AE63-D6D1088684DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C44C8D3B-2F49-4B3D-AE63-D6D1088684DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C44C8D3B-2F49-4B3D-AE63-D6D1088684DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C44C8D3B-2F49-4B3D-AE63-D6D1088684DC}.Release|Any CPU.Build.0 = Release|Any CPU
 																{CCA814C4-8369-4AD6-A2DA-59F54D01CE26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CCA814C4-8369-4AD6-A2DA-59F54D01CE26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCA814C4-8369-4AD6-A2DA-59F54D01CE26}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -305,6 +311,7 @@ Global
 																{E6A49621-154E-4A00-A54A-39C3BA55799A} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
 																{80DF9E99-C794-42EE-AD0B-549D5020B754} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
 																{E882EAE4-97D4-47EB-AC9B-56DB746DE40C} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
+                {C44C8D3B-2F49-4B3D-AE63-D6D1088684DC} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
 																{CCA814C4-8369-4AD6-A2DA-59F54D01CE26} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
 		{9FF95B40-ECA7-440B-9342-688C53F1AE8E} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
 		{B6762749-9061-49AE-A994-777DB6018A45} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}

--- a/tests/Dock.MarkupExtension.UnitTests/App.axaml
+++ b/tests/Dock.MarkupExtension.UnitTests/App.axaml
@@ -1,0 +1,3 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Dock.MarkupExtension.UnitTests.App"/>

--- a/tests/Dock.MarkupExtension.UnitTests/App.axaml.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/App.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.MarkupExtension.UnitTests;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/tests/Dock.MarkupExtension.UnitTests/Dock.MarkupExtension.UnitTests.csproj
+++ b/tests/Dock.MarkupExtension.UnitTests/Dock.MarkupExtension.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>False</IsPackable>
+    <IsTestProject>True</IsTestProject>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Headless.props" />
+  <Import Project="..\..\build\XUnit.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.MarkupExtension\Dock.MarkupExtension.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/tests/Dock.MarkupExtension.UnitTests/LoadExtensionTests.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/LoadExtensionTests.cs
@@ -1,0 +1,55 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.MarkupExtension;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Dock.MarkupExtension.UnitTests;
+
+public class LoadExtensionTests
+{
+    [AvaloniaFact]
+    public void Constructor_Sets_Source()
+    {
+        var uri = new Uri("avares://Dock.MarkupExtension.UnitTests/Views/TestView.axaml");
+        var ext = new LoadExtension(uri);
+        Assert.Equal(uri, ext.Source);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_Loads_Object_From_Uri()
+    {
+        var uri = new Uri("avares://Dock.MarkupExtension.UnitTests/Views/TestView.axaml");
+        var ext = new LoadExtension(uri);
+        var context = new UriContext { BaseUri = new Uri("avares://Dock.MarkupExtension.UnitTests/") };
+        var sp = new TestServiceProvider(context, null);
+        var value = ext.ProvideValue(sp);
+        Assert.IsType<TextBlock>(value);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_No_Context_Returns_Null()
+    {
+        var uri = new Uri("avares://Dock.MarkupExtension.UnitTests/Views/TestView.axaml");
+        var ext = new LoadExtension(uri);
+        var sp = new TestServiceProvider(null, null);
+        var value = ext.ProvideValue(sp);
+        Assert.Null(value);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_No_Source_Returns_Null()
+    {
+        var ext = new LoadExtension();
+        var context = new UriContext { BaseUri = new Uri("avares://Dock.MarkupExtension.UnitTests/") };
+        var sp = new TestServiceProvider(context, null);
+        var value = ext.ProvideValue(sp);
+        Assert.Null(value);
+    }
+}
+
+internal class UriContext : IUriContext
+{
+    public Uri? BaseUri { get; set; }
+}

--- a/tests/Dock.MarkupExtension.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Reflection;
+using Xunit;
+
+[assembly: AssemblyTitle("Dock.MarkupExtension.UnitTests")]
+
+// Don't run tests in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Dock.MarkupExtension.UnitTests/ReferenceExtensionTests.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/ReferenceExtensionTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.MarkupExtension;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Dock.MarkupExtension.UnitTests;
+
+public class ReferenceExtensionTests
+{
+    [AvaloniaFact]
+    public void Constructor_Sets_Name()
+    {
+        var ext = new ReferenceExtension("myElement");
+        Assert.Equal("myElement", ext.Name);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_Returns_Referenced_Object()
+    {
+        var button = new Button();
+        var scope = new NameScope();
+        scope.Register("btn", button);
+        var ext = new ReferenceExtension("btn");
+        var sp = new TestServiceProvider(null, scope);
+        var value = ext.ProvideValue(sp);
+        Assert.Same(button, value);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_No_Scope_Returns_Null()
+    {
+        var ext = new ReferenceExtension("missing");
+        var sp = new TestServiceProvider(null, null);
+        var value = ext.ProvideValue(sp);
+        Assert.Null(value);
+    }
+
+    [AvaloniaFact]
+    public void ProvideValue_Missing_Name_Returns_Null()
+    {
+        var scope = new NameScope();
+        var ext = new ReferenceExtension("unknown");
+        var sp = new TestServiceProvider(null, scope);
+        var value = ext.ProvideValue(sp);
+        Assert.Null(value);
+    }
+}

--- a/tests/Dock.MarkupExtension.UnitTests/TestAppBuilder.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.MarkupExtension.UnitTests.TestAppBuilder))]
+
+namespace Dock.MarkupExtension.UnitTests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/Dock.MarkupExtension.UnitTests/TestServiceProvider.cs
+++ b/tests/Dock.MarkupExtension.UnitTests/TestServiceProvider.cs
@@ -1,0 +1,26 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.MarkupExtension.UnitTests;
+
+internal class TestServiceProvider : IServiceProvider
+{
+    private readonly IUriContext? _uriContext;
+    private readonly INameScope? _nameScope;
+
+    public TestServiceProvider(IUriContext? uriContext = null, INameScope? nameScope = null)
+    {
+        _uriContext = uriContext;
+        _nameScope = nameScope;
+    }
+
+    public object? GetService(Type serviceType)
+    {
+        if (serviceType == typeof(IUriContext))
+            return _uriContext;
+        if (serviceType == typeof(INameScope))
+            return _nameScope;
+        return null;
+    }
+}

--- a/tests/Dock.MarkupExtension.UnitTests/Views/TestView.axaml
+++ b/tests/Dock.MarkupExtension.UnitTests/Views/TestView.axaml
@@ -1,0 +1,1 @@
+<TextBlock xmlns="https://github.com/avaloniaui" Text="Hello"/>


### PR DESCRIPTION
## Summary
- add new Dock.MarkupExtension.UnitTests project
- cover LoadExtension and ReferenceExtension with tests
- register test project in solution

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6870271f5e9483219afe51de410dd8b7