### PR TITLE
Add ReactiveUI tests

### DIFF
--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DockControlsTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DockControlsTests.cs
@@ -1,0 +1,90 @@
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Controls;
+using Xunit;
+
+namespace Dock.Model.ReactiveUI.UnitTests.Controls;
+
+public class DockControlsTests
+{
+    [Fact]
+    public void DockDock_Default_LastChildFill_True()
+    {
+        var dock = new DockDock();
+        Assert.True(dock.LastChildFill);
+    }
+
+    [Fact]
+    public void StackDock_Defaults()
+    {
+        var dock = new StackDock();
+        Assert.Equal(Orientation.Horizontal, dock.Orientation);
+        Assert.Equal(0, dock.Spacing);
+    }
+
+    [Fact]
+    public void WrapDock_Defaults()
+    {
+        var dock = new WrapDock();
+        Assert.Equal(Orientation.Horizontal, dock.Orientation);
+    }
+
+    [Fact]
+    public void UniformGridDock_Defaults()
+    {
+        var dock = new UniformGridDock();
+        Assert.Equal(0, dock.Rows);
+        Assert.Equal(0, dock.Columns);
+    }
+
+    [Fact]
+    public void GridDock_Defaults()
+    {
+        var dock = new GridDock();
+        Assert.Null(dock.ColumnDefinitions);
+        Assert.Null(dock.RowDefinitions);
+    }
+
+    [Fact]
+    public void ProportionalDock_Default_Orientation_Horizontal()
+    {
+        var dock = new ProportionalDock();
+        Assert.Equal(Orientation.Horizontal, dock.Orientation);
+    }
+
+    [Fact]
+    public void ProportionalDockSplitter_CanResize_Default_True()
+    {
+        var splitter = new ProportionalDockSplitter();
+        Assert.True(splitter.CanResize);
+    }
+
+    [Fact]
+    public void GridDockSplitter_Defaults()
+    {
+        var splitter = new GridDockSplitter();
+        Assert.Equal(0, splitter.Column);
+        Assert.Equal(0, splitter.Row);
+        Assert.Equal(GridResizeDirection.Columns, splitter.ResizeDirection);
+    }
+
+    [Fact]
+    public void ToolDock_Defaults()
+    {
+        var dock = new ToolDock();
+        Assert.Equal(Alignment.Unset, dock.Alignment);
+        Assert.False(dock.IsExpanded);
+        Assert.True(dock.AutoHide);
+        Assert.Equal(GripMode.Visible, dock.GripMode);
+    }
+
+    [Fact]
+    public void DocumentDock_Defaults()
+    {
+        var dock = new DocumentDock();
+        Assert.False(dock.CanCreateDocument);
+        Assert.Null(dock.DocumentFactory);
+        Assert.NotNull(dock.CreateDocument);
+        Assert.False(dock.EnableWindowDrag);
+        Assert.Equal(DocumentTabLayout.Top, dock.TabsLayout);
+    }
+}

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DocumentDockActionsTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Controls/DocumentDockActionsTests.cs
@@ -1,0 +1,66 @@
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Controls;
+using Xunit;
+
+namespace Dock.Model.ReactiveUI.UnitTests.Controls;
+
+public class DocumentDockActionsTests
+{
+    private class RecordingFactory : Factory
+    {
+        public IDock? AddedDock;
+        public IDockable? AddedDockable;
+        public IDockable? ActiveDockable;
+        public (IDock dock, IDockable? dockable)? Focused;
+
+        public override void AddDockable(IDock dock, IDockable dockable)
+        {
+            AddedDock = dock;
+            AddedDockable = dockable;
+        }
+
+        public override void SetActiveDockable(IDockable dockable)
+        {
+            ActiveDockable = dockable;
+        }
+
+        public override void SetFocusedDockable(IDock dock, IDockable? dockable)
+        {
+            Focused = (dock, dockable);
+        }
+    }
+
+    [Fact]
+    public void AddDocument_Uses_Factory_Methods()
+    {
+        var factory = new RecordingFactory();
+        var dock = new DocumentDock { Factory = factory };
+        var document = new Document();
+
+        dock.AddDocument(document);
+
+        Assert.Same(dock, factory.AddedDock);
+        Assert.Same(document, factory.AddedDockable);
+        Assert.Same(document, factory.ActiveDockable);
+        Assert.NotNull(factory.Focused);
+        Assert.Same(dock, factory.Focused?.dock);
+        Assert.Same(document, factory.Focused?.dockable);
+    }
+
+    [Fact]
+    public void AddTool_Uses_Factory_Methods()
+    {
+        var factory = new RecordingFactory();
+        var dock = new DocumentDock { Factory = factory };
+        var tool = new Tool();
+
+        dock.AddTool(tool);
+
+        Assert.Same(dock, factory.AddedDock);
+        Assert.Same(tool, factory.AddedDockable);
+        Assert.Same(tool, factory.ActiveDockable);
+        Assert.NotNull(factory.Focused);
+        Assert.Same(dock, factory.Focused?.dock);
+        Assert.Same(tool, factory.Focused?.dockable);
+    }
+}

--- a/tests/Dock.Model.ReactiveUI.UnitTests/DockWindowTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/DockWindowTests.cs
@@ -1,0 +1,142 @@
+using Dock.Model.Core;
+using Dock.Model.ReactiveUI.Core;
+using Xunit;
+
+namespace Dock.Model.ReactiveUI.UnitTests;
+
+public class DockWindowTests
+{
+    private class TestHostWindow : IHostWindow
+    {
+        public IDockManager? DockManager { get; }
+        public IHostWindowState? HostWindowState { get; }
+        public bool IsTracked { get; set; }
+        public IDockWindow? Window { get; set; }
+
+        public bool Presented { get; private set; }
+        public bool PresentedAsDialog { get; private set; }
+        public bool Exited { get; private set; }
+        public double X { get; private set; }
+        public double Y { get; private set; }
+        public double Width { get; private set; }
+        public double Height { get; private set; }
+        public string? Title { get; private set; }
+        public IDock? Layout { get; private set; }
+
+        public void Present(bool isDialog)
+        {
+            Presented = true;
+            PresentedAsDialog = isDialog;
+        }
+
+        public void Exit()
+        {
+            Exited = true;
+        }
+
+        public void SetPosition(double x, double y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public void GetPosition(out double x, out double y)
+        {
+            x = X; y = Y;
+        }
+
+        public void SetSize(double width, double height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        public void GetSize(out double width, out double height)
+        {
+            width = Width; height = Height;
+        }
+
+        public void SetTitle(string title)
+        {
+            Title = title;
+        }
+
+        public void SetLayout(IDock layout)
+        {
+            Layout = layout;
+        }
+    }
+
+    private class HostFactory : Factory
+    {
+        public TestHostWindow Host { get; } = new();
+        public override IHostWindow? GetHostWindow(string id) => Host;
+    }
+
+    [Fact]
+    public void DockWindow_Defaults_Are_Correct()
+    {
+        var window = new DockWindow();
+
+        Assert.Equal(nameof(IDockWindow), window.Id);
+        Assert.Equal(nameof(IDockWindow), window.Title);
+        Assert.Equal(0, window.X);
+        Assert.Equal(0, window.Y);
+        Assert.Equal(0, window.Width);
+        Assert.Equal(0, window.Height);
+        Assert.False(window.Topmost);
+    }
+
+    [Fact]
+    public void Save_Updates_Position_And_Size_From_Host()
+    {
+        var window = new DockWindow();
+        var host = new TestHostWindow();
+        window.Host = host;
+        host.SetPosition(10, 20);
+        host.SetSize(300, 200);
+
+        window.Save();
+
+        Assert.Equal(10, window.X);
+        Assert.Equal(20, window.Y);
+        Assert.Equal(300, window.Width);
+        Assert.Equal(200, window.Height);
+    }
+
+    [Fact]
+    public void Present_Creates_Host_And_Presents()
+    {
+        var factory = new HostFactory();
+        var window = new DockWindow { Factory = factory, Layout = new RootDock() };
+
+        window.Present(false);
+
+        var host = factory.Host;
+        Assert.True(host.Presented);
+        Assert.False(host.PresentedAsDialog);
+        Assert.True(host.IsTracked);
+        Assert.Same(window, host.Window);
+        Assert.Equal(window.Title, host.Title);
+        Assert.Equal(window.Layout, host.Layout);
+    }
+
+    [Fact]
+    public void Exit_Saves_And_Resets_Host()
+    {
+        var factory = new HostFactory();
+        var window = new DockWindow { Factory = factory, Layout = new RootDock(), Host = factory.Host };
+        factory.Host.SetPosition(5, 6);
+        factory.Host.SetSize(100, 120);
+
+        window.Exit();
+
+        Assert.True(factory.Host.Exited);
+        Assert.False(factory.Host.IsTracked);
+        Assert.Null(window.Host);
+        Assert.Equal(5, window.X);
+        Assert.Equal(6, window.Y);
+        Assert.Equal(100, window.Width);
+        Assert.Equal(120, window.Height);
+    }
+}

--- a/tests/Dock.Model.ReactiveUI.UnitTests/DockableTrackingTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/DockableTrackingTests.cs
@@ -1,0 +1,64 @@
+using Dock.Model.ReactiveUI.Controls;
+using Xunit;
+
+namespace Dock.Model.ReactiveUI.UnitTests;
+
+public class DockableTrackingTests
+{
+    [Fact]
+    public void VisibleBounds_Are_Tracked()
+    {
+        var doc = new Document();
+        doc.GetVisibleBounds(out var x, out var y, out var w, out var h);
+        Assert.True(double.IsNaN(x));
+        Assert.True(double.IsNaN(y));
+        Assert.True(double.IsNaN(w));
+        Assert.True(double.IsNaN(h));
+
+        doc.SetVisibleBounds(1, 2, 3, 4);
+        doc.GetVisibleBounds(out x, out y, out w, out h);
+        Assert.Equal(1, x);
+        Assert.Equal(2, y);
+        Assert.Equal(3, w);
+        Assert.Equal(4, h);
+    }
+
+    [Fact]
+    public void PinnedBounds_Are_Tracked()
+    {
+        var doc = new Document();
+        doc.SetPinnedBounds(5, 6, 7, 8);
+        doc.GetPinnedBounds(out var x, out var y, out var w, out var h);
+        Assert.Equal(5, x);
+        Assert.Equal(6, y);
+        Assert.Equal(7, w);
+        Assert.Equal(8, h);
+    }
+
+    [Fact]
+    public void TabBounds_Are_Tracked()
+    {
+        var doc = new Document();
+        doc.SetTabBounds(9, 10, 11, 12);
+        doc.GetTabBounds(out var x, out var y, out var w, out var h);
+        Assert.Equal(9, x);
+        Assert.Equal(10, y);
+        Assert.Equal(11, w);
+        Assert.Equal(12, h);
+    }
+
+    [Fact]
+    public void PointerPositions_Are_Tracked()
+    {
+        var doc = new Document();
+        doc.SetPointerPosition(13, 14);
+        doc.GetPointerPosition(out var x, out var y);
+        Assert.Equal(13, x);
+        Assert.Equal(14, y);
+
+        doc.SetPointerScreenPosition(15, 16);
+        doc.GetPointerScreenPosition(out x, out y);
+        Assert.Equal(15, x);
+        Assert.Equal(16, y);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for ReactiveUI controls
- cover DocumentDock interactions with the factory
- test DockWindow functionality
- verify DockableBase tracking helpers

## Testing
- `dotnet test tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj --no-build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6870274ab93083219bd524b202eb2b6e