### PR TITLE
Add Dock.Settings unit tests

### DIFF
--- a/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
+++ b/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
@@ -1,0 +1,74 @@
+using Avalonia;
+using Avalonia.Headless;
+using Dock.Settings;
+using Xunit;
+
+namespace Dock.Settings.UnitTests;
+
+public class AppBuilderExtensionsTests
+{
+    private static AppBuilder CreateBuilder() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+
+    [Fact]
+    public void WithDockSettings_Applies_Options()
+    {
+        var builder = CreateBuilder();
+        var options = new DockSettingsOptions
+        {
+            MinimumHorizontalDragDistance = 10,
+            MinimumVerticalDragDistance = 12,
+            UseFloatingDockAdorner = true,
+            UsePinnedDockWindow = true,
+            EnableGlobalDocking = false,
+            UseOwnerForFloatingWindows = false
+        };
+
+        var result = builder.WithDockSettings(options);
+
+        Assert.Same(builder, result);
+        Assert.Equal(10, DockSettings.MinimumHorizontalDragDistance);
+        Assert.Equal(12, DockSettings.MinimumVerticalDragDistance);
+        Assert.True(DockSettings.UseFloatingDockAdorner);
+        Assert.True(DockSettings.UsePinnedDockWindow);
+        Assert.False(DockSettings.EnableGlobalDocking);
+        Assert.False(DockSettings.UseOwnerForFloatingWindows);
+    }
+
+    [Fact]
+    public void WithDockSettings_Returns_Builder_When_Options_Null()
+    {
+        var builder = CreateBuilder();
+        var oldH = DockSettings.MinimumHorizontalDragDistance;
+        var oldV = DockSettings.MinimumVerticalDragDistance;
+        try
+        {
+            var result = builder.WithDockSettings(null);
+            Assert.Same(builder, result);
+            Assert.Equal(oldH, DockSettings.MinimumHorizontalDragDistance);
+            Assert.Equal(oldV, DockSettings.MinimumVerticalDragDistance);
+        }
+        finally
+        {
+            DockSettings.MinimumHorizontalDragDistance = oldH;
+            DockSettings.MinimumVerticalDragDistance = oldV;
+        }
+    }
+
+    [Fact]
+    public void Extension_Methods_Set_Flags()
+    {
+        var builder = CreateBuilder();
+
+        builder.UseFloatingDockAdorner(true)
+               .UsePinnedDockWindow(true)
+               .EnableGlobalDocking(false)
+               .UseOwnerForFloatingWindows(false);
+
+        Assert.True(DockSettings.UseFloatingDockAdorner);
+        Assert.True(DockSettings.UsePinnedDockWindow);
+        Assert.False(DockSettings.EnableGlobalDocking);
+        Assert.False(DockSettings.UseOwnerForFloatingWindows);
+    }
+}

--- a/tests/Dock.Settings.UnitTests/Dock.Settings.UnitTests.csproj
+++ b/tests/Dock.Settings.UnitTests/Dock.Settings.UnitTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>False</IsPackable>
+    <IsTestProject>True</IsTestProject>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Headless.props" />
+  <Import Project="..\..\build\XUnit.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Settings\Dock.Settings.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Dock.Settings.UnitTests/DockPropertiesTests.cs
+++ b/tests/Dock.Settings.UnitTests/DockPropertiesTests.cs
@@ -1,0 +1,49 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Dock.Settings;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Settings.UnitTests;
+
+public class DockPropertiesTests
+{
+    [AvaloniaFact]
+    public void DefaultValues_Are_Correct()
+    {
+        var control = new Control();
+        Assert.False(DockProperties.GetIsDockTarget(control));
+        Assert.False(DockProperties.GetIsDragArea(control));
+        Assert.False(DockProperties.GetIsDropArea(control));
+        Assert.True(DockProperties.GetIsDragEnabled(control));
+        Assert.True(DockProperties.GetIsDropEnabled(control));
+        Assert.False(DockProperties.GetShowDockIndicatorOnly(control));
+        Assert.Equal(DockOperation.Fill, DockProperties.GetIndicatorDockOperation(control));
+        Assert.Null(DockProperties.GetDockAdornerHost(control));
+    }
+
+    [AvaloniaFact]
+    public void Setters_Update_Property_Values()
+    {
+        var control = new Control();
+        var host = new Control();
+
+        DockProperties.SetIsDockTarget(control, true);
+        DockProperties.SetIsDragArea(control, true);
+        DockProperties.SetIsDropArea(control, true);
+        DockProperties.SetIsDragEnabled(control, false);
+        DockProperties.SetIsDropEnabled(control, false);
+        DockProperties.SetShowDockIndicatorOnly(control, true);
+        DockProperties.SetIndicatorDockOperation(control, DockOperation.Left);
+        DockProperties.SetDockAdornerHost(control, host);
+
+        Assert.True(DockProperties.GetIsDockTarget(control));
+        Assert.True(DockProperties.GetIsDragArea(control));
+        Assert.True(DockProperties.GetIsDropArea(control));
+        Assert.False(DockProperties.GetIsDragEnabled(control));
+        Assert.False(DockProperties.GetIsDropEnabled(control));
+        Assert.True(DockProperties.GetShowDockIndicatorOnly(control));
+        Assert.Equal(DockOperation.Left, DockProperties.GetIndicatorDockOperation(control));
+        Assert.Equal(host, DockProperties.GetDockAdornerHost(control));
+    }
+}

--- a/tests/Dock.Settings.UnitTests/DockSettingsTests.cs
+++ b/tests/Dock.Settings.UnitTests/DockSettingsTests.cs
@@ -1,0 +1,50 @@
+using Avalonia;
+using Dock.Settings;
+using Xunit;
+
+namespace Dock.Settings.UnitTests;
+
+public class DockSettingsTests
+{
+    [Fact]
+    public void IsMinimumDragDistance_Vector_Works()
+    {
+        var oldH = DockSettings.MinimumHorizontalDragDistance;
+        var oldV = DockSettings.MinimumVerticalDragDistance;
+        try
+        {
+            DockSettings.MinimumHorizontalDragDistance = 4;
+            DockSettings.MinimumVerticalDragDistance = 4;
+
+            Assert.False(DockSettings.IsMinimumDragDistance(new Vector(3, 3)));
+            Assert.True(DockSettings.IsMinimumDragDistance(new Vector(5, 1)));
+            Assert.True(DockSettings.IsMinimumDragDistance(new Vector(0, 5)));
+        }
+        finally
+        {
+            DockSettings.MinimumHorizontalDragDistance = oldH;
+            DockSettings.MinimumVerticalDragDistance = oldV;
+        }
+    }
+
+    [Fact]
+    public void IsMinimumDragDistance_PixelPoint_Works()
+    {
+        var oldH = DockSettings.MinimumHorizontalDragDistance;
+        var oldV = DockSettings.MinimumVerticalDragDistance;
+        try
+        {
+            DockSettings.MinimumHorizontalDragDistance = 4;
+            DockSettings.MinimumVerticalDragDistance = 4;
+
+            Assert.False(DockSettings.IsMinimumDragDistance(new PixelPoint(3, 3)));
+            Assert.True(DockSettings.IsMinimumDragDistance(new PixelPoint(5, 1)));
+            Assert.True(DockSettings.IsMinimumDragDistance(new PixelPoint(0, 5)));
+        }
+        finally
+        {
+            DockSettings.MinimumHorizontalDragDistance = oldH;
+            DockSettings.MinimumVerticalDragDistance = oldV;
+        }
+    }
+}

--- a/tests/Dock.Settings.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/Dock.Settings.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Reflection;
+using Xunit;
+
+[assembly: AssemblyTitle("Dock.Settings.UnitTests")]
+
+// Don't run tests in parallel.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Dock.Settings.UnitTests/TestAppBuilder.cs
+++ b/tests/Dock.Settings.UnitTests/TestAppBuilder.cs
@@ -1,0 +1,17 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.Settings.UnitTests.TestAppBuilder))]
+
+namespace Dock.Settings.UnitTests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}
+
+public class App : Application
+{
+}


### PR DESCRIPTION
## Summary
- add new Dock.Settings.UnitTests project
- cover DockProperties, DockSettings, and AppBuilderExtensions

## Testing
- `dotnet test tests/Dock.Settings.UnitTests/Dock.Settings.UnitTests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6870277252a08321a0ab7fb26d883d98