### PR TITLE
Add tests for ControlRecycling

### DIFF
--- a/Dock.sln
+++ b/Dock.sln
@@ -116,8 +116,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Controls.Recycling.Mod
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DockReactiveUISample", "samples\DockReactiveUISample\DockReactiveUISample.csproj", "{2A2C622B-3001-4DEB-833E-BEF8A94A3343}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Controls.Recycling.UnitTests", "tests\Dock.Controls.Recycling.UnitTests\Dock.Controls.Recycling.UnitTests.csproj", "{A832AF6B-0B26-44B0-838A-7DFF930481D5}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentation", "{B6494977-A4A3-4492-8344-2D093694D49E}"
-	ProjectSection(SolutionItems) = preProject
+        ProjectSection(SolutionItems) = preProject
 		docs\quick-start.md = docs\quick-start.md
 		docs\dock-reference.md = docs\dock-reference.md
 		docs\dock-xaml.md = docs\dock-xaml.md
@@ -274,11 +276,15 @@ Global
 		{2A2C622B-3001-4DEB-833E-BEF8A94A3343}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A2C622B-3001-4DEB-833E-BEF8A94A3343}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
+                {0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0550FADE-AE71-427E-BE5F-8EF57A734AC3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {A832AF6B-0B26-44B0-838A-7DFF930481D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A832AF6B-0B26-44B0-838A-7DFF930481D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A832AF6B-0B26-44B0-838A-7DFF930481D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A832AF6B-0B26-44B0-838A-7DFF930481D5}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
@@ -312,6 +318,7 @@ Global
                 {2A2C622B-3001-4DEB-833E-BEF8A94A3343} = {2B045CC0-AA4B-44B1-9D92-459B71EC7AA3}
                 {0550FADE-AE71-427E-BE5F-8EF57A734AC3} = {2B045CC0-AA4B-44B1-9D92-459B71EC7AA3}
                 {0A7D7571-2957-4891-A4F1-3EE5E513CE90} = {2B045CC0-AA4B-44B1-9D92-459B71EC7AA3}
+                {A832AF6B-0B26-44B0-838A-7DFF930481D5} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
         EndGlobalSection
         GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5617659E-FC7E-40D7-9D62-258513329CA1}

--- a/tests/Dock.Controls.Recycling.UnitTests/App.axaml
+++ b/tests/Dock.Controls.Recycling.UnitTests/App.axaml
@@ -1,0 +1,3 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Dock.Controls.Recycling.UnitTests.App" />

--- a/tests/Dock.Controls.Recycling.UnitTests/App.axaml.cs
+++ b/tests/Dock.Controls.Recycling.UnitTests/App.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Controls.Recycling.UnitTests;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/tests/Dock.Controls.Recycling.UnitTests/Controls/ControlRecyclingDataTemplateTests.cs
+++ b/tests/Dock.Controls.Recycling.UnitTests/Controls/ControlRecyclingDataTemplateTests.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Recycling;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace Dock.Controls.Recycling.UnitTests.Controls;
+
+public class ControlRecyclingDataTemplateTests
+{
+    [AvaloniaFact]
+    public void Build_Returns_Null_When_No_Parent()
+    {
+        var template = new ControlRecyclingDataTemplate();
+        Assert.Null(template.Build(new object(), null));
+    }
+
+    [AvaloniaFact]
+    public void Build_Uses_Parent_ControlRecycling()
+    {
+        var parent = new Control();
+        var recycling = new ControlRecycling();
+        ControlRecyclingDataTemplate.SetControlRecycling(parent, recycling);
+        parent.DataTemplates.Add(new FuncDataTemplate<string>((_, _) => new TextBlock(), true));
+        var template = new ControlRecyclingDataTemplate { Parent = parent };
+
+        var control = template.Build("test", null);
+
+        Assert.NotNull(control);
+        Assert.True(recycling.TryGetValue("test", out var cached));
+        Assert.Same(control, cached);
+    }
+
+    [AvaloniaFact]
+    public void Build_Falls_Back_To_Parent_Template()
+    {
+        var parent = new Control();
+        parent.DataTemplates.Add(new FuncDataTemplate<int>((_, _) => new TextBlock(), true));
+        var template = new ControlRecyclingDataTemplate { Parent = parent };
+
+        var control = template.Build(5, null);
+
+        Assert.NotNull(control);
+    }
+}

--- a/tests/Dock.Controls.Recycling.UnitTests/Controls/ControlRecyclingTests.cs
+++ b/tests/Dock.Controls.Recycling.UnitTests/Controls/ControlRecyclingTests.cs
@@ -1,0 +1,105 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Recycling;
+using Avalonia.Controls.Recycling.Model;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Xunit;
+
+namespace Dock.Controls.Recycling.UnitTests.Controls;
+
+public class ControlRecyclingTests
+{
+    private class IdData(string id) : AvaloniaObject, IControlRecyclingIdProvider
+    {
+        public string? Id { get; } = id;
+        public string? GetControlRecyclingId() => Id;
+    }
+
+    [AvaloniaFact]
+    public void Add_And_TryGetValue_Work()
+    {
+        var recycling = new ControlRecycling();
+        var data = new object();
+        var control = new TextBlock();
+
+        recycling.Add(data, control);
+
+        var found = recycling.TryGetValue(data, out var cached);
+        Assert.True(found);
+        Assert.Same(control, cached);
+    }
+
+    [AvaloniaFact]
+    public void TryGetValue_With_Null_Returns_False()
+    {
+        var recycling = new ControlRecycling();
+        var result = recycling.TryGetValue(null, out var cached);
+        Assert.False(result);
+        Assert.Null(cached);
+    }
+
+    [AvaloniaFact]
+    public void Clear_Removes_Items()
+    {
+        var recycling = new ControlRecycling();
+        var data = new object();
+        recycling.Add(data, new TextBlock());
+        recycling.Clear();
+        Assert.False(recycling.TryGetValue(data, out _));
+    }
+
+    [AvaloniaFact]
+    public void Build_Returns_Null_For_Null_Data()
+    {
+        var recycling = new ControlRecycling();
+        Assert.Null(recycling.Build(null, null, null));
+    }
+
+    [AvaloniaFact]
+    public void Build_Uses_DataTemplate_And_Caches_Result()
+    {
+        var recycling = new ControlRecycling();
+        var parent = new Control();
+        parent.DataTemplates.Add(new FuncDataTemplate<int>((_, _) => new Border { Background = Brushes.Red }, true));
+
+        var result1 = recycling.Build(10, null, parent) as Control;
+        var result2 = recycling.Build(10, null, parent) as Control;
+
+        Assert.NotNull(result1);
+        Assert.Same(result1, result2);
+    }
+
+    [AvaloniaFact]
+    public void Build_Uses_Id_When_Enabled()
+    {
+        var recycling = new ControlRecycling { TryToUseIdAsKey = true };
+        var parent = new Control();
+        parent.DataTemplates.Add(new FuncDataTemplate<IdData>((_, _) => new Border(), true));
+
+        var data1 = new IdData("a");
+        var data2 = new IdData("a");
+
+        var result1 = recycling.Build(data1, null, parent);
+        var result2 = recycling.Build(data2, null, parent);
+
+        Assert.Same(result1, result2);
+    }
+
+    [AvaloniaFact]
+    public void Build_Ignores_Id_When_Disabled()
+    {
+        var recycling = new ControlRecycling { TryToUseIdAsKey = false };
+        var parent = new Control();
+        parent.DataTemplates.Add(new FuncDataTemplate<IdData>((_, _) => new Border(), true));
+
+        var data1 = new IdData("a");
+        var data2 = new IdData("a");
+
+        var result1 = recycling.Build(data1, null, parent);
+        var result2 = recycling.Build(data2, null, parent);
+
+        Assert.NotSame(result1, result2);
+    }
+}

--- a/tests/Dock.Controls.Recycling.UnitTests/Dock.Controls.Recycling.UnitTests.csproj
+++ b/tests/Dock.Controls.Recycling.UnitTests/Dock.Controls.Recycling.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>False</IsPackable>
+    <IsTestProject>True</IsTestProject>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Headless.props" />
+  <Import Project="..\..\build\XUnit.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Controls.Recycling\Dock.Controls.Recycling.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Controls.Recycling.Model\Dock.Controls.Recycling.Model.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/tests/Dock.Controls.Recycling.UnitTests/TestAppBuilder.cs
+++ b/tests/Dock.Controls.Recycling.UnitTests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.Controls.Recycling.UnitTests.TestAppBuilder))]
+
+namespace Dock.Controls.Recycling.UnitTests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<App>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}


### PR DESCRIPTION
## Summary
- add new Dock.Controls.Recycling.UnitTests project
- implement tests for ControlRecycling and ControlRecyclingDataTemplate

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68702715d2608321affdc5bfc9432ca8