### PR TITLE
Fix list type support for SystemTextJson serializer

### DIFF
--- a/src/Dock.Serializer.SystemTextJson/DockSerializer.cs
+++ b/src/Dock.Serializer.SystemTextJson/DockSerializer.cs
@@ -23,12 +23,15 @@ public sealed class DockSerializer : IDockSerializer
     /// <param name="listType">The type of list to use in the serialization process.</param>
     public DockSerializer(Type listType)
     {
-        _ = listType;
         _options = new JsonSerializerOptions
         {
             WriteIndented = true,
             ReferenceHandler = ReferenceHandler.Preserve,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters =
+            {
+                new JsonConverterFactoryList(listType)
+            }
         };
     }
 

--- a/src/Dock.Serializer.SystemTextJson/JsonConverterFactoryList.cs
+++ b/src/Dock.Serializer.SystemTextJson/JsonConverterFactoryList.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dock.Serializer.SystemTextJson;
+
+/// <summary>
+/// JSON converter factory for <see cref="IList{T}"/> using a custom list type.
+/// </summary>
+public class JsonConverterFactoryList : JsonConverterFactory
+{
+    private readonly Type _listType;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonConverterFactoryList"/> class.
+    /// </summary>
+    /// <param name="listType">The generic list type to instantiate.</param>
+    public JsonConverterFactoryList(Type listType)
+    {
+        _listType = listType;
+    }
+
+    /// <inheritdoc/>
+    public override bool CanConvert(Type typeToConvert)
+        => typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IList<>);
+
+    /// <inheritdoc/>
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        Debug.Assert(typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(IList<>));
+
+        var elementType = typeToConvert.GetGenericArguments()[0];
+        var converterType = typeof(JsonConverterList<>).MakeGenericType(elementType);
+        return (JsonConverter)Activator.CreateInstance(
+            converterType,
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            args: new object[] { _listType },
+            culture: null)!;
+    }
+}

--- a/src/Dock.Serializer.SystemTextJson/JsonConverterList.cs
+++ b/src/Dock.Serializer.SystemTextJson/JsonConverterList.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dock.Serializer.SystemTextJson;
+
+/// <summary>
+/// JSON converter for <see cref="IList{T}"/> using a custom list type.
+/// </summary>
+/// <typeparam name="T">The element type.</typeparam>
+public class JsonConverterList<T> : JsonConverter<IList<T>>
+{
+    private readonly Type _listType;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonConverterList{T}"/> class.
+    /// </summary>
+    /// <param name="listType">The generic list type to instantiate.</param>
+    public JsonConverterList(Type listType)
+    {
+        _listType = listType;
+    }
+
+    /// <inheritdoc/>
+    public override IList<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartArray)
+        {
+            throw new JsonException();
+        }
+        reader.Read();
+
+        var list = (IList<T>)Activator.CreateInstance(_listType.MakeGenericType(typeof(T)))!;
+
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            var item = JsonSerializer.Deserialize<T>(ref reader, options)!;
+            list.Add(item);
+            reader.Read();
+        }
+
+        return list;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, IList<T> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var item in value)
+        {
+            JsonSerializer.Serialize(writer, item, options);
+        }
+        writer.WriteEndArray();
+    }
+}

--- a/tests/Dock.Serializer.UnitTests/Dock.Serializer.UnitTests.csproj
+++ b/tests/Dock.Serializer.UnitTests/Dock.Serializer.UnitTests.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Serializer\Dock.Serializer.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.SystemTextJson\Dock.Serializer.SystemTextJson.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dock.Serializer.UnitTests/SystemTextJsonDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/SystemTextJsonDockSerializerTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Dock.Serializer.SystemTextJson;
+using Xunit;
+
+namespace Dock.Serializer.UnitTests;
+
+public class SystemTextJsonDockSerializerTests
+{
+    private class Sample
+    {
+        public string? Name { get; set; }
+        public IList<int>? Numbers { get; set; }
+        public string ReadOnly => "skip";
+    }
+
+    private sealed class NonClosingMemoryStream : MemoryStream
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Flush();
+            }
+        }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_DefaultListType_ObservableCollection()
+    {
+        var serializer = new DockSerializer();
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 1, 2 } };
+
+        var json = serializer.Serialize(sample);
+
+        Assert.Contains("\"Name\"", json);
+        Assert.DoesNotContain("ReadOnly", json);
+
+        var result = serializer.Deserialize<Sample>(json);
+        Assert.NotNull(result);
+        Assert.Equal(sample.Name, result!.Name);
+        Assert.IsType<ObservableCollection<int>>(result.Numbers);
+        Assert.Equal(sample.Numbers, result.Numbers.ToList());
+    }
+
+    [Fact]
+    public void CustomListType_List_DeserializesToList()
+    {
+        var serializer = new DockSerializer(typeof(List<>));
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 7, 8 } };
+
+        var json = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(json);
+
+        Assert.NotNull(result);
+        Assert.IsType<List<int>>(result!.Numbers);
+    }
+
+    [Fact]
+    public void SaveLoad_Roundtrip_Works()
+    {
+        var serializer = new DockSerializer();
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 3, 4, 5 } };
+        using var stream = new NonClosingMemoryStream();
+
+        serializer.Save(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = serializer.Load<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
+
+    [Fact]
+    public void Load_EmptyStream_ReturnsNull()
+    {
+        var serializer = new DockSerializer();
+        using var stream = new NonClosingMemoryStream();
+
+        var result = serializer.Load<Sample>(stream);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Save_Null_WritesNullString()
+    {
+        var serializer = new DockSerializer();
+        using var stream = new NonClosingMemoryStream();
+
+        serializer.Save<object?>(stream, null);
+        stream.Position = 0;
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var text = reader.ReadToEnd();
+
+        Assert.Equal("null", text.Trim());
+    }
+}


### PR DESCRIPTION
## Summary
- implement generic `JsonConverterList` and factory for System.Text.Json
- use the new converter in `DockSerializer` constructor
- reference the System.Text.Json serializer in unit tests and add tests

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68714eb44a3883219937524429bc502d