### PR TITLE
Implement list type support across serializers

### DIFF
--- a/src/Dock.Serializer.Protobuf/ListTypeConverter.cs
+++ b/src/Dock.Serializer.Protobuf/ListTypeConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Dock.Serializer.Protobuf;
+
+internal static class ListTypeConverter
+{
+    public static void Convert(object? obj, Type listType)
+    {
+        if (obj is null)
+            return;
+        if (obj is IEnumerable enumerable && obj is not string)
+        {
+            foreach (var item in enumerable)
+            {
+                Convert(item, listType);
+            }
+        }
+        var type = obj.GetType();
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || !property.CanWrite)
+                continue;
+            var value = property.GetValue(obj);
+            if (value is null)
+                continue;
+            var propType = property.PropertyType;
+            if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(IList<>))
+            {
+                var elementType = propType.GetGenericArguments()[0];
+                var list = (IList)Activator.CreateInstance(listType.MakeGenericType(elementType))!;
+                foreach (var item in (IEnumerable)value)
+                {
+                    list.Add(item);
+                }
+                foreach (var item in list)
+                {
+                    Convert(item, listType);
+                }
+                property.SetValue(obj, list);
+            }
+            else
+            {
+                Convert(value, listType);
+            }
+        }
+    }
+}

--- a/src/Dock.Serializer.Protobuf/ProtobufDockSerializer.cs
+++ b/src/Dock.Serializer.Protobuf/ProtobufDockSerializer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using Dock.Model.Core;
 using ProtoBuf;
@@ -10,6 +11,23 @@ namespace Dock.Serializer.Protobuf;
 /// </summary>
 public sealed class ProtobufDockSerializer : IDockSerializer
 {
+    private readonly Type _listType;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProtobufDockSerializer"/> class with the specified list type.
+    /// </summary>
+    /// <param name="listType">The generic list type to instantiate.</param>
+    public ProtobufDockSerializer(Type listType)
+    {
+        _listType = listType;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProtobufDockSerializer"/> class.
+    /// </summary>
+    public ProtobufDockSerializer() : this(typeof(ObservableCollection<>))
+    {
+    }
+
     /// <inheritdoc/>
     public string Serialize<T>(T value)
     {
@@ -23,13 +41,17 @@ public sealed class ProtobufDockSerializer : IDockSerializer
     {
         var bytes = Convert.FromBase64String(text);
         using var stream = new MemoryStream(bytes);
-        return global::ProtoBuf.Serializer.Deserialize<T>(stream);
+        var result = global::ProtoBuf.Serializer.Deserialize<T>(stream);
+        ListTypeConverter.Convert(result, _listType);
+        return result;
     }
 
     /// <inheritdoc/>
     public T? Load<T>(Stream stream)
     {
-        return global::ProtoBuf.Serializer.Deserialize<T>(stream);
+        var result = global::ProtoBuf.Serializer.Deserialize<T>(stream);
+        ListTypeConverter.Convert(result, _listType);
+        return result;
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Serializer.Xml/ListTypeConverter.cs
+++ b/src/Dock.Serializer.Xml/ListTypeConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Dock.Serializer.Xml;
+
+internal static class ListTypeConverter
+{
+    public static void Convert(object? obj, Type listType)
+    {
+        if (obj is null)
+            return;
+        if (obj is IEnumerable enumerable && obj is not string)
+        {
+            foreach (var item in enumerable)
+            {
+                Convert(item, listType);
+            }
+        }
+        var type = obj.GetType();
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || !property.CanWrite)
+                continue;
+            var value = property.GetValue(obj);
+            if (value is null)
+                continue;
+            var propType = property.PropertyType;
+            if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(IList<>))
+            {
+                var elementType = propType.GetGenericArguments()[0];
+                var list = (IList)Activator.CreateInstance(listType.MakeGenericType(elementType))!;
+                foreach (var item in (IEnumerable)value)
+                {
+                    list.Add(item);
+                }
+                foreach (var item in list)
+                {
+                    Convert(item, listType);
+                }
+                property.SetValue(obj, list);
+            }
+            else
+            {
+                Convert(value, listType);
+            }
+        }
+    }
+}

--- a/src/Dock.Serializer.Yaml/DockYamlSerializer.cs
+++ b/src/Dock.Serializer.Yaml/DockYamlSerializer.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
 using Dock.Model.Core;
@@ -13,12 +15,16 @@ public sealed class DockYamlSerializer : IDockSerializer
 {
     private readonly ISerializer _serializer;
     private readonly IDeserializer _deserializer;
+    private readonly Type _listType;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DockYamlSerializer"/> class.
+    /// Initializes a new instance of the <see cref="DockYamlSerializer"/> class
+    /// with the specified list type.
     /// </summary>
-    public DockYamlSerializer()
+    /// <param name="listType">The generic list type to instantiate.</param>
+    public DockYamlSerializer(Type listType)
     {
+        _listType = listType;
         _serializer = new SerializerBuilder()
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
@@ -27,6 +33,13 @@ public sealed class DockYamlSerializer : IDockSerializer
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .IgnoreUnmatchedProperties()
             .Build();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockYamlSerializer"/> class.
+    /// </summary>
+    public DockYamlSerializer() : this(typeof(ObservableCollection<>))
+    {
     }
 
     /// <inheritdoc/>
@@ -38,7 +51,9 @@ public sealed class DockYamlSerializer : IDockSerializer
     /// <inheritdoc/>
     public T? Deserialize<T>(string text)
     {
-        return _deserializer.Deserialize<T>(text);
+        var result = _deserializer.Deserialize<T>(text);
+        ListTypeConverter.Convert(result, _listType);
+        return result;
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Serializer.Yaml/ListTypeConverter.cs
+++ b/src/Dock.Serializer.Yaml/ListTypeConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Dock.Serializer.Yaml;
+
+internal static class ListTypeConverter
+{
+    public static void Convert(object? obj, Type listType)
+    {
+        if (obj is null)
+            return;
+        if (obj is IEnumerable enumerable && obj is not string)
+        {
+            foreach (var item in enumerable)
+            {
+                Convert(item, listType);
+            }
+        }
+        var type = obj.GetType();
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (!property.CanRead || !property.CanWrite)
+                continue;
+            var value = property.GetValue(obj);
+            if (value is null)
+                continue;
+            var propType = property.PropertyType;
+            if (propType.IsGenericType && propType.GetGenericTypeDefinition() == typeof(IList<>))
+            {
+                var elementType = propType.GetGenericArguments()[0];
+                var list = (IList)Activator.CreateInstance(listType.MakeGenericType(elementType))!;
+                foreach (var item in (IEnumerable)value)
+                {
+                    list.Add(item);
+                }
+                foreach (var item in list)
+                {
+                    Convert(item, listType);
+                }
+                property.SetValue(obj, list);
+            }
+            else
+            {
+                Convert(value, listType);
+            }
+        }
+    }
+}

--- a/tests/Dock.Serializer.UnitTests/Dock.Serializer.UnitTests.csproj
+++ b/tests/Dock.Serializer.UnitTests/Dock.Serializer.UnitTests.csproj
@@ -14,6 +14,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Serializer\Dock.Serializer.csproj" />
     <ProjectReference Include="..\..\src\Dock.Serializer.SystemTextJson\Dock.Serializer.SystemTextJson.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Yaml\Dock.Serializer.Yaml.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Xml\Dock.Serializer.Xml.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Protobuf\Dock.Serializer.Protobuf.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dock.Serializer.UnitTests/ProtobufDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/ProtobufDockSerializerTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Dock.Serializer.Protobuf;
+using Xunit;
+
+namespace Dock.Serializer.UnitTests;
+
+public class ProtobufDockSerializerTests
+{
+    [ProtoBuf.ProtoContract]
+    private class Sample
+    {
+        [ProtoBuf.ProtoMember(1)]
+        public string? Name { get; set; }
+        [ProtoBuf.ProtoMember(2)]
+        public IList<int>? Numbers { get; set; }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_DefaultListType_ObservableCollection()
+    {
+        var serializer = new ProtobufDockSerializer();
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 1, 2 } };
+
+        var data = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(data);
+
+        Assert.NotNull(result);
+        Assert.Equal(sample.Name, result!.Name);
+        Assert.IsType<ObservableCollection<int>>(result.Numbers);
+        Assert.Equal(sample.Numbers, result.Numbers.ToList());
+    }
+
+    [Fact]
+    public void CustomListType_List_DeserializesToList()
+    {
+        var serializer = new ProtobufDockSerializer(typeof(List<>));
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 7, 8 } };
+
+        var data = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(data);
+
+        Assert.NotNull(result);
+        Assert.IsType<List<int>>(result!.Numbers);
+    }
+}

--- a/tests/Dock.Serializer.UnitTests/XmlDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/XmlDockSerializerTests.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Dock.Serializer.Xml;
+using Xunit;
+
+namespace Dock.Serializer.UnitTests;
+
+public class XmlDockSerializerTests
+{
+    [System.Runtime.Serialization.DataContract]
+    private class Sample
+    {
+        [System.Runtime.Serialization.DataMember]
+        public string? Name { get; set; }
+        [System.Runtime.Serialization.DataMember]
+        public IList<int>? Numbers { get; set; }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_DefaultListType_ObservableCollection()
+    {
+        var serializer = new DockXmlSerializer();
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 1, 2 } };
+
+        var xml = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(xml);
+
+        Assert.NotNull(result);
+        Assert.Equal(sample.Name, result!.Name);
+        Assert.IsType<ObservableCollection<int>>(result.Numbers);
+        Assert.Equal(sample.Numbers, result.Numbers.ToList());
+    }
+
+    [Fact]
+    public void CustomListType_List_DeserializesToList()
+    {
+        var serializer = new DockXmlSerializer(typeof(List<>));
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 7, 8 } };
+
+        var xml = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(xml);
+
+        Assert.NotNull(result);
+        Assert.IsType<List<int>>(result!.Numbers);
+    }
+}

--- a/tests/Dock.Serializer.UnitTests/YamlDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/YamlDockSerializerTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Dock.Serializer.Yaml;
+using Xunit;
+
+namespace Dock.Serializer.UnitTests;
+
+public class YamlDockSerializerTests
+{
+    private class Sample
+    {
+        public string? Name { get; set; }
+        public IList<int>? Numbers { get; set; }
+    }
+
+    [Fact]
+    public void SerializeDeserialize_DefaultListType_ObservableCollection()
+    {
+        var serializer = new DockYamlSerializer();
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 1, 2 } };
+
+        var yaml = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(yaml);
+
+        Assert.NotNull(result);
+        Assert.Equal(sample.Name, result!.Name);
+        Assert.IsType<ObservableCollection<int>>(result.Numbers);
+        Assert.Equal(sample.Numbers, result.Numbers.ToList());
+    }
+
+    [Fact]
+    public void CustomListType_List_DeserializesToList()
+    {
+        var serializer = new DockYamlSerializer(typeof(List<>));
+        var sample = new Sample { Name = "Test", Numbers = new List<int> { 7, 8 } };
+
+        var yaml = serializer.Serialize(sample);
+        var result = serializer.Deserialize<Sample>(yaml);
+
+        Assert.NotNull(result);
+        Assert.IsType<List<int>>(result!.Numbers);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `DockYamlSerializer`, `DockXmlSerializer` and `ProtobufDockSerializer` to accept a list type
- create helper `ListTypeConverter` in each serializer to convert deserialized lists
- add new unit tests verifying list type behaviour for YAML, XML and Protobuf serializers
- update test project references

## Testing
- `dotnet test tests/Dock.Serializer.UnitTests/Dock.Serializer.UnitTests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687151de8020832192781cdf60a2a4b3