### PR TITLE
Improve ReactiveUI navigation

### DIFF
--- a/samples/DockReactiveUIRoutingSample/ViewModels/DockFactory.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/DockFactory.cs
@@ -2,9 +2,9 @@ using Dock.Avalonia.Controls;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Model.ReactiveUI;
-using ReactiveUI;
 using Dock.Model.ReactiveUI.Controls;
 using Dock.Model.ReactiveUI.Navigation.Controls;
+using ReactiveUI;
 
 namespace DockReactiveUIRoutingSample.ViewModels;
 
@@ -19,13 +19,18 @@ public class DockFactory : Factory
 
     public override IRootDock CreateLayout()
     {
-        var document1 = new DocumentViewModel { Id = "Doc1", Title = "Document 1" };
-        var tool1 = new ToolViewModel { Id = "Tool1", Title = "Tool 1" };
+        var document1 = new DocumentViewModel(_host) { Id = "Doc1", Title = "Document 1" };
+        var document2 = new DocumentViewModel(_host) { Id = "Doc2", Title = "Document 2" };
+        var tool1 = new ToolViewModel(_host) { Id = "Tool1", Title = "Tool 1" };
+
+        document1.InitNavigation(document2, tool1);
+        document2.InitNavigation(document1, tool1);
+        tool1.InitNavigation(document1, document2);
 
         var documentDock = new DocumentDock
         {
             Id = "Documents",
-            VisibleDockables = CreateList<IDockable>(document1),
+            VisibleDockables = CreateList<IDockable>(document1, document2),
             ActiveDockable = document1,
             CanCreateDocument = false
         };

--- a/samples/DockReactiveUIRoutingSample/ViewModels/DocumentViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/DocumentViewModel.cs
@@ -1,7 +1,24 @@
-using Dock.Model.ReactiveUI.Controls;
+using System;
+using System.Reactive.Linq;
+using Dock.Model.ReactiveUI.Navigation.Controls;
+using ReactiveUI;
+using System.Reactive;
 
 namespace DockReactiveUIRoutingSample.ViewModels;
 
-public class DocumentViewModel : Document
+public class DocumentViewModel : RoutableDocument
 {
+    public ReactiveCommand<Unit, Unit>? GoDocument { get; private set; }
+    public ReactiveCommand<Unit, Unit>? GoTool { get; private set; }
+
+    public DocumentViewModel(IScreen host) : base(host)
+    {
+        Router.Navigate.Execute(new InnerViewModel(this, "Home"));
+    }
+
+    public void InitNavigation(IRoutableViewModel document, IRoutableViewModel tool)
+    {
+        GoDocument = ReactiveCommand.Create(() => { HostScreen.Router.Navigate.Execute(document).Subscribe(_ => { }); });
+        GoTool = ReactiveCommand.Create(() => { HostScreen.Router.Navigate.Execute(tool).Subscribe(_ => { }); });
+    }
 }

--- a/samples/DockReactiveUIRoutingSample/ViewModels/InnerViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/InnerViewModel.cs
@@ -1,0 +1,17 @@
+using ReactiveUI;
+
+namespace DockReactiveUIRoutingSample.ViewModels;
+
+public class InnerViewModel : ReactiveObject, IRoutableViewModel
+{
+    public string UrlPathSegment { get; }
+    public IScreen HostScreen { get; }
+    public string Text { get; }
+
+    public InnerViewModel(IScreen host, string text)
+    {
+        HostScreen = host;
+        UrlPathSegment = GetType().Name;
+        Text = text;
+    }
+}

--- a/samples/DockReactiveUIRoutingSample/ViewModels/ToolViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/ToolViewModel.cs
@@ -1,7 +1,24 @@
-using Dock.Model.ReactiveUI.Controls;
+using System;
+using System.Reactive.Linq;
+using Dock.Model.ReactiveUI.Navigation.Controls;
+using ReactiveUI;
+using System.Reactive;
 
 namespace DockReactiveUIRoutingSample.ViewModels;
 
-public class ToolViewModel : Tool
+public class ToolViewModel : RoutableTool
 {
+    public ReactiveCommand<Unit, Unit>? GoDocument { get; private set; }
+    public ReactiveCommand<Unit, Unit>? GoTool { get; private set; }
+
+    public ToolViewModel(IScreen host) : base(host)
+    {
+        Router.Navigate.Execute(new InnerViewModel(this, "Tool Home"));
+    }
+
+    public void InitNavigation(IRoutableViewModel document, IRoutableViewModel tool)
+    {
+        GoDocument = ReactiveCommand.Create(() => { HostScreen.Router.Navigate.Execute(document).Subscribe(_ => { }); });
+        GoTool = ReactiveCommand.Create(() => { HostScreen.Router.Navigate.Execute(tool).Subscribe(_ => { }); });
+    }
 }

--- a/samples/DockReactiveUIRoutingSample/Views/Documents/DocumentView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Documents/DocumentView.axaml
@@ -1,13 +1,15 @@
 <UserControl x:Class="DockReactiveUIRoutingSample.Views.Documents.DocumentView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
              xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
              x:DataType="vm:DocumentViewModel">
-    <Grid>
-        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-            <TextBlock Text="{Binding Id}" />
-            <TextBlock Text="{Binding Title}" />
-            <TextBlock Text="{Binding Context}" />
+    <StackPanel Margin="10" Spacing="5">
+        <TextBlock Text="{Binding Title}" FontWeight="Bold" />
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <Button Content="Open Other Doc" Command="{Binding GoDocument}"/>
+            <Button Content="Open Tool" Command="{Binding GoTool}"/>
         </StackPanel>
-    </Grid>
+        <rxui:RoutedViewHost Router="{Binding Router}" />
+    </StackPanel>
 </UserControl>

--- a/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml
@@ -1,0 +1,7 @@
+<UserControl x:Class="DockReactiveUIRoutingSample.Views.Inner.InnerView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
+             x:DataType="vm:InnerViewModel">
+    <TextBlock Text="{Binding Text}"/>
+</UserControl>

--- a/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml.cs
+++ b/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DockReactiveUIRoutingSample.Views.Inner;
+
+public partial class InnerView : UserControl
+{
+    public InnerView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/DockReactiveUIRoutingSample/Views/Tools/ToolView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Tools/ToolView.axaml
@@ -1,13 +1,15 @@
 <UserControl x:Class="DockReactiveUIRoutingSample.Views.Tools.ToolView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
              xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
              x:DataType="vm:ToolViewModel">
-    <Grid>
-        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
-            <TextBlock Text="{Binding Id}" />
-            <TextBlock Text="{Binding Title}" />
-            <TextBlock Text="{Binding Context}" />
+    <StackPanel Margin="10" Spacing="5">
+        <TextBlock Text="{Binding Title}" FontWeight="Bold" />
+        <StackPanel Orientation="Horizontal" Spacing="5">
+            <Button Content="Go Doc" Command="{Binding GoDocument}"/>
+            <Button Content="Next Tool" Command="{Binding GoTool}"/>
         </StackPanel>
-    </Grid>
+        <rxui:RoutedViewHost Router="{Binding Router}" />
+    </StackPanel>
 </UserControl>

--- a/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableDocument.cs
+++ b/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableDocument.cs
@@ -1,0 +1,37 @@
+using System.Runtime.Serialization;
+using Dock.Model.ReactiveUI.Controls;
+using ReactiveUI;
+
+namespace Dock.Model.ReactiveUI.Navigation.Controls;
+
+/// <summary>
+/// Document that supports ReactiveUI routing and acts as a screen for nested navigation.
+/// </summary>
+[DataContract(IsReference = true)]
+public class RoutableDocument : Document, IRoutableViewModel, IScreen
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RoutableDocument"/> class.
+    /// </summary>
+    /// <param name="host">The host screen.</param>
+    /// <param name="url">Optional url segment.</param>
+    public RoutableDocument(IScreen host, string? url = null)
+    {
+        HostScreen = host;
+        UrlPathSegment = url ?? GetType().Name;
+    }
+
+    /// <summary>
+    /// Gets router used for nested navigation.
+    /// </summary>
+    [IgnoreDataMember]
+    public RoutingState Router { get; } = new RoutingState();
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public string UrlPathSegment { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public IScreen HostScreen { get; }
+}

--- a/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableTool.cs
+++ b/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableTool.cs
@@ -1,0 +1,37 @@
+using System.Runtime.Serialization;
+using Dock.Model.ReactiveUI.Controls;
+using ReactiveUI;
+
+namespace Dock.Model.ReactiveUI.Navigation.Controls;
+
+/// <summary>
+/// Tool that supports ReactiveUI routing and acts as a screen for nested navigation.
+/// </summary>
+[DataContract(IsReference = true)]
+public class RoutableTool : Tool, IRoutableViewModel, IScreen
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RoutableTool"/> class.
+    /// </summary>
+    /// <param name="host">The host screen.</param>
+    /// <param name="url">Optional url segment.</param>
+    public RoutableTool(IScreen host, string? url = null)
+    {
+        HostScreen = host;
+        UrlPathSegment = url ?? GetType().Name;
+    }
+
+    /// <summary>
+    /// Gets router used for nested navigation.
+    /// </summary>
+    [IgnoreDataMember]
+    public RoutingState Router { get; } = new RoutingState();
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public string UrlPathSegment { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public IScreen HostScreen { get; }
+}


### PR DESCRIPTION
## Summary
- support nested navigation by adding `RoutableDocument` and `RoutableTool`
- extend routing sample with multiple documents and tools
- embed `RoutedViewHost` in documents and tools

## Testing
- `dotnet build src/Dock.Model.ReactiveUI.Navigation/Dock.Model.ReactiveUI.Navigation.csproj -c Release`
- `dotnet build samples/DockReactiveUIRoutingSample/DockReactiveUIRoutingSample.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687174056890832180bc71ce37db8a4c