### PR TITLE
Fix ReactiveUI routing sample

### DIFF
--- a/samples/DockReactiveUIRoutingSample/ViewModels/DockFactory.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/DockFactory.cs
@@ -4,6 +4,8 @@ using Dock.Model.Core;
 using Dock.Model.ReactiveUI;
 using Dock.Model.ReactiveUI.Controls;
 using Dock.Model.ReactiveUI.Navigation.Controls;
+using DockReactiveUIRoutingSample.ViewModels.Documents;
+using DockReactiveUIRoutingSample.ViewModels.Tools;
 using ReactiveUI;
 
 namespace DockReactiveUIRoutingSample.ViewModels;

--- a/samples/DockReactiveUIRoutingSample/ViewModels/DocumentViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/DocumentViewModel.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Reactive.Linq;
 using Dock.Model.ReactiveUI.Navigation.Controls;
+using DockReactiveUIRoutingSample.ViewModels.Inner;
 using ReactiveUI;
 using System.Reactive;
 
-namespace DockReactiveUIRoutingSample.ViewModels;
+namespace DockReactiveUIRoutingSample.ViewModels.Documents;
 
 public class DocumentViewModel : RoutableDocument
 {

--- a/samples/DockReactiveUIRoutingSample/ViewModels/InnerViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/InnerViewModel.cs
@@ -1,6 +1,6 @@
 using ReactiveUI;
 
-namespace DockReactiveUIRoutingSample.ViewModels;
+namespace DockReactiveUIRoutingSample.ViewModels.Inner;
 
 public class InnerViewModel : ReactiveObject, IRoutableViewModel
 {

--- a/samples/DockReactiveUIRoutingSample/ViewModels/ToolViewModel.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewModels/ToolViewModel.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Reactive.Linq;
 using Dock.Model.ReactiveUI.Navigation.Controls;
+using DockReactiveUIRoutingSample.ViewModels.Inner;
 using ReactiveUI;
 using System.Reactive;
 
-namespace DockReactiveUIRoutingSample.ViewModels;
+namespace DockReactiveUIRoutingSample.ViewModels.Tools;
 
 public class ToolViewModel : RoutableTool
 {

--- a/samples/DockReactiveUIRoutingSample/Views/Documents/DocumentView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Documents/DocumentView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
-             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
+             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels.Documents"
              x:DataType="vm:DocumentViewModel">
     <StackPanel Margin="10" Spacing="5">
         <TextBlock Text="{Binding Title}" FontWeight="Bold" />

--- a/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Inner/InnerView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="DockReactiveUIRoutingSample.Views.Inner.InnerView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
+             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels.Inner"
              x:DataType="vm:InnerViewModel">
     <TextBlock Text="{Binding Text}"/>
 </UserControl>

--- a/samples/DockReactiveUIRoutingSample/Views/Tools/ToolView.axaml
+++ b/samples/DockReactiveUIRoutingSample/Views/Tools/ToolView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:rxui="clr-namespace:Avalonia.ReactiveUI;assembly=Avalonia.ReactiveUI"
-             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels"
+             xmlns:vm="using:DockReactiveUIRoutingSample.ViewModels.Tools"
              x:DataType="vm:ToolViewModel">
     <StackPanel Margin="10" Spacing="5">
         <TextBlock Text="{Binding Title}" FontWeight="Bold" />

--- a/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableRootDock.cs
+++ b/src/Dock.Model.ReactiveUI.Navigation/Controls/RoutableRootDock.cs
@@ -9,7 +9,7 @@ namespace Dock.Model.ReactiveUI.Navigation.Controls;
 /// Root dock that supports <see cref="IRoutableViewModel"/> for ReactiveUI navigation.
 /// </summary>
 [DataContract(IsReference = true)]
-public class RoutableRootDock : RootDock, IRoutableViewModel
+public class RoutableRootDock : RootDock, IRoutableViewModel, IScreen
 {
     /// <summary>
     /// Initializes new instance of the <see cref="RoutableRootDock"/> class.
@@ -21,6 +21,12 @@ public class RoutableRootDock : RootDock, IRoutableViewModel
         HostScreen = host;
         UrlPathSegment = url ?? GetType().Name;
     }
+
+    /// <summary>
+    /// Gets router used for nested navigation.
+    /// </summary>
+    [IgnoreDataMember]
+    public RoutingState Router { get; } = new RoutingState();
 
     /// <inheritdoc/>
     [IgnoreDataMember]


### PR DESCRIPTION
## Summary
- update namespaces so the static view locator can find the sample views
- map inner view models to new namespaces in XAML
- expose a `Router` on `RoutableRootDock` so the root dock can act as a navigation screen

## Testing
- `dotnet build src/Dock.Model.ReactiveUI.Navigation/Dock.Model.ReactiveUI.Navigation.csproj -c Release`
- `dotnet build samples/DockReactiveUIRoutingSample/DockReactiveUIRoutingSample.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68717a493134832189fc80edecf54863