### PR TITLE
Add DI helper for Dock

### DIFF
--- a/Dock.sln
+++ b/Dock.sln
@@ -189,6 +189,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DockReactiveUIRoutingSample
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.ReactiveUI.Navigation", "src\Dock.Model.ReactiveUI.Navigation\Dock.Model.ReactiveUI.Navigation.csproj", "{B72BB21A-3700-4666-BB14-112F11EA0CDA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.Extensions.DependencyInjection", "src\Dock.Model.Extensions.DependencyInjection\Dock.Model.Extensions.DependencyInjection.csproj", "{485B94B7-C0E2-4037-8942-58FDC22FE751}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -342,7 +344,11 @@ Global
 		{B72BB21A-3700-4666-BB14-112F11EA0CDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B72BB21A-3700-4666-BB14-112F11EA0CDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B72BB21A-3700-4666-BB14-112F11EA0CDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B72BB21A-3700-4666-BB14-112F11EA0CDA}.Release|Any CPU.Build.0 = Release|Any CPU
+               {B72BB21A-3700-4666-BB14-112F11EA0CDA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {485B94B7-C0E2-4037-8942-58FDC22FE751}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {485B94B7-C0E2-4037-8942-58FDC22FE751}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {485B94B7-C0E2-4037-8942-58FDC22FE751}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {485B94B7-C0E2-4037-8942-58FDC22FE751}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 								GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -388,8 +394,9 @@ Global
 		{927DBE0C-567E-40F1-BD2F-D9D42EBDAFA9} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
 		{77DDDBB0-4EA2-493E-BFEE-17E40A733EA7} = {71FD12F4-0BCB-422A-9FB0-4137E898E991}
 		{3267D62B-EFE2-40C1-ACD5-8BF43CAF8AF6} = {2B045CC0-AA4B-44B1-9D92-459B71EC7AA3}
-		{B72BB21A-3700-4666-BB14-112F11EA0CDA} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
-	EndGlobalSection
+                {B72BB21A-3700-4666-BB14-112F11EA0CDA} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
+                {485B94B7-C0E2-4037-8942-58FDC22FE751} = {FC61A082-2335-4C45-A38C-1EBEEA7BBE0A}
+        EndGlobalSection
 								GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5617659E-FC7E-40D7-9D62-258513329CA1}
 								EndGlobalSection

--- a/build/Microsoft.Extensions.DependencyInjection.props
+++ b/build/Microsoft.Extensions.DependencyInjection.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+</Project>

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Serialization and persistence](dock-serialization.md) – Save and restore layouts.
 - [Serialization state](dock-serialization-state.md) – Capture focus information.
 - [Dock state guide](dock-state.md) – Why and how to use `DockState`.
+- [Dependency injection](dock-dependency-injection.md) – Register Dock services with `IServiceCollection`.
 - [Context locators](dock-context-locator.md) – Provide `DataContext` objects for dockables.
 - [Architecture overview](dock-architecture.md) – High level design of the docking system.
 - [Deep dive](dock-deep-dive.md) – Internals of `DockControl`.

--- a/docs/dock-dependency-injection.md
+++ b/docs/dock-dependency-injection.md
@@ -1,0 +1,15 @@
+# Dependency injection
+
+Dock provides an integration library for the default .NET service container. The `Dock.Model.Extensions.DependencyInjection` package exposes an `AddDock` extension for `IServiceCollection`.
+
+## Register services
+
+Reference the package and register your factory and serializer types during startup:
+
+```csharp
+services.AddDock<MyDockFactory, DockSerializer>();
+```
+
+This registers `IDockState`, your factory implementation as `IFactory`, and the serializer as `IDockSerializer`.
+
+

--- a/src/Dock.Model.Extensions.DependencyInjection/Dock.Model.Extensions.DependencyInjection.csproj
+++ b/src/Dock.Model.Extensions.DependencyInjection/Dock.Model.Extensions.DependencyInjection.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Dock.Model.Extensions.DependencyInjection</PackageId>
+  </PropertyGroup>
+  <Import Project="..\..\build\SignAssembly.props" />
+  <Import Project="..\..\build\SourceLink.props" />
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Microsoft.Extensions.DependencyInjection.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Model\Dock.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Dock.Model;
+using Dock.Model.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dock.Model.Extensions.DependencyInjection;
+
+/// <summary>
+/// Provides registration helpers for Dock model services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers Dock model services using the provided factory and serializer types.
+    /// </summary>
+    /// <typeparam name="TFactory">Implementation of <see cref="IFactory"/>.</typeparam>
+    /// <typeparam name="TSerializer">Implementation of <see cref="IDockSerializer"/>.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddDock<TFactory, TSerializer>(this IServiceCollection services)
+        where TFactory : class, IFactory
+        where TSerializer : class, IDockSerializer
+    {
+        services.AddSingleton<IDockState, DockState>();
+        services.AddSingleton<TFactory>();
+        services.AddSingleton<IFactory>(static sp => sp.GetRequiredService<TFactory>());
+        services.AddSingleton<TSerializer>();
+        services.AddSingleton<IDockSerializer>(static sp => sp.GetRequiredService<TSerializer>());
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Dock.Model.Extensions.DependencyInjection` library
- register Dock types easily with `IServiceCollection`
- document DI support and include new build props

## Testing
- `dotnet test` *(fails: blocked network telemetry)*

------
https://chatgpt.com/codex/tasks/task_e_68717aa25110832180209ee4c6e9ab71