### PR TITLE
Introduce basic MDI window sample

### DIFF
--- a/samples/DockMdiSample/App.axaml
+++ b/samples/DockMdiSample/App.axaml
@@ -1,0 +1,30 @@
+﻿<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="DockMdiSample.App"
+             Name="Dock Avalonia Demo"
+             RequestedThemeVariant="Light">
+
+  <Application.Resources>
+    <ControlRecycling x:Key="ControlRecyclingKey" TryToUseIdAsKey="True" />
+    <Color x:Key="RegionColor">Transparent</Color>
+  </Application.Resources>
+
+  <Application.Styles>
+
+    <FluentTheme />
+
+    <!-- <StyleInclude Source="avares://Dock.Avalonia/Themes/DockFluentTheme.axaml" /> -->
+    <DockFluentTheme />
+
+    <Style Selector="TextBlock">
+      <Setter Property="HorizontalAlignment" Value="Center" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+
+    <Style Selector="DockControl">
+      <Setter Property="(ControlRecyclingDataTemplate.ControlRecycling)" Value="{StaticResource ControlRecyclingKey}" />
+    </Style>
+
+  </Application.Styles>
+
+</Application>

--- a/samples/DockMdiSample/App.axaml.cs
+++ b/samples/DockMdiSample/App.axaml.cs
@@ -1,0 +1,31 @@
+﻿using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace DockMdiSample;
+
+public class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopLifetime)
+        {
+            desktopLifetime.MainWindow = new MainWindow();
+        }
+
+        if (ApplicationLifetime is ISingleViewApplicationLifetime singleLifetime)
+        {
+            singleLifetime.MainView = new MainView();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+#if DEBUG
+        this.AttachDevTools();
+#endif
+    }
+}

--- a/samples/DockMdiSample/DockMdiSample.csproj
+++ b/samples/DockMdiSample/DockMdiSample.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <AvaloniaNameGeneratorBehavior>OnlyProperties</AvaloniaNameGeneratorBehavior>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\AOT.props" />
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
+  <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Newtonsoft\Dock.Serializer.Newtonsoft.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/DockMdiSample/MainView.axaml
+++ b/samples/DockMdiSample/MainView.axaml
@@ -1,0 +1,116 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="DockMdiSample.MainView"
+             x:CompileBindings="True" x:DataType="DockControl">
+  <Grid RowDefinitions="Auto,*">
+
+    <Menu Grid.Row="0">
+      <MenuItem Header="_File">
+        <MenuItem x:Name="FileOpenLayout" Header="_Open layout..." Click="FileOpenLayout_OnClick" />
+        <Separator/>
+        <MenuItem x:Name="FileSaveLayout" Header="_Save layout..." Click="FileSaveLayout_OnClick" />
+        <Separator/>
+        <MenuItem x:Name="FileCloseLayout" Header="_Close layout" Click="FileCloseLayout_OnClick" />
+      </MenuItem>
+      <MenuItem Header="_View" x:Name="ViewsMenu" />
+    </Menu>
+
+    <DockControl x:Name="DockControl" Grid.Row="1" InitializeLayout="True" InitializeFactory="True">
+      <DockControl.Factory>
+        <Factory HideToolsOnClose="True" HideDocumentsOnClose="True" />
+      </DockControl.Factory>
+
+      <RootDock x:Name="Root" Id="Root" IsCollapsable="False" DefaultDockable="{Binding #MainLayout}">
+
+        <!-- Windows -->
+
+        <RootDock.Windows>
+          <DockWindow x:Name="DockWindow" Id="DockWindow" X="281" Y="233" Width="250" Height="400" Topmost="True">
+            <RootDock ActiveDockable="{Binding #ToolDock}" Window="{Binding #DockWindow}">
+              <ToolDock x:Name="ToolDock">
+                <Tool x:Name="ToolWindow" Id="ToolWindow" Title="Tool Window" x:DataType="Tool">
+                  <TextBlock Text="{Binding Title}"/>
+                </Tool>
+              </ToolDock>
+            </RootDock>
+          </DockWindow>
+        </RootDock.Windows>
+
+        <ProportionalDock x:Name="MainLayout" Id="MainLayout" Orientation="Horizontal">
+
+          <!-- Left Pane -->
+
+          <ToolDock x:Name="LeftPane" Id="LeftPane" Proportion="0.25" Alignment="Left">
+            <Tool x:Name="SolutionExplorer" Id="SolutionExplorer" Title="Solution Explorer" x:DataType="Tool">
+              <TextBlock Text="{Binding Title}"/>
+            </Tool>
+          </ToolDock>
+
+          <ProportionalDockSplitter x:Name="LeftSplitter" Id="LeftSplitter" />
+
+          <!-- Top Pane -->
+
+          <ProportionalDock x:Name="TopPane" Id="TopPane" Orientation="Vertical">
+
+            <!-- Right Pane -->
+
+            <ProportionalDock x:Name="RightPane" Id="RightPane" Orientation="Horizontal">
+
+              <!-- Documents Pane -->
+
+              <DocumentDock x:Name="DocumentsPane" Id="DocumentsPane" CanCreateDocument="True" ActiveDockable="Document1">
+                <DocumentDock.DocumentTemplate>
+                  <DocumentTemplate>
+                    <StackPanel x:DataType="Document">
+                      <TextBlock Text="Title"/>
+                      <TextBox Text="{Binding Title}"/>
+                      <TextBlock Text="Context"/>
+                      <TextBox Text="{Binding Context}" AcceptsReturn="True"/>
+                    </StackPanel>
+                  </DocumentTemplate>
+                </DocumentDock.DocumentTemplate>
+                <Document x:Name="Document1" Id="Document1" Title="Program.cs" Context="" x:DataType="Document">
+                  <TextBox Text="{Binding Context}" AcceptsReturn="True"/>
+                </Document>
+                <Document x:Name="Document2" Id="Document2" Title="App.axaml" Context="" x:DataType="Document">
+                  <TextBox Text="{Binding Context}" AcceptsReturn="True"/>
+                </Document>
+              </DocumentDock>
+
+              <ProportionalDockSplitter x:Name="RightSplitter" Id="RightSplitter" />
+
+              <!-- Properties Pane -->
+              <ToolDock x:Name="PropertiesPane" Id="PropertiesPane" Proportion="0.3" Alignment="Right">
+                <Tool x:Name="Properties" Id="Properties" Title="Properties" x:DataType="Tool">
+                  <TextBlock Text="{Binding Title}"/>
+                </Tool>
+              </ToolDock>
+
+            </ProportionalDock>
+
+            <ProportionalDockSplitter x:Name="BottomSplitter" Id="BottomSplitter" />
+
+            <!-- Bottom Pane -->
+
+            <ToolDock x:Name="BottomPane" Id="BottomPane" Proportion="0.3" Alignment="Bottom" ActiveDockable="Output">
+              <Tool x:Name="ErrorList" Id="ErrorList" Title="Error List" x:DataType="Tool">
+                <TextBlock Text="{Binding Title}"/>
+              </Tool>
+              <Tool x:Name="Output" Id="Output" Title="Output" x:DataType="Tool">
+                <TextBlock Text="{Binding Title}"/>
+              </Tool>
+            </ToolDock>
+
+          </ProportionalDock>
+
+        </ProportionalDock>
+      </RootDock>
+
+    </DockControl>
+
+  </Grid>
+</UserControl>
+

--- a/samples/DockMdiSample/MainView.axaml.cs
+++ b/samples/DockMdiSample/MainView.axaml.cs
@@ -1,0 +1,216 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
+using Dock.Model;
+using Dock.Model.Core;
+using Dock.Model.Controls;
+using Dock.Model.Avalonia;
+using Dock.Avalonia.Controls;
+using Dock.Serializer;
+
+namespace DockMdiSample;
+
+public partial class MainView : UserControl
+{
+    private IDockSerializer? _serializer;
+    private IDockState? _dockState;
+    private IRootDock? _rootDock;
+    private MenuItem? _viewsMenu;
+
+    public MainView()
+    {
+        InitializeComponent();
+        InitializeDockState();
+    }
+
+    private void InitializeDockState()
+    {
+        _serializer = new DockSerializer(typeof(AvaloniaList<>));
+        // TODO:
+        // _serializer = new AvaloniaDockSerializer();
+        _dockState = new DockState();
+
+        var layout = DockControl?.Layout;
+        if (layout != null)
+        {
+            _dockState.Save(layout);
+        }
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+
+        if (DockControl?.Factory is Factory factory)
+        {
+            factory.DefaultHostWindowLocator = () => new MdiHostWindow();
+        }
+        _viewsMenu = ViewsMenu;
+        _rootDock = DockControl?.Layout as IRootDock;
+
+        if (DockControl?.Factory is { } factory)
+        {
+            factory.DockableHidden += (_, _) => UpdateViewsMenu();
+            factory.DockableRestored += (_, _) => UpdateViewsMenu();
+        }
+
+        UpdateViewsMenu();
+    }
+
+    private async Task OpenLayout()
+    {
+        if (_serializer is null || _dockState is null)
+        {
+            return;
+        }
+
+        var storageProvider = (this.GetVisualRoot() as TopLevel)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var result = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open layout",
+            FileTypeFilter = [new FilePickerFileType("Json") { Patterns = ["*.json"] }, new FilePickerFileType("All") { Patterns = ["*.*"] }],
+            AllowMultiple = false
+        });
+
+        var file = result.FirstOrDefault();
+
+        if (file is not null)
+        {
+            try
+            {
+                await using var stream = await file.OpenReadAsync();
+                using var reader = new StreamReader(stream);
+                if (DockControl is not null)
+                {
+                    var layout = _serializer.Load<IDock?>(stream);
+                    // TODO:
+                    // var layout = await JsonSerializer.DeserializeAsync(
+                    //     stream, 
+                    //     AvaloniaDockSerializer.s_serializerContext.RootDock);
+                    if (layout is { })
+                    {
+                        DockControl.Layout = layout;
+                        DockControl.Factory?.InitLayout(layout);
+                        _dockState.Restore(layout);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    private async Task SaveLayout()
+    {
+        if (_serializer is null || _dockState is null)
+        {
+            return;
+        }
+
+        var storageProvider = (this.GetVisualRoot() as TopLevel)?.StorageProvider;
+        if (storageProvider is null)
+        {
+            return;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save layout",
+            FileTypeChoices = [new FilePickerFileType("Json") { Patterns = ["*.json"] }, new FilePickerFileType("All") { Patterns = ["*.*"] }],
+            SuggestedFileName = "layout",
+            DefaultExtension = "json",
+            ShowOverwritePrompt = true
+        });
+
+        if (file is not null)
+        {
+            try
+            {
+                await using var stream = await file.OpenWriteAsync();
+                if (DockControl?.Layout is not null)
+                {
+                    _serializer.Save(stream, DockControl.Layout);
+                    // TODO:
+                    // await JsonSerializer.SerializeAsync(
+                    //     stream, 
+                    //     (RootDock)dock.Layout, AvaloniaDockSerializer.s_serializerContext.RootDock);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+            }
+        }
+    }
+
+    private void CloseLayout()
+    {
+        if (DockControl is not null)
+        {
+            DockControl.Layout = null;
+        }
+    }
+
+    private async void FileOpenLayout_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await OpenLayout();
+    }
+
+    private async void FileSaveLayout_OnClick(object? sender, RoutedEventArgs e)
+    {
+        await SaveLayout();
+    }
+
+    private void FileCloseLayout_OnClick(object? sender, RoutedEventArgs e)
+    {
+        CloseLayout();
+    }
+
+    private void ViewsMenuItem_OnClick(object? sender, RoutedEventArgs e)
+    {
+        if (sender is MenuItem { Tag: IDockable dockable } && DockControl?.Factory is { } factory)
+        {
+            factory.RestoreDockable(dockable);
+        }
+    }
+
+    private void UpdateViewsMenu()
+    {
+        if (_viewsMenu is null)
+        {
+            return;
+        }
+
+        _viewsMenu.Items.Clear();
+
+        if (_rootDock?.HiddenDockables is { Count: >0 } hidden)
+        {
+            foreach (var dockable in hidden)
+            {
+                var item = new MenuItem { Header = dockable.Title ?? dockable.Id, Tag = dockable };
+                item.Click += ViewsMenuItem_OnClick;
+                _viewsMenu.Items.Add(item);
+            }
+            _viewsMenu.IsEnabled = true;
+        }
+        else
+        {
+            _viewsMenu.IsEnabled = false;
+        }
+    }
+}
+

--- a/samples/DockMdiSample/MainWindow.axaml
+++ b/samples/DockMdiSample/MainWindow.axaml
@@ -1,0 +1,50 @@
+﻿<Window x:Class="DockMdiSample.MainWindow"
+        xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:DockMdiSample"
+        mc:Ignorable="d" 
+        d:DesignWidth="800" d:DesignHeight="600"
+        x:CompileBindings="True"
+        x:Name="MainWindowView"
+        UseLayoutRounding="True" RenderOptions.BitmapInterpolationMode="HighQuality"
+        WindowState="Normal" WindowStartupLocation="CenterScreen"
+        Background="{x:Null}"
+        TransparencyLevelHint="AcrylicBlur"
+        Foreground="{DynamicResource DockThemeForegroundBrush}"
+        BorderThickness="1" BorderBrush="{DynamicResource DockThemeBorderLowBrush}"
+        Title="Dock Avalonia Demo" Width="800" Height="600"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="PreferSystemChrome">
+  <Window.Resources>
+    <ExperimentalAcrylicMaterial BackgroundSource="Digger"
+                                 TintColor="{DynamicResource SystemAltHighColor}"
+                                 TintOpacity="1"
+                                 FallbackColor="{DynamicResource AcrylicFallbackColor}"
+                                 MaterialOpacity="0.55"
+                                 x:Key="AcrylicMaterial"/>
+  </Window.Resources>
+  <Panel>
+    <ExperimentalAcrylicBorder IsHitTestVisible="False" Material="{StaticResource AcrylicMaterial}" />
+    <Panel Margin="{Binding #MainWindowView.OffScreenMargin}">
+      <Panel Margin="{Binding #MainWindowView.WindowDecorationMargin}">
+        <local:MainView>
+          <local:MainView.Styles>
+            <Style Selector="GridSplitter">
+              <Setter Property="Template">
+                <Setter.Value>
+                  <ControlTemplate>
+                    <Border Background="Transparent">
+                      <ExperimentalAcrylicBorder Material="{StaticResource AcrylicMaterial}" />
+                    </Border>
+                  </ControlTemplate>
+                </Setter.Value>
+              </Setter>
+            </Style>
+          </local:MainView.Styles>
+        </local:MainView>
+      </Panel>
+    </Panel>
+  </Panel>
+</Window>

--- a/samples/DockMdiSample/MainWindow.axaml.cs
+++ b/samples/DockMdiSample/MainWindow.axaml.cs
@@ -1,0 +1,18 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DockMdiSample;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/samples/DockMdiSample/Program.cs
+++ b/samples/DockMdiSample/Program.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Avalonia;
+using Dock.Model.Avalonia;
+using Dock.Settings;
+
+namespace DockMdiSample;
+
+internal class Program
+{
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        // DockSettings.UseFloatingDockAdorner = true;
+        // DockSettings.EnableGlobalDocking = true;
+
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        GC.KeepAlive(typeof(Factory).Assembly);
+
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+    }
+}

--- a/src/Dock.Avalonia/Controls/MdiHostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/MdiHostWindow.axaml
@@ -1,0 +1,8 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:Dock.Avalonia.Controls">
+  <Style x:Key="{x:Type local:MdiHostWindow}" BasedOn="{StaticResource {x:Type HostWindow}}">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+  </Style>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/MdiHostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/MdiHostWindow.axaml.cs
@@ -1,0 +1,23 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Host window used for MDI style child windows.
+/// </summary>
+public class MdiHostWindow : HostWindow
+{
+    /// <inheritdoc/>
+    protected override Type StyleKeyOverride => typeof(MdiHostWindow);
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="MdiHostWindow"/> class.
+    /// </summary>
+    public MdiHostWindow()
+    {
+        SystemDecorations = SystemDecorations.None;
+        ShowInTaskbar = false;
+    }
+}

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -32,6 +32,7 @@
         <ResourceInclude Source="/Controls/DockControl.axaml" />
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
+        <ResourceInclude Source="/Controls/MdiHostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockWindow.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -32,6 +32,7 @@
         <ResourceInclude Source="/Controls/DockControl.axaml" />
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
+        <ResourceInclude Source="/Controls/MdiHostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockWindow.axaml" />


### PR DESCRIPTION
## Summary
- support MDI child windows with new `MdiHostWindow`
- expose theme resources for `MdiHostWindow`
- add new `DockMdiSample` showing docking with MDI windows defined in XAML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687241874ec48321890f3a5d966a1b01