### PR TITLE
Add dockable closing hooks

### DIFF
--- a/docs/dock-active-document.md
+++ b/docs/dock-active-document.md
@@ -15,3 +15,11 @@ var current = factory.GetCurrentDocument();
 
 The helper `GetCurrentDocument` extension returns the focused document
 for the active root dock or `null` if no document is selected.
+
+```csharp
+// Close whichever dockable currently has focus
+factory.CloseFocusedDockable();
+```
+
+The `CloseFocusedDockable` helper can be used to close the active document or tool
+without manually looking it up.

--- a/docs/dock-events.md
+++ b/docs/dock-events.md
@@ -16,6 +16,7 @@ possible to intercept an operation before it completes.
 | `FocusedDockableChanged` | Triggered when focus moves to another dockable. |
 | `DockableAdded` | Raised after a dockable is inserted into a dock. |
 | `DockableRemoved` | Raised after a dockable has been removed. |
+| `DockableClosing` | Fired before a dockable is closed so it can be cancelled. |
 | `DockableClosed` | Occurs when a dockable is closed via command or UI. |
 | `DockableMoved` | Indicates a dockable was rearranged within its parent. |
 | `DockableDocked` | Raised after a dock operation completes such as splitting or floating. |

--- a/src/Dock.Model/Core/Events/DockableClosingEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableClosingEventArgs.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+
+namespace Dock.Model.Core.Events;
+
+/// <summary>
+/// Dockable closing event args.
+/// </summary>
+public class DockableClosingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets closing dockable.
+    /// </summary>
+    public IDockable? Dockable { get; }
+
+    /// <summary>
+    /// Gets or sets flag indicating whether dockable closing should be canceled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="DockableClosingEventArgs"/> class.
+    /// </summary>
+    /// <param name="dockable">The closing dockable.</param>
+    public DockableClosingEventArgs(IDockable? dockable)
+    {
+        Dockable = dockable;
+    }
+}

--- a/src/Dock.Model/Core/FactoryExtensions.cs
+++ b/src/Dock.Model/Core/FactoryExtensions.cs
@@ -32,4 +32,17 @@ internal static class FactoryExtensions
     {
         return factory.GetActiveRoot()?.FocusedDockable as IDocument;
     }
+
+    /// <summary>
+    /// Closes the dockable that is currently focused across all docks and windows.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    public static void CloseFocusedDockable(this IFactory factory)
+    {
+        var dockable = factory.GetActiveRoot()?.FocusedDockable;
+        if (dockable is { })
+        {
+            factory.CloseDockable(dockable);
+        }
+    }
 }

--- a/src/Dock.Model/Core/IFactory.Events.cs
+++ b/src/Dock.Model/Core/IFactory.Events.cs
@@ -36,6 +36,11 @@ public partial interface IFactory
     event EventHandler<DockableRemovedEventArgs>? DockableRemoved;
 
     /// <summary>
+    /// Dockable closing event handler.
+    /// </summary>
+    event EventHandler<DockableClosingEventArgs>? DockableClosing;
+
+    /// <summary>
     /// Dockable closed event handler.
     /// </summary>
     event EventHandler<DockableClosedEventArgs>? DockableClosed;
@@ -149,6 +154,13 @@ public partial interface IFactory
     /// </summary>
     /// <param name="dockable">The removed dockable.</param>
     void OnDockableRemoved(IDockable? dockable);
+
+    /// <summary>
+    /// Called when the dockable is closing.
+    /// </summary>
+    /// <param name="dockable">The closing dockable.</param>
+    /// <returns>False if closing canceled, otherwise true.</returns>
+    bool OnDockableClosing(IDockable? dockable);
 
     /// <summary>
     /// Called when the dockable has been closed.

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -734,7 +734,7 @@ public abstract partial class FactoryBase
             return;
         }
 
-        if (dockable.CanClose && dockable.OnClose())
+        if (dockable.CanClose && OnDockableClosing(dockable))
         {
             var hide = (dockable is ITool && HideToolsOnClose)
                        || (dockable is IDocument && HideDocumentsOnClose);

--- a/src/Dock.Model/FactoryBase.Events.cs
+++ b/src/Dock.Model/FactoryBase.Events.cs
@@ -27,6 +27,9 @@ public abstract partial class FactoryBase
     public event EventHandler<DockableRemovedEventArgs>? DockableRemoved;
 
     /// <inheritdoc />
+    public event EventHandler<DockableClosingEventArgs>? DockableClosing;
+
+    /// <inheritdoc />
     public event EventHandler<DockableClosedEventArgs>? DockableClosed;
 
     /// <inheritdoc />
@@ -99,6 +102,21 @@ public abstract partial class FactoryBase
     public virtual void OnDockableRemoved(IDockable? dockable)
     {
         DockableRemoved?.Invoke(this, new DockableRemovedEventArgs(dockable));
+    }
+
+    /// <inheritdoc />
+    public virtual bool OnDockableClosing(IDockable? dockable)
+    {
+        var canClose = dockable?.OnClose() ?? true;
+
+        var eventArgs = new DockableClosingEventArgs(dockable)
+        {
+            Cancel = !canClose
+        };
+
+        DockableClosing?.Invoke(this, eventArgs);
+
+        return !eventArgs.Cancel;
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
- expose `DockableClosing` event and `OnDockableClosing` method
- add `DockableClosingEventArgs`
- call closing hooks from `CloseDockable`
- add `CloseFocusedDockable` layout helper
- document new event and helper

## Testing
- `dotnet test Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -c Release --no-build --verbosity minimal` *(fails: No test is available)*

------
https://chatgpt.com/codex/tasks/task_e_6872440b90c0832184af7db423f89d22