### PR TITLE
Add pointer input doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Custom themes](dock-custom-theme.md) – Build and apply your own theme.
 - [Context menus](dock-context-menus.md) – Localize or replace built in menus.
 - [Control recycling](dock-control-recycling.md) – Reuse visuals when dockables return.
+- [Pointer input](dock-pointer-input.md) – Use mouse, touch or pen to interact with docking windows.
 - [Proportional StackPanel](dock-proportional-stackpanel.md) – Layout panel with adjustable proportions.
 - [Sizing guide](dock-sizing.md) – Control pixel sizes and fixed dimensions.
 - [Floating windows](dock-windows.md) – Detach dockables into separate windows.

--- a/docs/dock-pointer-input.md
+++ b/docs/dock-pointer-input.md
@@ -1,0 +1,9 @@
+# Pointer Input
+
+Dock uses Avalonia's pointer events which unify all pointer devices. This means mouse clicks, touch gestures and pen presses all invoke the same drag logic. No additional configuration is required.
+
+Any pointer can drag tabs, resize docks or reposition floating windows. Features such as `EnableWindowDrag` or global docking work the same whether the user is using a mouse, touch screen or stylus.
+
+Use the standard Avalonia `PointerPressed`, `PointerMoved` and `PointerReleased` events when extending Dock. These events automatically report the pointer type if you need to provide device-specific feedback.
+
+For more details on floating windows see [Floating Windows](dock-windows.md) and [Enable Window Drag](dock-window-drag.md).


### PR DESCRIPTION
## Summary
- document pointer input support for Dock
- reference the new guide from the docs index

## Testing
- `./build.sh --target Test --skip Restore` *(fails: av-build-tel-api-v1.avaloniaui.net blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687244929ae083218a4c230b619b7984