### PR TITLE
Add localization guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Styling and theming](dock-styling.md) – Customize the appearance of Dock controls.
 - [Custom themes](dock-custom-theme.md) – Build and apply your own theme.
 - [Context menus](dock-context-menus.md) – Localize or replace built in menus.
+- [Localization](dock-localization.md) – Customize Dock text strings.
 - [Control recycling](dock-control-recycling.md) – Reuse visuals when dockables return.
 - [Proportional StackPanel](dock-proportional-stackpanel.md) – Layout panel with adjustable proportions.
 - [Sizing guide](dock-sizing.md) – Control pixel sizes and fixed dimensions.

--- a/docs/dock-localization.md
+++ b/docs/dock-localization.md
@@ -1,0 +1,24 @@
+# Localization and string resources
+
+Dock controls use dynamic resources for menu text and other UI labels. All text properties are decorated with localization attributes so the values can be translated.
+The default strings ship in `ControlStrings.axaml` under the `Dock.Avalonia` assembly.
+
+## Overriding strings
+
+Override any built in string by adding a resource dictionary with the same keys in your application:
+
+```xaml
+<Application.Resources>
+    <ResourceDictionary>
+        <ResourceInclude Source="avares://Dock.Avalonia/Controls/ControlStrings.axaml" />
+        <x:String x:Key="ToolTabStripItemCloseString">Schließen</x:String>
+        <x:String x:Key="DocumentTabStripItemCloseAllTabsString">Alle Tabs schließen</x:String>
+    </ResourceDictionary>
+</Application.Resources>
+```
+
+Avalonia resolves dynamic resources from the application scope first so your values override the defaults.
+
+## See also
+
+- [Context menus](dock-context-menus.md) – Customize or replace built in menus.


### PR DESCRIPTION
## Summary
- document how to override built-in string resources
- link new guide from the documentation index

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687244a659888321841e41f9549f1e07