### PR TITLE
Add cancellable dock operations

### DIFF
--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -96,11 +96,10 @@ new ToolDock
 
 **Can I cancel switching the active dockable or closing a dock?**
 
-Dock currently raises `ActiveDockableChanged` only *after* the active dockable
-has been updated, so the change cannot be cancelled. Likewise there is no
-pre-close event for dockables. The only cancellable closing hook is
-`WindowClosing`, which is fired when a host window is about to close. Set the
-`Cancel` property on the event arguments to keep the window open:
+Use the `ActiveDockableChanging` event to intercept focus changes and
+`DockableClosing` to intercept closing a dockable. Set the `Cancel` property on
+the event arguments to abort the operation. The `WindowClosing` event is still
+fired when a host window is about to close:
 
 ```csharp
 factory.WindowClosing += (_, args) =>
@@ -112,7 +111,7 @@ factory.WindowClosing += (_, args) =>
 };
 ```
 
-Cancelling individual dockables is not supported.
+Both operations are cancellable.
 
 **How do I disable undocking or drag-and-drop?**
 

--- a/src/Dock.Model/Core/Events/ActiveDockableChangingEventArgs.cs
+++ b/src/Dock.Model/Core/Events/ActiveDockableChangingEventArgs.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Dock.Model.Core.Events;
+
+/// <summary>
+/// Active dockable changing event args.
+/// </summary>
+public class ActiveDockableChangingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets dockable that is about to become active.
+    /// </summary>
+    public IDockable? Dockable { get; }
+
+    /// <summary>
+    /// Gets or sets flag indicating whether active dockable change should be canceled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="ActiveDockableChangingEventArgs"/> class.
+    /// </summary>
+    /// <param name="dockable">The dockable that will become active.</param>
+    public ActiveDockableChangingEventArgs(IDockable? dockable)
+    {
+        Dockable = dockable;
+    }
+}

--- a/src/Dock.Model/Core/Events/DockableClosingEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableClosingEventArgs.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Dock.Model.Core.Events;
+
+/// <summary>
+/// Dockable closing event args.
+/// </summary>
+public class DockableClosingEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets closing dockable.
+    /// </summary>
+    public IDockable? Dockable { get; }
+
+    /// <summary>
+    /// Gets or sets flag indicating whether dockable closing should be canceled.
+    /// </summary>
+    public bool Cancel { get; set; }
+
+    /// <summary>
+    /// Initializes new instance of the <see cref="DockableClosingEventArgs"/> class.
+    /// </summary>
+    /// <param name="dockable">The closing dockable.</param>
+    public DockableClosingEventArgs(IDockable? dockable)
+    {
+        Dockable = dockable;
+    }
+}

--- a/src/Dock.Model/Core/IFactory.Events.cs
+++ b/src/Dock.Model/Core/IFactory.Events.cs
@@ -16,6 +16,11 @@ public partial interface IFactory
     event EventHandler<ActiveDockableChangedEventArgs>? ActiveDockableChanged;
 
     /// <summary>
+    /// Active dockable changing event handler.
+    /// </summary>
+    event EventHandler<ActiveDockableChangingEventArgs>? ActiveDockableChanging;
+
+    /// <summary>
     /// Focused dockable changed event handler.
     /// </summary>
     event EventHandler<FocusedDockableChangedEventArgs>? FocusedDockableChanged;
@@ -39,6 +44,11 @@ public partial interface IFactory
     /// Dockable closed event handler.
     /// </summary>
     event EventHandler<DockableClosedEventArgs>? DockableClosed;
+
+    /// <summary>
+    /// Dockable closing event handler.
+    /// </summary>
+    event EventHandler<DockableClosingEventArgs>? DockableClosing;
 
     /// <summary>
     /// Dockable moved event handler.
@@ -127,6 +137,13 @@ public partial interface IFactory
     void OnActiveDockableChanged(IDockable? dockable);
 
     /// <summary>
+    /// Called when the active dockable is about to change.
+    /// </summary>
+    /// <param name="dockable">The dockable that will become active.</param>
+    /// <returns>False if changing canceled, otherwise true.</returns>
+    bool OnActiveDockableChanging(IDockable? dockable);
+
+    /// <summary>
     /// Called when the focused dockable changed.
     /// </summary>
     /// <param name="dockable">The focused dockable.</param>
@@ -155,6 +172,13 @@ public partial interface IFactory
     /// </summary>
     /// <param name="dockable">The closed dockable.</param>
     void OnDockableClosed(IDockable? dockable);
+
+    /// <summary>
+    /// Called when the dockable is closing.
+    /// </summary>
+    /// <param name="dockable">The closing dockable.</param>
+    /// <returns>False if closing canceled, otherwise true.</returns>
+    bool OnDockableClosing(IDockable? dockable);
 
     /// <summary>
     /// Called when the dockable has been moved.

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -57,7 +57,15 @@ public abstract partial class FactoryBase
         if (dock.VisibleDockables.Count > 0)
         {
             var nextActiveDockable = dock.VisibleDockables[indexActiveDockable];
-            dock.ActiveDockable = nextActiveDockable is not IProportionalDockSplitter ? nextActiveDockable : null;
+            var candidate = nextActiveDockable is not IProportionalDockSplitter ? nextActiveDockable : null;
+            if (candidate is not null)
+            {
+                SetActiveDockable(candidate);
+            }
+            else
+            {
+                dock.ActiveDockable = null;
+            }
         }
         else
         {
@@ -113,7 +121,7 @@ public abstract partial class FactoryBase
             OnDockableAdded(sourceDockable);
             OnDockableMoved(sourceDockable);
             OnDockableDocked(sourceDockable, DockOperation.Fill);
-            dock.ActiveDockable = sourceDockable;
+            SetActiveDockable(sourceDockable);
         }
     }
 
@@ -215,7 +223,7 @@ public abstract partial class FactoryBase
                 OnDockableMoved(sourceDockable);
                 OnDockableDocked(sourceDockable, DockOperation.Fill);
                 InitDockable(sourceDockable, targetDock);
-                targetDock.ActiveDockable = sourceDockable;
+                SetActiveDockable(sourceDockable);
             }
         }
     }
@@ -243,7 +251,7 @@ public abstract partial class FactoryBase
             OnDockableAdded(originalTargetDockable);
             OnDockableSwapped(originalSourceDockable);
             OnDockableSwapped(originalTargetDockable);
-            dock.ActiveDockable = originalTargetDockable;
+            SetActiveDockable(originalTargetDockable);
         }
     }
 
@@ -271,8 +279,8 @@ public abstract partial class FactoryBase
             OnDockableSwapped(originalTargetDockable);
             OnDockableSwapped(originalSourceDockable);
 
-            sourceDock.ActiveDockable = originalTargetDockable;
-            targetDock.ActiveDockable = originalSourceDockable;
+            SetActiveDockable(originalTargetDockable);
+            SetActiveDockable(originalSourceDockable);
         }
     }
 
@@ -679,7 +687,7 @@ public abstract partial class FactoryBase
             RemoveDockable(d, dock.IsCollapsable);
             AddDockable(targetDock, d);
             OnDockableMoved(d);
-            targetDock.ActiveDockable = d;
+            SetActiveDockable(d);
         }
 
         var window = CreateWindowFrom(targetDock);
@@ -734,7 +742,7 @@ public abstract partial class FactoryBase
             return;
         }
 
-        if (dockable.CanClose && dockable.OnClose())
+        if (dockable.CanClose && OnDockableClosing(dockable))
         {
             var hide = (dockable is ITool && HideToolsOnClose)
                        || (dockable is IDocument && HideDocumentsOnClose);

--- a/src/Dock.Model/FactoryBase.Events.cs
+++ b/src/Dock.Model/FactoryBase.Events.cs
@@ -15,6 +15,9 @@ public abstract partial class FactoryBase
     public event EventHandler<ActiveDockableChangedEventArgs>? ActiveDockableChanged;
 
     /// <inheritdoc />
+    public event EventHandler<ActiveDockableChangingEventArgs>? ActiveDockableChanging;
+
+    /// <inheritdoc />
     public event EventHandler<FocusedDockableChangedEventArgs>? FocusedDockableChanged;
 
     /// <inheritdoc />
@@ -28,6 +31,9 @@ public abstract partial class FactoryBase
 
     /// <inheritdoc />
     public event EventHandler<DockableClosedEventArgs>? DockableClosed;
+
+    /// <inheritdoc />
+    public event EventHandler<DockableClosingEventArgs>? DockableClosing;
 
     /// <inheritdoc />
     public event EventHandler<DockableMovedEventArgs>? DockableMoved;
@@ -78,6 +84,14 @@ public abstract partial class FactoryBase
     public event EventHandler<WindowMoveDragEndEventArgs>? WindowMoveDragEnd;
 
     /// <inheritdoc />
+    public virtual bool OnActiveDockableChanging(IDockable? dockable)
+    {
+        var eventArgs = new ActiveDockableChangingEventArgs(dockable);
+        ActiveDockableChanging?.Invoke(this, eventArgs);
+        return !eventArgs.Cancel;
+    }
+
+    /// <inheritdoc />
     public virtual void OnActiveDockableChanged(IDockable? dockable)
     {
         ActiveDockableChanged?.Invoke(this, new ActiveDockableChangedEventArgs(dockable));
@@ -99,6 +113,21 @@ public abstract partial class FactoryBase
     public virtual void OnDockableRemoved(IDockable? dockable)
     {
         DockableRemoved?.Invoke(this, new DockableRemovedEventArgs(dockable));
+    }
+
+    /// <inheritdoc />
+    public virtual bool OnDockableClosing(IDockable? dockable)
+    {
+        var canClose = dockable?.OnClose() ?? true;
+
+        var eventArgs = new DockableClosingEventArgs(dockable)
+        {
+            Cancel = !canClose
+        };
+
+        DockableClosing?.Invoke(this, eventArgs);
+
+        return !eventArgs.Cancel;
     }
 
     /// <inheritdoc />

--- a/src/Dock.Model/FactoryBase.Init.cs
+++ b/src/Dock.Model/FactoryBase.Init.cs
@@ -21,7 +21,7 @@ public abstract partial class FactoryBase
         {
             if (dock.DefaultDockable is not null)
             {
-                dock.ActiveDockable = dock.DefaultDockable;
+                SetActiveDockable(dock.DefaultDockable);
             }
         }
 
@@ -147,7 +147,10 @@ public abstract partial class FactoryBase
     {
         if (dockable.Owner is IDock dock)
         {
-            dock.ActiveDockable = dockable;
+            if (OnActiveDockableChanging(dockable))
+            {
+                dock.ActiveDockable = dockable;
+            }
         }
     }
 

--- a/src/Dock.Model/FactoryBase.cs
+++ b/src/Dock.Model/FactoryBase.cs
@@ -129,7 +129,7 @@ public abstract partial class FactoryBase : IFactory
             {
                 AddVisibleDockable(split, dockable);
                 OnDockableAdded(dockable);
-                split.ActiveDockable = dockable;
+                SetActiveDockable(dockable);
             }
         }
 
@@ -169,7 +169,7 @@ public abstract partial class FactoryBase : IFactory
                 {
                     AddVisibleDockable(layout, split);
                     OnDockableAdded(split);
-                    layout.ActiveDockable = split;
+                    SetActiveDockable(split);
                 }
 
                 break;
@@ -181,7 +181,7 @@ public abstract partial class FactoryBase : IFactory
                 {
                     AddVisibleDockable(layout, dock);
                     OnDockableAdded(dock);
-                    layout.ActiveDockable = dock;
+                    SetActiveDockable(dock);
                 }
 
                 break;
@@ -200,7 +200,7 @@ public abstract partial class FactoryBase : IFactory
                 {
                     AddVisibleDockable(layout, dock);
                     OnDockableAdded(dock);
-                    layout.ActiveDockable = dock;
+                    SetActiveDockable(dock);
                 }
 
                 break;
@@ -212,7 +212,7 @@ public abstract partial class FactoryBase : IFactory
                 {
                     AddVisibleDockable(layout, split);
                     OnDockableAdded(split);
-                    layout.ActiveDockable = split;
+                    SetActiveDockable(split);
                 }
 
                 break;
@@ -244,7 +244,7 @@ public abstract partial class FactoryBase : IFactory
                         InsertVisibleDockable(ownerDock, index, layout);
                         OnDockableAdded(dockable);
                         InitDockable(layout, ownerDock);
-                        ownerDock.ActiveDockable = layout;
+                        SetActiveDockable(layout);
                         OnDockableDocked(dockable, operation);
                     }
                 }
@@ -273,7 +273,7 @@ public abstract partial class FactoryBase : IFactory
                     {
                         AddVisibleDockable(dock, dockable);
                         OnDockableAdded(dockable);
-                        dock.ActiveDockable = dockable;
+                        SetActiveDockable(dockable);
                     }
                 }
                 break;
@@ -305,7 +305,7 @@ public abstract partial class FactoryBase : IFactory
                     {
                         AddVisibleDockable(dock, dockable);
                         OnDockableAdded(dockable);
-                        dock.ActiveDockable = dockable;
+                        SetActiveDockable(dockable);
                     }
                 }
                 break;


### PR DESCRIPTION
## Summary
- add `ActiveDockableChanging` and `DockableClosing` events
- implement `OnActiveDockableChanging` and `OnDockableClosing`
- update factory methods to use the new events
- document new cancellable operations

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687243b8e0b88321840eb302751a5e22