### PR TITLE
Enable runtime customizable context menus

### DIFF
--- a/docs/dock-context-menus.md
+++ b/docs/dock-context-menus.md
@@ -48,7 +48,13 @@ This approach allows you to customize the menu structure or attach your own comm
 
 ## Extensibility analysis
 
-The current design relies on static resources. Replacing or localizing items is straightforward by overriding resource keys, but adding items dynamically requires providing a completely new menu. There are no hooks to inject menu items at runtime.
+Prior to version 0.9 Dock relied on static resources. Replacing or localizing items was straightforward by overriding resource keys, but adding entries at runtime meant providing a completely new menu. Version 0.9 introduces a `ContextMenuManager` service which loads the built-in menus and allows registering providers or customizers at runtime:
 
-If extensibility is important for your application, consider wrapping the default menus in your own `ContextMenu` definitions so you can append items in XAML. Alternatively you could fork the resource dictionaries and modify them to expose extension points via data templates or bindings.
+```csharp
+ContextMenuManager.RegisterCustomizer(
+    "ToolPinItemControlContextMenu",
+    menu => menu.Items.Add(new MenuItem { Header = "My Command", Command = ... }));
+```
+
+Controls now use the `MenuExtension` markup extension to resolve their menus via `ContextMenuManager`, making it possible to inject additional items without modifying the XAML resources.
 

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:menus="using:Dock.Avalonia.Menus"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -188,7 +189,7 @@
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   Padding="{TemplateBinding Padding}"
-                  ContextMenu="{DynamicResource DocumentTabStripItemContextMenu}">
+                  ContextMenu="{menus:Menu DocumentTabStripItemContextMenu}">
             <DockableControl TrackingMode="Tab">
               <StackPanel Background="Transparent"
                           Orientation="Horizontal"

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -4,6 +4,7 @@
                     xmlns:controls="using:Dock.Model.Controls"
                     x:DataType="controls:IToolDock"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:menus="using:Dock.Avalonia.Menus"
                     x:CompileBindings="True">
   <Design.PreviewWith>
   <ToolChromeControl Width="300" Height="400" />
@@ -97,7 +98,7 @@
           <Border x:Name="PART_Border"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   VerticalAlignment="Top"
-                  ContextFlyout="{DynamicResource ToolChromeControlContextMenu}"
+                  ContextFlyout="{menus:Menu ToolChromeControlContextMenu}"
                   Grid.Row="{Binding GripMode, Converter={x:Static GripModeConverters.GridRowAutoHideConverter}}">
             <Grid x:Name="PART_Grip">
               <DockPanel LastChildFill="True" Margin="8 0">
@@ -108,7 +109,7 @@
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                   <Button x:Name="PART_MenuButton"
                           Theme="{StaticResource ChromeButton}"
-                          Flyout="{StaticResource ToolChromeControlContextMenu}">
+                          Flyout="{menus:Menu ToolChromeControlContextMenu}">
                     <Viewbox Margin="2">
                       <Path x:Name="PART_MenuPath" />
                     </Viewbox>

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:menus="using:Dock.Avalonia.Menus"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -65,7 +66,7 @@
               <TextBlock Text="{Binding Title}"
                          VerticalAlignment="Center"
                          HorizontalAlignment="Left"
-                         ContextMenu="{DynamicResource ToolPinItemControlContextMenu}">
+                         ContextMenu="{menus:Menu ToolPinItemControlContextMenu}">
               </TextBlock>
             </Button>
           </LayoutTransformControl>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:menus="using:Dock.Avalonia.Menus"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -105,7 +106,7 @@
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
                   Padding="{TemplateBinding Padding}"
-                  ContextMenu="{DynamicResource ToolTabStripItemContextMenu}">
+                  ContextMenu="{menus:Menu ToolTabStripItemContextMenu}">
             <DockableControl TrackingMode="Tab">
               <StackPanel x:Name="DragTool"
                           Background="Transparent"

--- a/src/Dock.Avalonia/Menus/ContextMenuManager.cs
+++ b/src/Dock.Avalonia/Menus/ContextMenuManager.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+
+namespace Dock.Avalonia.Menus;
+
+/// <summary>
+/// Provides runtime access to Dock context menus.
+/// </summary>
+public static class ContextMenuManager
+{
+    /// <summary>
+    /// Gets or sets the default menu provider used when no custom provider is registered.
+    /// </summary>
+    public static Func<string, ContextMenu?> DefaultProvider { get; set; } = key =>
+        Application.Current?.FindResource(key) as ContextMenu;
+
+    private static readonly Dictionary<string, Func<ContextMenu?>> _providers = new();
+    private static readonly Dictionary<string, Action<ContextMenu>> _customizers = new();
+
+    /// <summary>
+    /// Registers a custom provider for a menu key.
+    /// </summary>
+    public static void RegisterProvider(string key, Func<ContextMenu?> provider)
+    {
+        _providers[key] = provider;
+    }
+
+    /// <summary>
+    /// Registers a customizer that can modify the menu before it is displayed.
+    /// </summary>
+    public static void RegisterCustomizer(string key, Action<ContextMenu> customizer)
+    {
+        if (_customizers.TryGetValue(key, out var existing))
+        {
+            _customizers[key] = existing + customizer;
+        }
+        else
+        {
+            _customizers[key] = customizer;
+        }
+    }
+
+    /// <summary>
+    /// Gets a menu instance for the specified key.
+    /// </summary>
+    public static ContextMenu? GetMenu(string key)
+    {
+        ContextMenu? menu;
+        if (_providers.TryGetValue(key, out var provider))
+        {
+            menu = provider();
+        }
+        else
+        {
+            menu = DefaultProvider(key);
+        }
+
+        if (menu != null && _customizers.TryGetValue(key, out var customize))
+        {
+            customize(menu);
+        }
+
+        return menu;
+    }
+}
+

--- a/src/Dock.Avalonia/Menus/MenuExtension.cs
+++ b/src/Dock.Avalonia/Menus/MenuExtension.cs
@@ -1,0 +1,42 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Menus;
+
+/// <summary>
+/// Markup extension that resolves context menus through <see cref="ContextMenuManager"/>.
+/// </summary>
+public class MenuExtension
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MenuExtension"/> class.
+    /// </summary>
+    public MenuExtension()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MenuExtension"/> class.
+    /// </summary>
+    /// <param name="key">The menu key.</param>
+    public MenuExtension(string key)
+    {
+        Key = key;
+    }
+
+    /// <summary>
+    /// Gets or sets the menu key.
+    /// </summary>
+    [ConstructorArgument("key")]
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Provides the context menu instance.
+    /// </summary>
+    public object? ProvideValue(IServiceProvider serviceProvider)
+    {
+        return Key is null ? null : ContextMenuManager.GetMenu(Key);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ContextMenuManager` and `MenuExtension` for runtime menu creation
- replace static menu lookups with `MenuExtension`
- document new dynamic context menu feature

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687243cabc688321879148a8af12b22a