### PR TITLE
Add helper extensions for easier Dock API

### DIFF
--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -121,6 +121,7 @@ public override IRootDock CreateLayout()
 - `MoveDockable` and `SwapDockable` for rearranging items.
 - `PinDockable`/`UnpinDockable` to keep tools in the pinned area.
 - `FloatDockable` to open a dockable in a separate window.
+- Helpers like `AddAndActivate` or `CloseActiveDockable` for common tasks.
 - Commands such as `CloseDockable`, `CloseOtherDockables` or `CloseAllDockables`.
 
 ```csharp

--- a/src/Dock.Model/Core/FactoryUserExtensions.cs
+++ b/src/Dock.Model/Core/FactoryUserExtensions.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Core;
+
+/// <summary>
+/// User friendly helper methods for <see cref="IFactory"/>.
+/// </summary>
+public static class FactoryUserExtensions
+{
+    /// <summary>
+    /// Adds a dockable to the dock and activates it.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <param name="dock">The dock to add to.</param>
+    /// <param name="dockable">The dockable to add.</param>
+    public static void AddAndActivate(this IFactory factory, IDock dock, IDockable dockable)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (dock == null) throw new ArgumentNullException(nameof(dock));
+        if (dockable == null) throw new ArgumentNullException(nameof(dockable));
+
+        factory.AddDockable(dock, dockable);
+        factory.SetActiveDockable(dockable);
+        factory.SetFocusedDockable(dock, dockable);
+    }
+
+    /// <summary>
+    /// Closes the currently active dockable of the given dock.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <param name="dock">The dock whose active dockable should be closed.</param>
+    public static void CloseActiveDockable(this IFactory factory, IDock dock)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (dock == null) throw new ArgumentNullException(nameof(dock));
+
+        if (dock.ActiveDockable is { } active)
+        {
+            factory.CloseDockable(active);
+        }
+    }
+
+    /// <summary>
+    /// Floats the dockable into a new window and returns the created window.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <param name="dockable">The dockable to float.</param>
+    /// <returns>The window hosting the dockable or null.</returns>
+    public static IDockWindow? FloatDockableWindow(this IFactory factory, IDockable dockable)
+    {
+        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (dockable == null) throw new ArgumentNullException(nameof(dockable));
+
+        factory.FloatDockable(dockable);
+        var root = factory.FindRoot(dockable);
+        return root?.Window;
+    }
+}


### PR DESCRIPTION
## Summary
- add `FactoryUserExtensions` with helper methods for common operations
- document these helpers in the MVVM guide

## Testing
- `dotnet build src/Dock.Model/Dock.Model.csproj -c Release -f net6.0`
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687246619f948321aabf792aef8d044a