### PR TITLE
Document initial dock location preferences

### DIFF
--- a/docs/dock-dockable-properties.md
+++ b/docs/dock-dockable-properties.md
@@ -24,6 +24,7 @@ Dockable items such as documents, tools and docks implement the `IDockable` inte
 | `CanFloat` | Controls if the item may be detached into a floating window. |
 | `CanDrag` | Enables dragging the dockable to another position. |
 | `CanDrop` | Determines if other dockables can be dropped onto this one. |
+| `Dock` | Preferred location for the dockable when it first opens. |
 
 ## Sample usage
 

--- a/docs/dock-windows.md
+++ b/docs/dock-windows.md
@@ -17,6 +17,14 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
 
 Calling `FloatDockable` on the factory opens a dockable in a new window. The returned `IDockWindow` stores its bounds and title and can be serialized together with the layout.
 
+## Choosing the starting dock
+
+Dockables may declare a preferred side when they are first shown. Assign one of the
+`DockMode` values to the `Dock` property on your view model to request docking on the
+left, right, top, bottom or center. When a window is docked without an explicit
+operation this value guides the placement. Tools further refine the position of auto
+hide panels through the `Alignment` property on their containing `ToolDock`.
+
 ## Window chrome options
 
 `HostWindow` provides two boolean properties that control how its chrome behaves:


### PR DESCRIPTION
## Summary
- document Dock property for view model initial location
- explain choosing starting dock when opening floating windows

## Testing
- `./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872483fb420832182dc3fb8f55e6a04