### PR TITLE
Enable per-tab tinting

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:dps="using:Dock.Settings"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -172,7 +173,11 @@
     <Setter Property="FontWeight" Value="Normal" />
     <Setter Property="MinHeight" Value="24" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background">
+      <Setter.Value>
+        <Binding Path="(dps:DockProperties.TabBrush)" RelativeSource="Self" TargetNullValue="Transparent" />
+      </Setter.Value>
+    </Setter>
     <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DockThemeBorderLowBrush}" />
     <Setter Property="BorderThickness" Value="0" />

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -2,6 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:dps="using:Dock.Settings"
                     x:DataType="core:IDockable"
                     x:CompileBindings="True">
   <Design.PreviewWith>
@@ -89,7 +90,11 @@
     <Setter Property="FontWeight" Value="Normal" />
     <Setter Property="MinHeight" Value="0" />
     <Setter Property="VerticalContentAlignment" Value="Center" />
-    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Background">
+      <Setter.Value>
+        <Binding Path="(dps:DockProperties.TabBrush)" RelativeSource="Self" TargetNullValue="Transparent" />
+      </Setter.Value>
+    </Setter>
     <Setter Property="Foreground" Value="{DynamicResource DockThemeForegroundBrush}" />
     <Setter Property="BorderBrush" Value="{DynamicResource DockThemeBorderLowBrush}" />
     <Setter Property="BorderThickness" Value="0 1 0 0" />

--- a/src/Dock.Settings/DockProperties.cs
+++ b/src/Dock.Settings/DockProperties.cs
@@ -3,6 +3,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
+using Avalonia.Media;
 
 namespace Dock.Settings;
 
@@ -65,6 +66,13 @@ public class DockProperties : AvaloniaObject
     /// </summary>
     public static readonly AttachedProperty<Control?> DockAdornerHostProperty =
         AvaloniaProperty.RegisterAttached<DockProperties, Control, Control?>("DockAdornerHost", null, false, BindingMode.TwoWay);
+
+    /// <summary>
+    /// Defines the TabBrush attached property used to tint dock tabs.
+    /// </summary>
+    public static readonly StyledProperty<IBrush?> TabBrushProperty =
+        AvaloniaProperty.RegisterAttached<DockProperties, Control, IBrush?>(
+            "TabBrush", null, false, BindingMode.TwoWay);
 
     /// <summary>
     /// Gets the value of the IsDockTarget attached property on the specified control.
@@ -224,5 +232,25 @@ public class DockProperties : AvaloniaObject
     public static void SetDockAdornerHost(AvaloniaObject control, Control? value)
     {
         control.SetValue(DockAdornerHostProperty, value);
+    }
+
+    /// <summary>
+    /// Gets the value of the TabBrush attached property on the specified control.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <returns>The TabBrush attached property.</returns>
+    public static IBrush? GetTabBrush(AvaloniaObject control)
+    {
+        return control.GetValue(TabBrushProperty);
+    }
+
+    /// <summary>
+    /// Sets the value of the TabBrush attached property on the specified control.
+    /// </summary>
+    /// <param name="control">The control.</param>
+    /// <param name="value">The brush value.</param>
+    public static void SetTabBrush(AvaloniaObject control, IBrush? value)
+    {
+        control.SetValue(TabBrushProperty, value);
     }
 }


### PR DESCRIPTION
## Summary
- add `TabBrush` attached property to `DockProperties`
- bind `TabBrush` in `DocumentTabStripItem` and `ToolTabStripItem`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6872488fb5508321b6e40831728f1af6