### PR TITLE
Add fade-in animation for document content

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using System;
+using Avalonia.Styling;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -44,7 +45,7 @@ public class DocumentContentControl : TemplatedControl
                 }
             }
         };
-        _ = animation.RunAsync(this, null);
+        _ = animation.RunAsync(this);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using System;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -20,6 +23,28 @@ public class DocumentContentControl : TemplatedControl
         {
             factory.DocumentControls[dockable] = this;
         }
+
+        // Fade the content in when it is attached to the visual tree
+        Opacity = 0;
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(200),
+            Easing = new CubicEaseOut(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters = { new Setter(OpacityProperty, 0d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters = { new Setter(OpacityProperty, 1d) }
+                }
+            }
+        };
+        _ = animation.RunAsync(this, null);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/PinnedDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/PinnedDockControl.axaml.cs
@@ -180,6 +180,7 @@ public class PinnedDockControl : TemplatedControl
                     _ownerWindow.AddHandler(PointerPressedEvent, OwnerWindow_PointerPressed, RoutingStrategies.Tunnel);
                     _ownerWindow.Deactivated += OwnerWindow_Deactivated;
                     _window.Show(owner);
+                    _ = _window.FadeInAsync();
                 }
             }
 
@@ -206,7 +207,7 @@ public class PinnedDockControl : TemplatedControl
     {
         if (_window is not null)
         {
-            _window.Close();
+            _ = _window.FadeOutAndCloseAsync();
             _window = null;
         }
 

--- a/src/Dock.Avalonia/Controls/PinnedDockWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/PinnedDockWindow.axaml.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -11,4 +15,58 @@ public class PinnedDockWindow : Window
 {
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(PinnedDockWindow);
+
+    /// <summary>
+    /// Play a fade-in animation when the window is shown.
+    /// </summary>
+    public async Task FadeInAsync()
+    {
+        Opacity = 0;
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(200),
+            Easing = new CubicEaseOut(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters = { new Setter(OpacityProperty, 0d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters = { new Setter(OpacityProperty, 1d) }
+                }
+            }
+        };
+        await animation.RunAsync(this, null);
+    }
+
+    /// <summary>
+    /// Fade the window out and close it.
+    /// </summary>
+    public async Task FadeOutAndCloseAsync()
+    {
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(200),
+            Easing = new CubicEaseOut(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters = { new Setter(OpacityProperty, 1d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters = { new Setter(OpacityProperty, 0d) }
+                }
+            }
+        };
+        await animation.RunAsync(this, null);
+        Close();
+    }
 }

--- a/src/Dock.Avalonia/Controls/PinnedDockWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/PinnedDockWindow.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
+using Avalonia.Styling;
 
 namespace Dock.Avalonia.Controls;
 
@@ -40,7 +41,7 @@ public class PinnedDockWindow : Window
                 }
             }
         };
-        await animation.RunAsync(this, null);
+        await animation.RunAsync(this);
     }
 
     /// <summary>
@@ -66,7 +67,7 @@ public class PinnedDockWindow : Window
                 }
             }
         };
-        await animation.RunAsync(this, null);
+        await animation.RunAsync(this);
         Close();
     }
 }

--- a/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using System;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -20,6 +23,28 @@ public class ToolContentControl : TemplatedControl
         {
             factory.ToolControls[dockable] = this;
         }
+
+        // Fade the tool content in when it attaches to the visual tree
+        Opacity = 0;
+        var animation = new Animation
+        {
+            Duration = TimeSpan.FromMilliseconds(200),
+            Easing = new CubicEaseOut(),
+            Children =
+            {
+                new KeyFrame
+                {
+                    Cue = new Cue(0d),
+                    Setters = { new Setter(OpacityProperty, 0d) }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1d),
+                    Setters = { new Setter(OpacityProperty, 1d) }
+                }
+            }
+        };
+        _ = animation.RunAsync(this, null);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using System;
+using Avalonia.Styling;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -44,7 +45,7 @@ public class ToolContentControl : TemplatedControl
                 }
             }
         };
-        _ = animation.RunAsync(this, null);
+        _ = animation.RunAsync(this);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary
- add fade-in animation when a `DocumentContentControl` enters the visual tree

## Testing
- `dotnet build -c Release` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872486e89088321945d362a32b289c9