### PR TITLE
Add global options for window drag and chrome

### DIFF
--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -48,6 +48,17 @@ hidden and drags are limited to the originating control.
 
 `DockSettings.UseOwnerForFloatingWindows` keeps floating windows above the main window by setting it as their owner.
 
+## Window drag and chrome
+
+`DockSettings.EnableWindowDrag` toggles whether the document tab strip can be used to drag the host window. The following flags control which buttons appear in the tool chrome and on document tabs:
+
+- `DockSettings.ShowToolOptionsButton`
+- `DockSettings.ShowToolPinButton`
+- `DockSettings.ShowToolCloseButton`
+- `DockSettings.ShowDocumentCloseButton`
+
+All are enabled by default.
+
 ## App builder integration
 
 You can configure the settings when building your Avalonia application:

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -44,8 +44,8 @@ public class DocumentTabStrip : TabStrip
     /// <summary>
     /// Define the <see cref="EnableWindowDrag"/> property.
     /// </summary>
-    public static readonly StyledProperty<bool> EnableWindowDragProperty = 
-        AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(EnableWindowDrag));
+    public static readonly StyledProperty<bool> EnableWindowDragProperty =
+        AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(EnableWindowDrag), global::Dock.Settings.DockSettings.EnableWindowDrag);
 
     /// <summary>
     /// Defines the <see cref="Orientation"/> property.

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -204,6 +204,7 @@
                         CommandParameter="{Binding}">
                   <Button.IsVisible>
                     <MultiBinding Converter="{x:Static BoolConverters.And}">
+                      <TemplateBinding Property="ShowCloseButton" />
                       <Binding Path="CanClose" />
                       <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
                         <Binding Path="((core:IDock)Owner).CanCloseLastDockable" FallbackValue="{x:True}" />

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -19,6 +19,20 @@ namespace Dock.Avalonia.Controls;
 public class DocumentTabStripItem : TabStripItem
 {
     /// <summary>
+    /// Defines the <see cref="ShowCloseButton"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowCloseButtonProperty =
+        AvaloniaProperty.Register<DocumentTabStripItem, bool>(nameof(ShowCloseButton), global::Dock.Settings.DockSettings.ShowDocumentCloseButton);
+
+    /// <summary>
+    /// Gets or sets whether the close button is visible.
+    /// </summary>
+    public bool ShowCloseButton
+    {
+        get => GetValue(ShowCloseButtonProperty);
+        set => SetValue(ShowCloseButtonProperty, value);
+    }
+    /// <summary>
     /// Define the <see cref="IsActive"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> IsActiveProperty =

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -107,6 +107,7 @@
                 </Panel>
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                   <Button x:Name="PART_MenuButton"
+                          IsVisible="{TemplateBinding ShowMenuButton}"
                           Theme="{StaticResource ChromeButton}"
                           Flyout="{StaticResource ToolChromeControlContextMenu}">
                     <Viewbox Margin="2">
@@ -119,6 +120,7 @@
                           Theme="{StaticResource ChromeButton}">
                     <Button.IsVisible>
                       <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <TemplateBinding Property="ShowPinButton" />
                         <Binding Path="ActiveDockable.CanPin" FallbackValue="{x:False}" />
                         <TemplateBinding Property="IsFloating" Converter="{x:Static BoolConverters.Not}" />
                       </MultiBinding>
@@ -140,6 +142,7 @@
                           Theme="{StaticResource ChromeButton}">
                     <Button.IsVisible>
                       <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <TemplateBinding Property="ShowCloseButton" />
                         <Binding Path="ActiveDockable.CanClose" FallbackValue="{x:False}" />
                         <MultiBinding Converter="{x:Static converters:CanRemoveDockableConverter.Instance}">
                           <Binding Path="(core:IDock).CanCloseLastDockable" FallbackValue="{x:True}" />

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -55,6 +55,24 @@ public class ToolChromeControl : ContentControl
         AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(IsMaximized));
 
     /// <summary>
+    /// Defines the <see cref="ShowMenuButton"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowMenuButtonProperty =
+        AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(ShowMenuButton), global::Dock.Settings.DockSettings.ShowToolOptionsButton);
+
+    /// <summary>
+    /// Defines the <see cref="ShowPinButton"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowPinButtonProperty =
+        AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(ShowPinButton), global::Dock.Settings.DockSettings.ShowToolPinButton);
+
+    /// <summary>
+    /// Defines the <see cref="ShowCloseButton"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowCloseButtonProperty =
+        AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(ShowCloseButton), global::Dock.Settings.DockSettings.ShowToolCloseButton);
+
+    /// <summary>
     /// Gets or sets is pinned
     /// </summary>
     public bool IsPinned
@@ -79,6 +97,33 @@ public class ToolChromeControl : ContentControl
     {
         get => GetValue(IsMaximizedProperty);
         set => SetValue(IsMaximizedProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the menu button is visible.
+    /// </summary>
+    public bool ShowMenuButton
+    {
+        get => GetValue(ShowMenuButtonProperty);
+        set => SetValue(ShowMenuButtonProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the pin button is visible.
+    /// </summary>
+    public bool ShowPinButton
+    {
+        get => GetValue(ShowPinButtonProperty);
+        set => SetValue(ShowPinButtonProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether the close button is visible.
+    /// </summary>
+    public bool ShowCloseButton
+    {
+        get => GetValue(ShowCloseButtonProperty);
+        set => SetValue(ShowCloseButtonProperty, value);
     }
 
     /// <summary>

--- a/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
@@ -34,7 +34,7 @@ public class DocumentDock : DockBase, IDocumentDock, IDocumentDockContent
     /// Defines the <see cref="EnableWindowDrag"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> EnableWindowDragProperty =
-        AvaloniaProperty.Register<DocumentDock, bool>(nameof(EnableWindowDrag));
+        AvaloniaProperty.Register<DocumentDock, bool>(nameof(EnableWindowDrag), global::Dock.Settings.DockSettings.EnableWindowDrag);
 
     /// <summary>
     /// Defines the <see cref="TabsLayout"/> property.

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -55,6 +55,31 @@ public static class AppBuilderExtensions
             DockSettings.UseOwnerForFloatingWindows = options.UseOwnerForFloatingWindows.Value;
         }
 
+        if (options.EnableWindowDrag != null)
+        {
+            DockSettings.EnableWindowDrag = options.EnableWindowDrag.Value;
+        }
+
+        if (options.ShowToolOptionsButton != null)
+        {
+            DockSettings.ShowToolOptionsButton = options.ShowToolOptionsButton.Value;
+        }
+
+        if (options.ShowToolPinButton != null)
+        {
+            DockSettings.ShowToolPinButton = options.ShowToolPinButton.Value;
+        }
+
+        if (options.ShowToolCloseButton != null)
+        {
+            DockSettings.ShowToolCloseButton = options.ShowToolCloseButton.Value;
+        }
+
+        if (options.ShowDocumentCloseButton != null)
+        {
+            DockSettings.ShowDocumentCloseButton = options.ShowDocumentCloseButton.Value;
+        }
+
         return builder;
     }
 
@@ -111,6 +136,61 @@ public static class AppBuilderExtensions
         bool enable = true)
     {
         DockSettings.UseOwnerForFloatingWindows = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.EnableWindowDrag"/> to the given value.
+    /// </summary>
+    public static AppBuilder EnableWindowDrag(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.EnableWindowDrag = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.ShowToolOptionsButton"/> to the given value.
+    /// </summary>
+    public static AppBuilder ShowToolOptionsButton(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.ShowToolOptionsButton = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.ShowToolPinButton"/> to the given value.
+    /// </summary>
+    public static AppBuilder ShowToolPinButton(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.ShowToolPinButton = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.ShowToolCloseButton"/> to the given value.
+    /// </summary>
+    public static AppBuilder ShowToolCloseButton(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.ShowToolCloseButton = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.ShowDocumentCloseButton"/> to the given value.
+    /// </summary>
+    public static AppBuilder ShowDocumentCloseButton(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.ShowDocumentCloseButton = enable;
         return builder;
     }
 }

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -42,6 +42,31 @@ public static class DockSettings
     public static bool UseOwnerForFloatingWindows = true;
 
     /// <summary>
+    /// Allow dragging the window by its document tab strip.
+    /// </summary>
+    public static bool EnableWindowDrag = true;
+
+    /// <summary>
+    /// Show the options button on tool windows.
+    /// </summary>
+    public static bool ShowToolOptionsButton = true;
+
+    /// <summary>
+    /// Show the pin button on tool windows.
+    /// </summary>
+    public static bool ShowToolPinButton = true;
+
+    /// <summary>
+    /// Show the close button on tool windows.
+    /// </summary>
+    public static bool ShowToolCloseButton = true;
+
+    /// <summary>
+    /// Show the close button on document tabs.
+    /// </summary>
+    public static bool ShowDocumentCloseButton = true;
+
+    /// <summary>
     /// Checks if the drag distance is greater than the minimum required distance to initiate a drag operation.
     /// </summary>
     /// <param name="diff">The drag delta.</param>

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -37,5 +37,30 @@ public class DockSettingsOptions
     /// Optional floating window owner flag.
     /// </summary>
     public bool? UseOwnerForFloatingWindows { get; set; }
+
+    /// <summary>
+    /// Optional window drag flag.
+    /// </summary>
+    public bool? EnableWindowDrag { get; set; }
+
+    /// <summary>
+    /// Optional tool options button visibility flag.
+    /// </summary>
+    public bool? ShowToolOptionsButton { get; set; }
+
+    /// <summary>
+    /// Optional tool pin button visibility flag.
+    /// </summary>
+    public bool? ShowToolPinButton { get; set; }
+
+    /// <summary>
+    /// Optional tool close button visibility flag.
+    /// </summary>
+    public bool? ShowToolCloseButton { get; set; }
+
+    /// <summary>
+    /// Optional document close button visibility flag.
+    /// </summary>
+    public bool? ShowDocumentCloseButton { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- extend DockSettings with toggles for window drag and tool/document chrome
- expose new settings via DockSettingsOptions and AppBuilderExtensions
- bind new options in ToolChromeControl and DocumentTabStrip styles
- set default EnableWindowDrag in DocumentDock and DocumentTabStrip
- document the new settings

## Testing
- `dotnet build -c Release` *(fails: av-build-tel-api-v1.avaloniaui.net blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872482d147883218c21ca9cc1437d1e