### PR TITLE
Add simple ctrl tab switcher

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentSwitcherControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentSwitcherControl.axaml
@@ -1,0 +1,15 @@
+<UserControl x:Class="Dock.Avalonia.Controls.DocumentSwitcherControl"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             xmlns:core="clr-namespace:Dock.Model.Core;assembly=Dock.Model"
+             x:CompileBindings="True"
+             x:DataType="controls:IRootDock">
+  <ListBox ItemsSource="{Binding VisibleDockables}" SelectedItem="{Binding ActiveDockable}">
+    <ListBox.ItemTemplate>
+      <DataTemplate DataType="core:IDockable">
+        <TextBlock Text="{Binding Title}" Margin="4" />
+      </DataTemplate>
+    </ListBox.ItemTemplate>
+  </ListBox>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/DocumentSwitcherControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentSwitcherControl.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Control hosting the document switcher list.
+/// </summary>
+public partial class DocumentSwitcherControl : UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentSwitcherControl"/> class.
+    /// </summary>
+    public DocumentSwitcherControl()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/DocumentSwitcherWindow.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentSwitcherWindow.axaml
@@ -1,0 +1,12 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <ControlTheme x:Key="{x:Type DocumentSwitcherWindow}" TargetType="DocumentSwitcherWindow"
+                BasedOn="{StaticResource {x:Type Window}}">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+    <Setter Property="CanResize" Value="False" />
+    <Setter Property="SizeToContent" Value="WidthAndHeight" />
+    <Setter Property="Topmost" Value="True" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DocumentSwitcherWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentSwitcherWindow.axaml.cs
@@ -1,0 +1,14 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Window used to display document switcher content.
+/// </summary>
+public class DocumentSwitcherWindow : Window
+{
+    /// <inheritdoc/>
+    protected override Type StyleKeyOverride => typeof(DocumentSwitcherWindow);
+}

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -29,6 +29,7 @@ public class HostWindow : Window, IHostWindow
 {
     private readonly DockManager _dockManager;
     private readonly HostWindowState _hostWindowState;
+    private readonly DocumentSwitcherHelper _documentSwitcherHelper = new();
     private List<Control> _chromeGrips = new();
     private HostWindowTitleBar? _hostWindowTitleBar;
     private bool _mouseDown, _draggingWindow;
@@ -100,6 +101,8 @@ public class HostWindow : Window, IHostWindow
     {
         PositionChanged += HostWindow_PositionChanged;
         LayoutUpdated += HostWindow_LayoutUpdated;
+        KeyDown += HostWindow_KeyDown;
+        KeyUp += HostWindow_KeyUp;
 
         _dockManager = new DockManager();
         _hostWindowState = new HostWindowState(_dockManager, this);
@@ -206,6 +209,27 @@ public class HostWindow : Window, IHostWindow
         if (Window is { } && IsTracked)
         {
             Window.Save();
+        }
+    }
+
+    private void HostWindow_KeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.Tab)
+        {
+            if (Window?.Layout is IRootDock root)
+            {
+                _documentSwitcherHelper.Show(root);
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void HostWindow_KeyUp(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Tab)
+        {
+            _documentSwitcherHelper.Hide();
+            e.Handled = true;
         }
     }
 

--- a/src/Dock.Avalonia/Internal/DocumentSwitcherHelper.cs
+++ b/src/Dock.Avalonia/Internal/DocumentSwitcherHelper.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using Dock.Avalonia.Controls;
+using Dock.Model.Controls;
+
+namespace Dock.Avalonia.Internal;
+
+internal class DocumentSwitcherHelper
+{
+    private DocumentSwitcherWindow? _window;
+
+    public void Show(IRootDock root)
+    {
+        if (_window != null)
+        {
+            return;
+        }
+
+        var control = new DocumentSwitcherControl
+        {
+            DataContext = root
+        };
+
+        _window = new DocumentSwitcherWindow
+        {
+            Content = control
+        };
+
+        _window.Show();
+    }
+
+    public void Hide()
+    {
+        if (_window == null)
+            return;
+
+        _window.Close();
+        _window = null;
+    }
+}

--- a/src/Dock.Model.Mvvm/Controls/RootDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/RootDock.cs
@@ -25,6 +25,7 @@ public class RootDock : DockBase, IRootDock
     private IDockWindow? _window;
     private IList<IDockWindow>? _windows;
     private IToolDock? _pinnedDock;
+    private DocumentSwitcherType _documentSwitcherType = DocumentSwitcherType.Simple;
 
     /// <summary>
     /// Initializes new instance of the <see cref="RootDock"/> class.
@@ -105,6 +106,14 @@ public class RootDock : DockBase, IRootDock
     {
         get => _windows;
         set => SetProperty(ref _windows, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public DocumentSwitcherType DocumentSwitcherType
+    {
+        get => _documentSwitcherType;
+        set => SetProperty(ref _documentSwitcherType, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Controls/IRootDock.cs
+++ b/src/Dock.Model/Controls/IRootDock.cs
@@ -65,4 +65,9 @@ public interface IRootDock : IDock
     /// Exit windows.
     /// </summary>
     ICommand ExitWindows { get; }
+
+    /// <summary>
+    /// Gets or sets the document switcher type.
+    /// </summary>
+    DocumentSwitcherType DocumentSwitcherType { get; set; }
 }

--- a/src/Dock.Model/Core/DocumentSwitcherType.cs
+++ b/src/Dock.Model/Core/DocumentSwitcherType.cs
@@ -1,0 +1,17 @@
+namespace Dock.Model.Core
+{
+    /// <summary>
+    /// Defines available document switcher types used for Ctrl+Tab navigation.
+    /// </summary>
+    public enum DocumentSwitcherType
+    {
+        /// <summary>
+        /// Simple switcher showing a basic list of documents.
+        /// </summary>
+        Simple,
+        /// <summary>
+        /// Visual Studio like switcher interface.
+        /// </summary>
+        VisualStudio
+    }
+}

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Avalonia;
+using Dock.Model.Core;
 
 namespace Dock.Settings;
 
@@ -53,6 +54,11 @@ public static class AppBuilderExtensions
         if (options.UseOwnerForFloatingWindows != null)
         {
             DockSettings.UseOwnerForFloatingWindows = options.UseOwnerForFloatingWindows.Value;
+        }
+
+        if (options.DocumentSwitcherType != null)
+        {
+            DockSettings.DocumentSwitcherType = options.DocumentSwitcherType.Value;
         }
 
         return builder;
@@ -111,6 +117,20 @@ public static class AppBuilderExtensions
         bool enable = true)
     {
         DockSettings.UseOwnerForFloatingWindows = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.DocumentSwitcherType"/> to the given value.
+    /// </summary>
+    /// <param name="builder">The app builder.</param>
+    /// <param name="type">The switcher type.</param>
+    /// <returns>The app builder instance.</returns>
+    public static AppBuilder UseDocumentSwitcherType(
+        this AppBuilder builder,
+        DocumentSwitcherType type)
+    {
+        DockSettings.DocumentSwitcherType = type;
         return builder;
     }
 }

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Avalonia;
+using Dock.Model.Core;
 
 namespace Dock.Settings;
 
@@ -40,6 +41,11 @@ public static class DockSettings
     /// Floating windows use the main window as their owner so they stay in front.
     /// </summary>
     public static bool UseOwnerForFloatingWindows = true;
+
+    /// <summary>
+    /// Type of the Ctrl+Tab document switcher.
+    /// </summary>
+    public static DocumentSwitcherType DocumentSwitcherType = DocumentSwitcherType.Simple;
 
     /// <summary>
     /// Checks if the drag distance is greater than the minimum required distance to initiate a drag operation.

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+using Dock.Model.Core;
+
 namespace Dock.Settings;
 
 /// <summary>
@@ -37,5 +39,10 @@ public class DockSettingsOptions
     /// Optional floating window owner flag.
     /// </summary>
     public bool? UseOwnerForFloatingWindows { get; set; }
+
+    /// <summary>
+    /// Optional document switcher type.
+    /// </summary>
+    public DocumentSwitcherType? DocumentSwitcherType { get; set; }
 }
 


### PR DESCRIPTION
## Summary
- add `DocumentSwitcherType` enum and new setting
- implement switcher window and control
- show switcher from HostWindow when pressing Ctrl+Tab

## Testing
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release -f net6.0`
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68724683350483218f4915fcbf436190