### PR TITLE
Add configurable animations

### DIFF
--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -53,6 +53,11 @@ hidden and drags are limited to the originating control.
 `DockSettings.EnableWindowMagnetism` toggles snapping of floating windows. The snap distance
 is controlled by `DockSettings.WindowMagnetDistance`.
 
+## Animations
+
+`DockSettings.EnableAnimations` toggles the opacity and position transitions defined in the
+default control themes. Set it to `false` if you prefer instant updates with no animations.
+
 ## App builder integration
 
 You can configure the settings when building your Avalonia application:
@@ -67,6 +72,7 @@ AppBuilder.Configure<App>()
     .EnableGlobalDocking(false)
     .EnableWindowMagnetism()
     .SetWindowMagnetDistance(16)
+    .EnableAnimations(false)
     .WithDockSettings(new DockSettingsOptions
     {
         MinimumHorizontalDragDistance = 6

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -178,6 +178,12 @@
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="4 0 4 0" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:.2" />
+        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.2" />
+      </Transitions>
+    </Setter>
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -257,16 +263,19 @@
     <Style Selector="^:active:selected">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}" />
       <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
     </Style>
 
     <Style Selector="^:pointerover">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}" />
       <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
     </Style>
 
     <Style Selector="^:selected:pointerover">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushLow}" />
       <Setter Property="Foreground" Value="{DynamicResource DockApplicationAccentForegroundBrush}" />
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
     </Style>
 
   </ControlTheme>

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -50,6 +50,12 @@ public class DocumentTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
+
+        if (!Dock.Settings.DockSettings.EnableAnimations)
+        {
+            Transitions = null;
+            RenderTransform = null;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -95,6 +95,12 @@
     <Setter Property="BorderThickness" Value="0 1 0 0" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="4 1 4 0" />
+    <Setter Property="Transitions">
+      <Transitions>
+        <DoubleTransition Property="Opacity" Duration="0:0:.2" />
+        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.2" />
+      </Transitions>
+    </Setter>
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -125,6 +131,7 @@
 
     <Style Selector="^:pointerover">
       <Setter Property="Background" Value="{DynamicResource DockApplicationAccentBrushMed}" />
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
     </Style>
 
     <Style Selector="^:selected">
@@ -134,12 +141,14 @@
       <Setter Property="BorderThickness" Value="1 0 1 1" />
       <Setter Property="Margin" Value="0 0 0 0" />
       <Setter Property="Padding" Value="4 2 4 0" />
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
     </Style>
 
     <Style Selector="^:selected:pointerover">
       <Setter Property="Background" Value="{DynamicResource DockThemeBackgroundBrush}" />
       <Setter Property="BorderBrush" Value="{DynamicResource DockThemeBorderLowBrush}" />
-    </Style> 
+      <Setter Property="RenderTransform" Value="translateY(-2px)" />
+    </Style>
     
   </ControlTheme>
 

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -24,6 +24,12 @@ public class ToolTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
+
+        if (!Dock.Settings.DockSettings.EnableAnimations)
+        {
+            Transitions = null;
+            RenderTransform = null;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -65,6 +65,11 @@ public static class AppBuilderExtensions
             DockSettings.WindowMagnetDistance = options.WindowMagnetDistance.Value;
         }
 
+        if (options.EnableAnimations != null)
+        {
+            DockSettings.EnableAnimations = options.EnableAnimations.Value;
+        }
+
         return builder;
     }
 
@@ -143,6 +148,17 @@ public static class AppBuilderExtensions
         double distance)
     {
         DockSettings.WindowMagnetDistance = distance;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.EnableAnimations"/> to the given value.
+    /// </summary>
+    public static AppBuilder EnableAnimations(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.EnableAnimations = enable;
         return builder;
     }
 }

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -52,6 +52,11 @@ public static class DockSettings
     public static double WindowMagnetDistance = 16;
 
     /// <summary>
+    /// Enable or disable UI animations.
+    /// </summary>
+    public static bool EnableAnimations = true;
+
+    /// <summary>
     /// Checks if the drag distance is greater than the minimum required distance to initiate a drag operation.
     /// </summary>
     /// <param name="diff">The drag delta.</param>

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -47,5 +47,10 @@ public class DockSettingsOptions
     /// Optional window magnet snap distance.
     /// </summary>
     public double? WindowMagnetDistance { get; set; }
+
+    /// <summary>
+    /// Optional animation flag.
+    /// </summary>
+    public bool? EnableAnimations { get; set; }
 }
 

--- a/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
+++ b/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
@@ -22,7 +22,8 @@ public class AppBuilderExtensionsTests
             UseFloatingDockAdorner = true,
             UsePinnedDockWindow = true,
             EnableGlobalDocking = false,
-            UseOwnerForFloatingWindows = false
+            UseOwnerForFloatingWindows = false,
+            EnableAnimations = false
         };
 
         var result = builder.WithDockSettings(options);
@@ -34,6 +35,7 @@ public class AppBuilderExtensionsTests
         Assert.True(DockSettings.UsePinnedDockWindow);
         Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);
+        Assert.False(DockSettings.EnableAnimations);
     }
 
     [Fact]
@@ -64,11 +66,13 @@ public class AppBuilderExtensionsTests
         builder.UseFloatingDockAdorner(true)
                .UsePinnedDockWindow(true)
                .EnableGlobalDocking(false)
-               .UseOwnerForFloatingWindows(false);
+               .UseOwnerForFloatingWindows(false)
+               .EnableAnimations(false);
 
         Assert.True(DockSettings.UseFloatingDockAdorner);
         Assert.True(DockSettings.UsePinnedDockWindow);
         Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);
+        Assert.False(DockSettings.EnableAnimations);
     }
 }


### PR DESCRIPTION
## Summary
- add `EnableAnimations` setting and AppBuilder extension
- animate tab items with opacity and transform transitions
- allow animations to be disabled in code
- document how to enable or disable animations
- test new setting options

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687266a884c08321996d77a0aa3ceb88