### PR TITLE
Improve ReactiveUI DI sample

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,15 +1,49 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
-  "$ref": "#/definitions/build",
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "Clean",
+        "Compile",
+        "Pack",
+        "Publish",
+        "Restore",
+        "Test"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "Configuration": {
-          "type": "string",
-          "description": "configuration"
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -19,24 +53,8 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
@@ -57,6 +75,38 @@
             "type": "string"
           }
         },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "$ref": "#/definitions/ExecutableTarget"
+          }
+        },
+        "Verbosity": {
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "$ref": "#/definitions/Verbosity"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "configuration"
+        },
         "PublishFramework": {
           "type": "string",
           "description": "publish-framework"
@@ -73,59 +123,18 @@
           "type": "boolean",
           "description": "publish-self-contained"
         },
-        "Root": {
-          "type": "string",
-          "description": "Root directory during build execution"
-        },
-        "Skip": {
-          "type": "array",
-          "description": "List of targets to be skipped. Empty list skips all dependencies",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "Compile",
-              "Pack",
-              "Publish",
-              "Restore",
-              "Test"
-            ]
-          }
-        },
         "Solution": {
           "type": "string",
           "description": "Path to a solution file that is automatically loaded"
-        },
-        "Target": {
-          "type": "array",
-          "description": "List of targets to be invoked. Default is '{default_target}'",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Clean",
-              "Compile",
-              "Pack",
-              "Publish",
-              "Restore",
-              "Test"
-            ]
-          }
-        },
-        "Verbosity": {
-          "type": "string",
-          "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
         },
         "VersionSuffix": {
           "type": "string",
           "description": "version-suffix"
         }
       }
+    },
+    {
+      "$ref": "#/definitions/NukeBuild"
     }
-  }
+  ]
 }

--- a/samples/DockReactiveUIDiSample/App.axaml.cs
+++ b/samples/DockReactiveUIDiSample/App.axaml.cs
@@ -5,7 +5,6 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Templates;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels;
-using DockReactiveUIDiSample.Views;
 using Microsoft.Extensions.DependencyInjection;
 using ReactiveUI;
 

--- a/samples/DockReactiveUIDiSample/App.axaml.cs
+++ b/samples/DockReactiveUIDiSample/App.axaml.cs
@@ -1,19 +1,22 @@
 using System;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Controls.Templates;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels;
 using DockReactiveUIDiSample.Views;
 using Microsoft.Extensions.DependencyInjection;
+using ReactiveUI;
 
 namespace DockReactiveUIDiSample;
 
 public partial class App : Application
 {
     public IServiceProvider? ServiceProvider { get; }
-    private readonly ViewLocator _viewLocator;
+    private readonly IViewLocator _viewLocator;
 
-    public App(IServiceProvider? serviceProvider, ViewLocator viewLocator)
+    public App(IServiceProvider? serviceProvider, IViewLocator viewLocator)
     {
         ServiceProvider = serviceProvider;
         _viewLocator = viewLocator;
@@ -22,7 +25,7 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
-        DataTemplates.Insert(0, _viewLocator);
+        DataTemplates.Insert(0, (IDataTemplate)_viewLocator);
     }
 
     public override void OnFrameworkInitializationCompleted()
@@ -30,10 +33,14 @@ public partial class App : Application
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop && ServiceProvider != null)
         {
             var vm = ServiceProvider.GetRequiredService<MainWindowViewModel>();
-            var window = new MainWindow { DataContext = vm };
-            window.Closing += async (_, _) => await vm.SaveLayoutAsync();
-            desktop.MainWindow = window;
-            desktop.Exit += async (_, _) => await vm.SaveLayoutAsync();
+            var view = ServiceProvider.GetRequiredService<IViewFor<MainWindowViewModel>>();
+            view.ViewModel = vm;
+            if (view is Window window)
+            {
+                window.Closing += async (_, _) => await vm.SaveLayoutAsync();
+                desktop.MainWindow = window;
+                desktop.Exit += async (_, _) => await vm.SaveLayoutAsync();
+            }
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/samples/DockReactiveUIDiSample/Program.cs
+++ b/samples/DockReactiveUIDiSample/Program.cs
@@ -7,8 +7,10 @@ using DockReactiveUIDiSample.Models;
 using DockReactiveUIDiSample.ViewModels;
 using DockReactiveUIDiSample.ViewModels.Documents;
 using DockReactiveUIDiSample.ViewModels.Tools;
+using DockReactiveUIDiSample.Views;
 using DockReactiveUIDiSample.Views.Documents;
 using DockReactiveUIDiSample.Views.Tools;
+using ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DockReactiveUIDiSample;
@@ -33,13 +35,14 @@ internal class Program
     private static void ConfigureServices(IServiceCollection services)
     {
         services.AddSingleton<App>();
-        services.AddSingleton<ViewLocator>();
+        services.AddSingleton<IViewLocator, ViewLocator>();
         services.AddSingleton<DemoData>();
         services.AddTransient<DocumentViewModel>();
         services.AddTransient<ToolViewModel>();
-        services.AddTransient<DocumentView>();
-        services.AddTransient<ToolView>();
+        services.AddTransient<IViewFor<DocumentViewModel>, DocumentView>();
+        services.AddTransient<IViewFor<ToolViewModel>, ToolView>();
         services.AddSingleton<MainWindowViewModel>();
+        services.AddTransient<IViewFor<MainWindowViewModel>, MainWindow>();
 
         services.AddDock<DockFactory, DockSerializer>();
    }

--- a/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
@@ -1,13 +1,32 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using DockReactiveUIDiSample.ViewModels.Documents;
+using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Documents;
 
-public partial class DocumentView : UserControl
+public partial class DocumentView : UserControl, IViewFor<DocumentViewModel>
 {
     public DocumentView()
     {
         InitializeComponent();
+    }
+
+    private DocumentViewModel? _viewModel;
+    public DocumentViewModel? ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            _viewModel = value;
+            DataContext = value;
+        }
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = (DocumentViewModel?)value;
     }
 
     private void InitializeComponent()
@@ -15,3 +34,4 @@ public partial class DocumentView : UserControl
         AvaloniaXamlLoader.Load(this);
     }
 }
+

--- a/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
@@ -1,8 +1,6 @@
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels.Documents;
 using Avalonia.ReactiveUI;
-using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Documents;
 
@@ -12,7 +10,6 @@ public partial class DocumentView : ReactiveUserControl<DocumentViewModel>
     {
         InitializeComponent();
     }
-
 
     private void InitializeComponent()
     {

--- a/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
@@ -1,10 +1,8 @@
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
 using DockReactiveUIDiSample.ViewModels;
 using Avalonia.ReactiveUI;
-using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views;
 
@@ -18,7 +16,6 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         this.AttachDevTools();
 #endif
     }
-
 
     private void InitializeComponent()
     {

--- a/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
@@ -2,17 +2,37 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
+using DockReactiveUIDiSample.ViewModels;
+using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views;
 
-public partial class MainWindow : Window
+public partial class MainWindow : Window, IViewFor<MainWindowViewModel>
 {
+
     public MainWindow()
     {
         InitializeComponent();
 #if DEBUG
         this.AttachDevTools();
 #endif
+    }
+
+    private MainWindowViewModel? _viewModel;
+    public MainWindowViewModel? ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            _viewModel = value;
+            DataContext = value;
+        }
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = (MainWindowViewModel?)value;
     }
 
     private void InitializeComponent()
@@ -22,25 +42,20 @@ public partial class MainWindow : Window
 
     private void FileLoadLayout_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is ViewModels.MainWindowViewModel vm)
-        {
-            vm.LoadLayout();
-        }
+        ViewModel?.LoadLayout();
     }
 
     private async void FileSaveLayout_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is ViewModels.MainWindowViewModel vm)
+        if (ViewModel is { })
         {
-            await vm.SaveLayoutAsync();
+            await ViewModel.SaveLayoutAsync();
         }
     }
 
     private void FileCloseLayout_OnClick(object? sender, RoutedEventArgs e)
     {
-        if (DataContext is ViewModels.MainWindowViewModel vm)
-        {
-            vm.CloseLayout();
-        }
+        ViewModel?.CloseLayout();
     }
 }
+

--- a/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
@@ -1,13 +1,32 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using DockReactiveUIDiSample.ViewModels.Tools;
+using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Tools;
 
-public partial class ToolView : UserControl
+public partial class ToolView : UserControl, IViewFor<ToolViewModel>
 {
     public ToolView()
     {
         InitializeComponent();
+    }
+
+    private ToolViewModel? _viewModel;
+    public ToolViewModel? ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            _viewModel = value;
+            DataContext = value;
+        }
+    }
+
+    object? IViewFor.ViewModel
+    {
+        get => ViewModel;
+        set => ViewModel = (ToolViewModel?)value;
     }
 
     private void InitializeComponent()
@@ -15,3 +34,4 @@ public partial class ToolView : UserControl
         AvaloniaXamlLoader.Load(this);
     }
 }
+

--- a/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
@@ -1,8 +1,6 @@
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels.Tools;
 using Avalonia.ReactiveUI;
-using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Tools;
 
@@ -12,7 +10,6 @@ public partial class ToolView : ReactiveUserControl<ToolViewModel>
     {
         InitializeComponent();
     }
-
 
     private void InitializeComponent()
     {


### PR DESCRIPTION
## Summary
- update DI wiring for DockReactiveUIDiSample to use `IViewLocator` and `IViewFor`
- implement view models and views pairing with explicit ViewModel property
- register views and locator through dependency injection

## Testing
- `dotnet build samples/DockReactiveUIDiSample/DockReactiveUIDiSample.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6873d55dbb408321a2bbe3d103c4cdd2