### PR TITLE
Use reactive base classes in DI sample

### DIFF
--- a/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Documents/DocumentView.axaml.cs
@@ -1,33 +1,18 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels.Documents;
+using Avalonia.ReactiveUI;
 using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Documents;
 
-public partial class DocumentView : UserControl, IViewFor<DocumentViewModel>
+public partial class DocumentView : ReactiveUserControl<DocumentViewModel>
 {
     public DocumentView()
     {
         InitializeComponent();
     }
 
-    private DocumentViewModel? _viewModel;
-    public DocumentViewModel? ViewModel
-    {
-        get => _viewModel;
-        set
-        {
-            _viewModel = value;
-            DataContext = value;
-        }
-    }
-
-    object? IViewFor.ViewModel
-    {
-        get => ViewModel;
-        set => ViewModel = (DocumentViewModel?)value;
-    }
 
     private void InitializeComponent()
     {

--- a/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
@@ -3,11 +3,12 @@ using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Interactivity;
 using DockReactiveUIDiSample.ViewModels;
+using Avalonia.ReactiveUI;
 using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views;
 
-public partial class MainWindow : Window, IViewFor<MainWindowViewModel>
+public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
 
     public MainWindow()
@@ -18,22 +19,6 @@ public partial class MainWindow : Window, IViewFor<MainWindowViewModel>
 #endif
     }
 
-    private MainWindowViewModel? _viewModel;
-    public MainWindowViewModel? ViewModel
-    {
-        get => _viewModel;
-        set
-        {
-            _viewModel = value;
-            DataContext = value;
-        }
-    }
-
-    object? IViewFor.ViewModel
-    {
-        get => ViewModel;
-        set => ViewModel = (MainWindowViewModel?)value;
-    }
 
     private void InitializeComponent()
     {

--- a/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/Tools/ToolView.axaml.cs
@@ -1,33 +1,18 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using DockReactiveUIDiSample.ViewModels.Tools;
+using Avalonia.ReactiveUI;
 using ReactiveUI;
 
 namespace DockReactiveUIDiSample.Views.Tools;
 
-public partial class ToolView : UserControl, IViewFor<ToolViewModel>
+public partial class ToolView : ReactiveUserControl<ToolViewModel>
 {
     public ToolView()
     {
         InitializeComponent();
     }
 
-    private ToolViewModel? _viewModel;
-    public ToolViewModel? ViewModel
-    {
-        get => _viewModel;
-        set
-        {
-            _viewModel = value;
-            DataContext = value;
-        }
-    }
-
-    object? IViewFor.ViewModel
-    {
-        get => ViewModel;
-        set => ViewModel = (ToolViewModel?)value;
-    }
 
     private void InitializeComponent()
     {


### PR DESCRIPTION
## Summary
- simplify DI sample views by inheriting from `ReactiveWindow` or `ReactiveUserControl`

## Testing
- `dotnet test Dock.sln --no-build -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874c5c925588321ab586a9656546f64