### PR TITLE
Refactor ReactiveUI DI sample menu actions

### DIFF
--- a/samples/DockReactiveUIDiSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockReactiveUIDiSample/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Reactive;
 using System.Threading.Tasks;
 using Dock.Model.Controls;
 using Dock.Model.Core;
@@ -20,11 +21,20 @@ public class MainWindowViewModel : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref _layout, value);
     }
 
+    public ReactiveCommand<Unit, Unit> LoadLayoutCommand { get; }
+    public ReactiveCommand<Unit, Unit> SaveLayoutCommand { get; }
+    public ReactiveCommand<Unit, Unit> CloseLayoutCommand { get; }
+
     public MainWindowViewModel(IFactory factory, IDockSerializer serializer, IDockState state)
     {
         _factory = factory;
         _serializer = serializer;
         _state = state;
+
+        LoadLayoutCommand = ReactiveCommand.Create(LoadLayout);
+        SaveLayoutCommand = ReactiveCommand.CreateFromTask(SaveLayoutAsync);
+        CloseLayoutCommand = ReactiveCommand.Create(CloseLayout);
+
         LoadLayout();
     }
 

--- a/samples/DockReactiveUIDiSample/Views/MainWindow.axaml
+++ b/samples/DockReactiveUIDiSample/Views/MainWindow.axaml
@@ -7,11 +7,11 @@
     <DockPanel>
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
-                <MenuItem Header="_Load Layout" Click="FileLoadLayout_OnClick" />
+                <MenuItem Header="_Load Layout" Command="{Binding LoadLayoutCommand}" />
                 <Separator />
-                <MenuItem Header="_Save Layout" Click="FileSaveLayout_OnClick" />
+                <MenuItem Header="_Save Layout" Command="{Binding SaveLayoutCommand}" />
                 <Separator />
-                <MenuItem Header="_Close Layout" Click="FileCloseLayout_OnClick" />
+                <MenuItem Header="_Close Layout" Command="{Binding CloseLayoutCommand}" />
             </MenuItem>
         </Menu>
         <DockControl Layout="{Binding Layout}" />

--- a/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
+++ b/samples/DockReactiveUIDiSample/Views/MainWindow.axaml.cs
@@ -1,6 +1,5 @@
 using Avalonia;
 using Avalonia.Markup.Xaml;
-using Avalonia.Interactivity;
 using DockReactiveUIDiSample.ViewModels;
 using Avalonia.ReactiveUI;
 
@@ -22,22 +21,5 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
         AvaloniaXamlLoader.Load(this);
     }
 
-    private void FileLoadLayout_OnClick(object? sender, RoutedEventArgs e)
-    {
-        ViewModel?.LoadLayout();
-    }
-
-    private async void FileSaveLayout_OnClick(object? sender, RoutedEventArgs e)
-    {
-        if (ViewModel is { })
-        {
-            await ViewModel.SaveLayoutAsync();
-        }
-    }
-
-    private void FileCloseLayout_OnClick(object? sender, RoutedEventArgs e)
-    {
-        ViewModel?.CloseLayout();
-    }
 }
 


### PR DESCRIPTION
## Summary
- use ReactiveCommands in the DI sample view model
- bind MainWindow menu items to commands
- drop unused click handlers from the view code-behind

## Testing
- `dotnet build samples/DockReactiveUIDiSample/DockReactiveUIDiSample.csproj -clp:ErrorsOnly`
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj -c Release -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874ddb4c93c8321a94b38b3efa1c53a