### PR TITLE
calculate the offset into the drag preview, based on the pointer pressed position

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -323,7 +323,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                             var sp = inputActiveDockControl.PointToScreen(point);
 
                             _context.DragOffset = DragOffsetCalculator.CalculateOffset(
-                                _context.DragControl, inputActiveDockControl, point);
+                                _context.DragControl, inputActiveDockControl, _context.DragStartPoint);
 
                             _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
                         }


### PR DESCRIPTION
If the user moves the mouse quickly when dragging out a tab, the calculated offset is wrong, because it uses the new pointer moved position and not the point the user originally pressed on.