### PR TITLE
Allow the window to be dragged by the last tab

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -272,9 +272,37 @@ public class DockControl : TemplatedControl, IDockControl
         return DragAction.Move;
     }
 
+    private bool ShouldIgnorePressedForWindowDrag(PointerPressedEventArgs e)
+    {
+        if (e.Source is not Control source)
+        {
+            return false;
+        }
+
+        var tabItem = source.FindAncestorOfType<DocumentTabStripItem>();
+        if (tabItem is null)
+        {
+            return false;
+        }
+
+        var tabStrip = tabItem.FindAncestorOfType<DocumentTabStrip>();
+        if (tabStrip is null)
+        {
+            return false;
+        }
+
+        return tabStrip.Items is { Count: 1 }
+               && tabStrip.DataContext is Dock.Model.Core.IDock { CanCloseLastDockable: false };
+    }
+
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
     {
         if (e.Source is Visual visual && visual.FindAncestorOfType<ScrollBar>() != null)
+        {
+            return;
+        }
+
+        if (ShouldIgnorePressedForWindowDrag(e))
         {
             return;
         }

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -183,10 +183,10 @@ public class DocumentTabStrip : TabStrip
         PseudoClasses.Set(":active", isActive);
     }
 
-    private WindowDragHelper CreateDragHelper(Control grip)
+    private WindowDragHelper CreateDragHelper()
     {
         return new WindowDragHelper(
-            grip,
+            this,
             () => EnableWindowDrag,
             source =>
             {
@@ -212,33 +212,22 @@ public class DocumentTabStrip : TabStrip
 
     private void AttachToWindow()
     {
-        if (!EnableWindowDrag || _grip == null)
+        if (!EnableWindowDrag)
         {
             return;
         }
 
-        if (VisualRoot is Window window)
+        if (VisualRoot is Window window &&
+            window is HostWindow hostWindow &&
+            _grip is { } &&
+            (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
         {
-            if (window is HostWindow hostWindow)
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                    RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    hostWindow.AttachGrip(_grip, ":documentwindow");
-                    _attachedWindow = hostWindow;
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    _windowDragHelper = CreateDragHelper(_grip);
-                    _windowDragHelper.Attach();
-                }
-            }
-            else
-            {
-                _windowDragHelper = CreateDragHelper(_grip);
-                _windowDragHelper.Attach();
-            }
+            hostWindow.AttachGrip(_grip, ":documentwindow");
+            _attachedWindow = hostWindow;
         }
+
+        _windowDragHelper = CreateDragHelper();
+        _windowDragHelper.Attach();
     }
 
     private void DetachFromWindow()

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -193,11 +193,20 @@ public class DocumentTabStrip : TabStrip
                 if (source == this)
                     return true;
 
-                return source is { } s &&
-                       !(s is DocumentTabStripItem) &&
-                       !(s is Button) &&
-                       !WindowDragHelper.IsChildOfType<DocumentTabStripItem>(this, s) &&
-                       !WindowDragHelper.IsChildOfType<Button>(this, s);
+                var allow = source is { } s &&
+                            !(s is DocumentTabStripItem) &&
+                            !(s is Button) &&
+                            !WindowDragHelper.IsChildOfType<DocumentTabStripItem>(this, s) &&
+                            !WindowDragHelper.IsChildOfType<Button>(this, s);
+
+                if (!allow &&
+                    Items is { } items && items.Count == 1 &&
+                    DataContext is Dock.Model.Core.IDock { CanCloseLastDockable: false })
+                {
+                    allow = true;
+                }
+
+                return allow;
             });
     }
 


### PR DESCRIPTION
https://github.com/wieslawsoltes/Dock/pull/538 implemented this feature but that was later lost. This PR re-introduces the feature.

If CanCloseLastDockable == false, and there is only 1 tab, then dragging that tab will not start a docking operation, it will instead drag the window with the mouse.