### PR TITLE
Add chrome-like tab drag improvements

### DIFF
--- a/docs/dock-tab-drag.md
+++ b/docs/dock-tab-drag.md
@@ -1,0 +1,13 @@
+# Chrome-style tab dragging
+
+`DocumentTabStrip` supports chrome-like tab dragging and reordering. With `ChromeTabDrag` enabled (the default), dragging a tab shows it following the pointer. Once the pointer crosses half of an adjacent tab, the items swap. Dragging further than a small vertical threshold detaches the document into a floating window.
+
+Use the property on the control to disable the behaviour:
+
+```xaml
+<DocumentTabStrip ChromeTabDrag="False" />
+```
+
+The logic uses `DockSettings.MinimumHorizontalDragDistance` and `DockSettings.MinimumVerticalDragDistance` to decide when the drag starts.
+
+

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -37,6 +37,7 @@
     <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
 
     <Setter Property="EnableWindowDrag" Value="{Binding EnableWindowDrag}" />
+    <Setter Property="ChromeTabDrag" Value="True" />
     
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Focusable" Value="False" />

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.VisualTree;
-
-using System.Runtime.InteropServices;
-using Dock.Avalonia.Internal;
 using Avalonia.Layout;
+using Avalonia.VisualTree;
+using Dock.Avalonia.Internal;
 
 namespace Dock.Avalonia.Controls;
 
@@ -28,7 +27,7 @@ public class DocumentTabStrip : TabStrip
     /// </summary>
     public static readonly StyledProperty<Control?> DockAdornerHostProperty =
         AvaloniaProperty.Register<DocumentTabStrip, Control?>(nameof(DockAdornerHost));
-    
+
     /// <summary>
     /// Defines the <see cref="CanCreateItem"/> property.
     /// </summary>
@@ -40,12 +39,18 @@ public class DocumentTabStrip : TabStrip
     /// </summary>
     public static readonly StyledProperty<bool> IsActiveProperty =
         AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(IsActive));
-    
+
     /// <summary>
     /// Define the <see cref="EnableWindowDrag"/> property.
     /// </summary>
-    public static readonly StyledProperty<bool> EnableWindowDragProperty = 
+    public static readonly StyledProperty<bool> EnableWindowDragProperty =
         AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(EnableWindowDrag));
+
+    /// <summary>
+    /// Enables chrome-like tab dragging and reordering.
+    /// </summary>
+    public static readonly StyledProperty<bool> ChromeTabDragProperty =
+        AvaloniaProperty.Register<DocumentTabStrip, bool>(nameof(ChromeTabDrag), true);
 
     /// <summary>
     /// Defines the <see cref="Orientation"/> property.
@@ -70,7 +75,7 @@ public class DocumentTabStrip : TabStrip
         get => GetValue(IsActiveProperty);
         set => SetValue(IsActiveProperty, value);
     }
-    
+
     /// <summary>
     /// Gets or sets if the window can be dragged by clicking on the tab strip.
     /// </summary>
@@ -78,6 +83,15 @@ public class DocumentTabStrip : TabStrip
     {
         get => GetValue(EnableWindowDragProperty);
         set => SetValue(EnableWindowDragProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets chrome-like tab dragging mode.
+    /// </summary>
+    public bool ChromeTabDrag
+    {
+        get => GetValue(ChromeTabDragProperty);
+        set => SetValue(ChromeTabDragProperty, value);
     }
 
     /// <summary>

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -1,14 +1,19 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.Styling;
+using Dock.Avalonia.Internal;
 using Dock.Model.Core;
+using Dock.Settings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -18,6 +23,13 @@ namespace Dock.Avalonia.Controls;
 [PseudoClasses(":active")]
 public class DocumentTabStripItem : TabStripItem
 {
+    private bool _pointerCaptured;
+    private bool _isDragging;
+    private Point _dragStartPoint;
+    private int _startIndex;
+    private DocumentTabStrip? _tabStrip;
+    private TranslateTransform? _dragTransform;
+    private const double FloatThreshold = 40;
     /// <summary>
     /// Define the <see cref="IsActive"/> property.
     /// </summary>
@@ -35,7 +47,7 @@ public class DocumentTabStripItem : TabStripItem
 
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(DocumentTabStripItem);
-        
+
     /// <summary>
     /// Initializes new instance of the <see cref="DocumentTabStripItem"/> class.
     /// </summary>
@@ -50,6 +62,9 @@ public class DocumentTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
+
+        AddHandler(PointerMovedEvent, MovedHandler, RoutingStrategies.Tunnel);
+        AddHandler(PointerReleasedEvent, ReleasedHandler, RoutingStrategies.Tunnel);
     }
 
     /// <inheritdoc/>
@@ -58,6 +73,8 @@ public class DocumentTabStripItem : TabStripItem
         base.OnDetachedFromVisualTree(e);
 
         RemoveHandler(PointerPressedEvent, PressedHandler);
+        RemoveHandler(PointerMovedEvent, MovedHandler);
+        RemoveHandler(PointerReleasedEvent, ReleasedHandler);
     }
 
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
@@ -67,6 +84,139 @@ public class DocumentTabStripItem : TabStripItem
             if (DataContext is IDockable { Owner: IDock { Factory: { } factory }, CanClose: true } dockable)
             {
                 factory.CloseDockable(dockable);
+            }
+            return;
+        }
+
+        if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            _tabStrip = this.FindAncestorOfType<DocumentTabStrip>();
+            if (_tabStrip is { } ts && ts.ChromeTabDrag)
+            {
+                _pointerCaptured = this.CapturePointer(e.Pointer);
+                _dragStartPoint = e.GetPosition(ts);
+                _startIndex = ts.ItemContainerGenerator.IndexFromContainer(this);
+                _dragTransform = new TranslateTransform();
+                RenderTransform = _dragTransform;
+                _isDragging = false;
+                e.Handled = true;
+            }
+        }
+    }
+
+    private void MovedHandler(object? sender, PointerEventArgs e)
+    {
+        if (!_pointerCaptured || _tabStrip is null)
+            return;
+
+        var position = e.GetPosition(_tabStrip);
+        var delta = position - _dragStartPoint;
+
+        if (_dragTransform is { } transform)
+        {
+            if (_tabStrip.Orientation == Orientation.Horizontal)
+                transform.X = delta.X;
+            else
+                transform.Y = delta.Y;
+        }
+
+        if (!_isDragging)
+        {
+            if (!DockSettings.IsMinimumDragDistance(delta))
+                return;
+            _isDragging = true;
+        }
+
+        if (_isDragging && Math.Abs(delta.Y) > FloatThreshold)
+        {
+            FloatDockable(e);
+            return;
+        }
+
+        var newIndex = GetIndexForPosition(position);
+        if (newIndex != _startIndex && newIndex >= 0)
+        {
+            MoveDockable(newIndex);
+            _startIndex = newIndex;
+            _dragStartPoint = position;
+            if (_dragTransform is { } t)
+            {
+                t.X = 0;
+                t.Y = 0;
+            }
+        }
+    }
+
+    private void ReleasedHandler(object? sender, PointerReleasedEventArgs e)
+    {
+        if (_pointerCaptured)
+        {
+            _pointerCaptured = false;
+            _isDragging = false;
+            _tabStrip = null;
+            if (_dragTransform is { })
+            {
+                _dragTransform.X = 0;
+                _dragTransform.Y = 0;
+                RenderTransform = null;
+                _dragTransform = null;
+            }
+            e.Pointer.Capture(null);
+        }
+    }
+
+    private void FloatDockable(PointerEventArgs e)
+    {
+        if (_tabStrip?.DataContext is IDocumentDock { Factory: { } factory } dock &&
+            DataContext is IDockable dockable)
+        {
+            var screen = this.PointToScreen(e.GetPosition(this));
+            dockable.SetPointerScreenPosition(screen.X, screen.Y);
+            factory.FloatDockable(dockable);
+        }
+        _pointerCaptured = false;
+        _isDragging = false;
+        _tabStrip = null;
+        if (_dragTransform is { })
+        {
+            _dragTransform.X = 0;
+            _dragTransform.Y = 0;
+            RenderTransform = null;
+            _dragTransform = null;
+        }
+        e.Pointer.Capture(null);
+    }
+
+    private int GetIndexForPosition(Point pos)
+    {
+        if (_tabStrip is null)
+            return -1;
+
+        for (var i = 0; i < _tabStrip.ItemCount; i++)
+        {
+            if (_tabStrip.ContainerFromIndex(i) is Control item)
+            {
+                var bounds = item.Bounds;
+                if (pos.X < bounds.X + bounds.Width / 2)
+                    return i;
+            }
+        }
+
+        return _tabStrip.ItemCount - 1;
+    }
+
+    private void MoveDockable(int index)
+    {
+        if (_tabStrip?.DataContext is IDocumentDock { VisibleDockables: { } list, Factory: { } factory } dock &&
+            DataContext is IDockable dockable)
+        {
+            if (index >= list.Count)
+                index = list.Count - 1;
+
+            var target = list[index];
+            if (!ReferenceEquals(target, dockable))
+            {
+                factory.MoveDockable(dock, dockable, target);
             }
         }
     }
@@ -87,3 +237,4 @@ public class DocumentTabStripItem : TabStripItem
         PseudoClasses.Set(":active", isActive);
     }
 }
+


### PR DESCRIPTION
## Summary
- animate tab following the pointer during chrome-style drag
- reorder when dragged past half of the neighbour
- document the new behaviour

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687a4469118c8321b6837d422bf702fc