### PR TITLE
Prevent local value being set on Window.Title preventing binding to FocusedDockable.Title

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml
@@ -19,7 +19,7 @@
     <Setter Property="TextBlock.Foreground" Value="{DynamicResource DockThemeForegroundBrush}" />
     <Setter Property="WindowState" Value="Normal" />
     <Setter Property="UseLayoutRounding" Value="True" />
-    <Setter Property="Title" Value="{Binding ActiveDockable.Title}"  />
+    <Setter Property="Title" Value="{Binding FocusedDockable.Title}"  />
     <Setter Property="Topmost" Value="{Binding Window.Topmost}" />
     <Setter Property="SystemDecorations" Value="Full" />
     <Setter Property="ToolChromeControlsWholeWindow" Value="{Binding OpenedDockablesCount, Converter={StaticResource LessThan2}}" />

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -498,9 +498,14 @@ public class HostWindow : Window, IHostWindow
     }
 
     /// <inheritdoc/>
-    public void SetTitle(string title)
+    public void SetTitle(string? title)
     {
-        Title = title;
+        if (!string.IsNullOrEmpty(title))
+        {
+            // Only do this if the user intended to manually set the title.
+            // Otherwise binding to the active document title will no longer work due to local values taking priority.
+            Title = title;
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model/Core/IHostWindow.cs
+++ b/src/Dock.Model/Core/IHostWindow.cs
@@ -70,7 +70,7 @@ public interface IHostWindow
     /// Sets host title.
     /// </summary>
     /// <param name="title">The host title.</param>
-    void SetTitle(string title);
+    void SetTitle(string? title);
 
     /// <summary>
     /// Sets host layout.


### PR DESCRIPTION
SetTitle() in host window was overriding the bindings with a local value.

Skip the call if the user calls it with a null or empty value.