### PR TITLE
Add Dock event logging support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,8 @@
     <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="9.0.4" />
     <PackageVersion Include="protobuf-net" Version="3.2.52" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Prism.Core" Version="9.0.537" />
   </ItemGroup>
 </Project>

--- a/build/Microsoft.Extensions.Logging.props
+++ b/build/Microsoft.Extensions.Logging.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/samples/DockReactiveUIDiSample/DockReactiveUIDiSample.csproj
+++ b/samples/DockReactiveUIDiSample/DockReactiveUIDiSample.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/DockReactiveUIDiSample/Program.cs
+++ b/samples/DockReactiveUIDiSample/Program.cs
@@ -22,7 +22,7 @@ internal class Program
     private static void Main(string[] args)
     {
         using var provider = Initialize();
-        using provider.UseDockEventLogger();
+        using var _ = provider.UseDockEventLogger();
         BuildAvaloniaApp(provider).StartWithClassicDesktopLifetime(args);
     }
 

--- a/samples/DockReactiveUIDiSample/Program.cs
+++ b/samples/DockReactiveUIDiSample/Program.cs
@@ -12,6 +12,7 @@ using DockReactiveUIDiSample.Views.Documents;
 using DockReactiveUIDiSample.Views.Tools;
 using ReactiveUI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace DockReactiveUIDiSample;
 
@@ -21,6 +22,7 @@ internal class Program
     private static void Main(string[] args)
     {
         using var provider = Initialize();
+        using provider.UseDockEventLogger();
         BuildAvaloniaApp(provider).StartWithClassicDesktopLifetime(args);
     }
 
@@ -45,7 +47,9 @@ internal class Program
         services.AddTransient<IViewFor<MainWindowViewModel>, MainWindow>();
 
         services.AddDock<DockFactory, DockSerializer>();
-   }
+        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        services.UseDockEventLogger();
+    }
 
     public static AppBuilder BuildAvaloniaApp(IServiceProvider provider)
         => AppBuilder.Configure(provider.GetRequiredService<App>)

--- a/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Dock.Model.Core;
+using Dock.Model.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Dock.Model.Extensions.DependencyInjection;
@@ -27,5 +28,26 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TSerializer>();
         services.AddSingleton<IDockSerializer>(static sp => sp.GetRequiredService<TSerializer>());
         return services;
+    }
+
+    /// <summary>
+    /// Adds a <see cref="DockEventLogger"/> to log factory events.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection UseDockEventLogger(this IServiceCollection services)
+    {
+        services.AddSingleton<DockEventLogger>();
+        return services;
+    }
+
+    /// <summary>
+    /// Starts logging dock events using the registered <see cref="DockEventLogger"/>.
+    /// </summary>
+    /// <param name="provider">The service provider.</param>
+    /// <returns>The <see cref="DockEventLogger"/> instance.</returns>
+    public static DockEventLogger UseDockEventLogger(this IServiceProvider provider)
+    {
+        return provider.GetRequiredService<DockEventLogger>();
     }
 }

--- a/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using System;
 using Dock.Model.Core;
 using Dock.Model.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Dock.Model/Diagnostics/DockEventLogger.cs
+++ b/src/Dock.Model/Diagnostics/DockEventLogger.cs
@@ -1,5 +1,4 @@
 using System;
-using Dock.Model.Core;
 using Dock.Model.Core.Events;
 using Microsoft.Extensions.Logging;
 
@@ -8,7 +7,7 @@ namespace Dock.Model.Diagnostics;
 /// <summary>
 /// Logs <see cref="FactoryBase"/> events using <see cref="ILogger"/>.
 /// </summary>
-internal sealed class DockEventLogger : IDisposable
+public sealed class DockEventLogger : IDisposable
 {
     private readonly FactoryBase _factory;
     private readonly ILogger _logger;

--- a/src/Dock.Model/Diagnostics/DockEventLogger.cs
+++ b/src/Dock.Model/Diagnostics/DockEventLogger.cs
@@ -1,0 +1,152 @@
+using System;
+using Dock.Model.Core;
+using Dock.Model.Core.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Dock.Model.Diagnostics;
+
+/// <summary>
+/// Logs <see cref="FactoryBase"/> events using <see cref="ILogger"/>.
+/// </summary>
+internal sealed class DockEventLogger : IDisposable
+{
+    private readonly FactoryBase _factory;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockEventLogger"/> class.
+    /// </summary>
+    /// <param name="factory">Factory emitting events.</param>
+    /// <param name="logger">Logger implementation.</param>
+    public DockEventLogger(FactoryBase factory, ILogger<DockEventLogger> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+        Subscribe();
+    }
+
+    private void Subscribe()
+    {
+        _factory.ActiveDockableChanged += OnActiveDockableChanged;
+        _factory.FocusedDockableChanged += OnFocusedDockableChanged;
+        _factory.DockableInit += OnDockableInit;
+        _factory.DockableAdded += OnDockableAdded;
+        _factory.DockableRemoved += OnDockableRemoved;
+        _factory.DockableClosed += OnDockableClosed;
+        _factory.DockableMoved += OnDockableMoved;
+        _factory.DockableDocked += OnDockableDocked;
+        _factory.DockableUndocked += OnDockableUndocked;
+        _factory.DockableSwapped += OnDockableSwapped;
+        _factory.DockablePinned += OnDockablePinned;
+        _factory.DockableUnpinned += OnDockableUnpinned;
+        _factory.DockableHidden += OnDockableHidden;
+        _factory.DockableRestored += OnDockableRestored;
+        _factory.WindowOpened += OnWindowOpened;
+        _factory.WindowClosing += OnWindowClosing;
+        _factory.WindowClosed += OnWindowClosed;
+        _factory.WindowAdded += OnWindowAdded;
+        _factory.WindowRemoved += OnWindowRemoved;
+        _factory.WindowMoveDragBegin += OnWindowMoveDragBegin;
+        _factory.WindowMoveDrag += OnWindowMoveDrag;
+        _factory.WindowMoveDragEnd += OnWindowMoveDragEnd;
+    }
+
+    private void Unsubscribe()
+    {
+        _factory.ActiveDockableChanged -= OnActiveDockableChanged;
+        _factory.FocusedDockableChanged -= OnFocusedDockableChanged;
+        _factory.DockableInit -= OnDockableInit;
+        _factory.DockableAdded -= OnDockableAdded;
+        _factory.DockableRemoved -= OnDockableRemoved;
+        _factory.DockableClosed -= OnDockableClosed;
+        _factory.DockableMoved -= OnDockableMoved;
+        _factory.DockableDocked -= OnDockableDocked;
+        _factory.DockableUndocked -= OnDockableUndocked;
+        _factory.DockableSwapped -= OnDockableSwapped;
+        _factory.DockablePinned -= OnDockablePinned;
+        _factory.DockableUnpinned -= OnDockableUnpinned;
+        _factory.DockableHidden -= OnDockableHidden;
+        _factory.DockableRestored -= OnDockableRestored;
+        _factory.WindowOpened -= OnWindowOpened;
+        _factory.WindowClosing -= OnWindowClosing;
+        _factory.WindowClosed -= OnWindowClosed;
+        _factory.WindowAdded -= OnWindowAdded;
+        _factory.WindowRemoved -= OnWindowRemoved;
+        _factory.WindowMoveDragBegin -= OnWindowMoveDragBegin;
+        _factory.WindowMoveDrag -= OnWindowMoveDrag;
+        _factory.WindowMoveDragEnd -= OnWindowMoveDragEnd;
+    }
+
+    private void OnActiveDockableChanged(object? sender, ActiveDockableChangedEventArgs e)
+        => _logger.LogInformation("ActiveDockableChanged {Id}", e.Dockable?.Id);
+
+    private void OnFocusedDockableChanged(object? sender, FocusedDockableChangedEventArgs e)
+        => _logger.LogInformation("FocusedDockableChanged {Id}", e.Dockable?.Id);
+
+    private void OnDockableInit(object? sender, DockableInitEventArgs e)
+        => _logger.LogInformation("DockableInit {Id}", e.Dockable?.Id);
+
+    private void OnDockableAdded(object? sender, DockableAddedEventArgs e)
+        => _logger.LogInformation("DockableAdded {Id}", e.Dockable?.Id);
+
+    private void OnDockableRemoved(object? sender, DockableRemovedEventArgs e)
+        => _logger.LogInformation("DockableRemoved {Id}", e.Dockable?.Id);
+
+    private void OnDockableClosed(object? sender, DockableClosedEventArgs e)
+        => _logger.LogInformation("DockableClosed {Id}", e.Dockable?.Id);
+
+    private void OnDockableMoved(object? sender, DockableMovedEventArgs e)
+        => _logger.LogInformation("DockableMoved {Id}", e.Dockable?.Id);
+
+    private void OnDockableDocked(object? sender, DockableDockedEventArgs e)
+        => _logger.LogInformation("DockableDocked {Id} {Operation}", e.Dockable?.Id, e.Operation);
+
+    private void OnDockableUndocked(object? sender, DockableUndockedEventArgs e)
+        => _logger.LogInformation("DockableUndocked {Id} {Operation}", e.Dockable?.Id, e.Operation);
+
+    private void OnDockableSwapped(object? sender, DockableSwappedEventArgs e)
+        => _logger.LogInformation("DockableSwapped {Id}", e.Dockable?.Id);
+
+    private void OnDockablePinned(object? sender, DockablePinnedEventArgs e)
+        => _logger.LogInformation("DockablePinned {Id}", e.Dockable?.Id);
+
+    private void OnDockableUnpinned(object? sender, DockableUnpinnedEventArgs e)
+        => _logger.LogInformation("DockableUnpinned {Id}", e.Dockable?.Id);
+
+    private void OnDockableHidden(object? sender, DockableHiddenEventArgs e)
+        => _logger.LogInformation("DockableHidden {Id}", e.Dockable?.Id);
+
+    private void OnDockableRestored(object? sender, DockableRestoredEventArgs e)
+        => _logger.LogInformation("DockableRestored {Id}", e.Dockable?.Id);
+
+    private void OnWindowOpened(object? sender, WindowOpenedEventArgs e)
+        => _logger.LogInformation("WindowOpened {Id}", e.Window?.Id);
+
+    private void OnWindowClosing(object? sender, WindowClosingEventArgs e)
+        => _logger.LogInformation("WindowClosing {Id} Cancel={Cancel}", e.Window?.Id, e.Cancel);
+
+    private void OnWindowClosed(object? sender, WindowClosedEventArgs e)
+        => _logger.LogInformation("WindowClosed {Id}", e.Window?.Id);
+
+    private void OnWindowAdded(object? sender, WindowAddedEventArgs e)
+        => _logger.LogInformation("WindowAdded {Id}", e.Window?.Id);
+
+    private void OnWindowRemoved(object? sender, WindowRemovedEventArgs e)
+        => _logger.LogInformation("WindowRemoved {Id}", e.Window?.Id);
+
+    private void OnWindowMoveDragBegin(object? sender, WindowMoveDragBeginEventArgs e)
+        => _logger.LogInformation("WindowMoveDragBegin {Id} Cancel={Cancel}", e.Window?.Id, e.Cancel);
+
+    private void OnWindowMoveDrag(object? sender, WindowMoveDragEventArgs e)
+        => _logger.LogInformation("WindowMoveDrag {Id}", e.Window?.Id);
+
+    private void OnWindowMoveDragEnd(object? sender, WindowMoveDragEndEventArgs e)
+        => _logger.LogInformation("WindowMoveDragEnd {Id}", e.Window?.Id);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Unsubscribe();
+    }
+}
+

--- a/src/Dock.Model/Dock.Model.csproj
+++ b/src/Dock.Model/Dock.Model.csproj
@@ -14,6 +14,7 @@
   <Import Project="..\..\build\SignAssembly.props" />
   <Import Project="..\..\build\SourceLink.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Microsoft.Extensions.Logging.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\Dock.Controls.Recycling.Model\Dock.Controls.Recycling.Model.csproj" />


### PR DESCRIPTION
## Summary
- implement `DockEventLogger` to trace FactoryBase events
- register `DockEventLogger` with DI
- wire up logging in DockReactiveUIDiSample
- add Microsoft.Extensions.Logging dependencies

## Testing
- `dotnet test --no-build` *(fails: `dotnet` SDK 9.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b372a2d348321bd4a36cbd20a9037