### PR TITLE
Add layout templates

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -87,3 +87,19 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    ```
 
 The window should show a single document hosted by `DockControl`. See the other guides for more advanced layouts.
+
+## Layout templates
+
+Dock includes helper methods that create common layouts for you. The `LayoutTemplates` class provides:
+
+- `CreateSingleDocumentLayout(IFactory factory)` – a single document dock.
+- `CreateSingleDocumentWithOutputLayout(IFactory factory)` – adds a bottom output pane.
+- `CreateTwoPaneLayout(IFactory factory)` – two horizontal document docks.
+- `CreateMultiWindowLayout(IFactory factory)` – two separate windows.
+
+You can use these helpers instead of manually composing the docks:
+
+```csharp
+var layout = LayoutTemplates.CreateSingleDocumentLayout(factory);
+factory.InitLayout(layout);
+```

--- a/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Dock.Model.Controls;
 using Dock.Model.Core;
+using Dock.Model;
 
 namespace DockMvvmSample.ViewModels;
 
@@ -70,12 +71,14 @@ public class MainWindowViewModel : ObservableObject
             }
         }
 
-        var layout = _factory?.CreateLayout();
-        if (layout is not null)
+        if (_factory is null)
         {
-            _factory?.InitLayout(layout);
-            Layout = layout;
+            return;
         }
+
+        var layout = LayoutTemplates.CreateSingleDocumentLayout(_factory);
+        _factory.InitLayout(layout);
+        Layout = layout;
     }
 
     private void DebugFactoryEvents(IFactory factory)

--- a/src/Dock.Model/LayoutTemplates.cs
+++ b/src/Dock.Model/LayoutTemplates.cs
@@ -1,0 +1,126 @@
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace Dock.Model;
+
+/// <summary>
+/// Provides helpers for creating common layouts.
+/// </summary>
+public static class LayoutTemplates
+{
+    /// <summary>
+    /// Creates a simple layout with a single document dock.
+    /// </summary>
+    /// <param name="factory">The factory used to create dock elements.</param>
+    /// <returns>The root dock.</returns>
+    public static IRootDock CreateSingleDocumentLayout(IFactory factory)
+    {
+        var documents = factory.CreateDocumentDock();
+        documents.Id = "Documents";
+        documents.Title = "Documents";
+        documents.VisibleDockables = factory.CreateList<IDockable>();
+        documents.ActiveDockable = null;
+
+        var root = factory.CreateRootDock();
+        root.IsCollapsable = false;
+        root.VisibleDockables = factory.CreateList<IDockable>(documents);
+        root.ActiveDockable = documents;
+        root.DefaultDockable = documents;
+        return root;
+    }
+
+    /// <summary>
+    /// Creates a single document layout with an output tool dock at the bottom.
+    /// </summary>
+    /// <param name="factory">The factory used to create dock elements.</param>
+    /// <returns>The root dock.</returns>
+    public static IRootDock CreateSingleDocumentWithOutputLayout(IFactory factory)
+    {
+        var documents = factory.CreateDocumentDock();
+        documents.Id = "Documents";
+        documents.Title = "Documents";
+        documents.VisibleDockables = factory.CreateList<IDockable>();
+        documents.ActiveDockable = null;
+
+        var output = factory.CreateToolDock();
+        output.Id = "Output";
+        output.Title = "Output";
+        output.Alignment = Alignment.Bottom;
+        output.VisibleDockables = factory.CreateList<IDockable>();
+        output.ActiveDockable = null;
+
+        var main = factory.CreateProportionalDock();
+        main.Orientation = Orientation.Vertical;
+        main.VisibleDockables = factory.CreateList<IDockable>(
+            documents,
+            factory.CreateProportionalDockSplitter(),
+            output);
+        main.ActiveDockable = documents;
+
+        var root = factory.CreateRootDock();
+        root.IsCollapsable = false;
+        root.VisibleDockables = factory.CreateList<IDockable>(main);
+        root.ActiveDockable = main;
+        root.DefaultDockable = main;
+        return root;
+    }
+
+    /// <summary>
+    /// Creates a layout with two document docks arranged horizontally.
+    /// </summary>
+    /// <param name="factory">The factory used to create dock elements.</param>
+    /// <returns>The root dock.</returns>
+    public static IRootDock CreateTwoPaneLayout(IFactory factory)
+    {
+        var left = factory.CreateDocumentDock();
+        left.Id = "Left";
+        left.Title = "Left";
+        left.VisibleDockables = factory.CreateList<IDockable>();
+        left.ActiveDockable = null;
+
+        var right = factory.CreateDocumentDock();
+        right.Id = "Right";
+        right.Title = "Right";
+        right.VisibleDockables = factory.CreateList<IDockable>();
+        right.ActiveDockable = null;
+
+        var main = factory.CreateProportionalDock();
+        main.Orientation = Orientation.Horizontal;
+        main.VisibleDockables = factory.CreateList<IDockable>(
+            left,
+            factory.CreateProportionalDockSplitter(),
+            right);
+        main.ActiveDockable = left;
+
+        var root = factory.CreateRootDock();
+        root.IsCollapsable = false;
+        root.VisibleDockables = factory.CreateList<IDockable>(main);
+        root.ActiveDockable = main;
+        root.DefaultDockable = main;
+        return root;
+    }
+
+    /// <summary>
+    /// Creates a layout with two windows each containing a single document dock.
+    /// </summary>
+    /// <param name="factory">The factory used to create dock elements.</param>
+    /// <returns>The root dock.</returns>
+    public static IRootDock CreateMultiWindowLayout(IFactory factory)
+    {
+        var window1 = factory.CreateDockWindow();
+        window1.Id = "Window1";
+        window1.Title = "Window1";
+        window1.Layout = CreateSingleDocumentLayout(factory);
+
+        var window2 = factory.CreateDockWindow();
+        window2.Id = "Window2";
+        window2.Title = "Window2";
+        window2.Layout = CreateSingleDocumentLayout(factory);
+
+        var root = factory.CreateRootDock();
+        root.IsCollapsable = false;
+        root.Windows = factory.CreateList<IDockWindow>(window1, window2);
+        return root;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `LayoutTemplates` helper with common layout methods
- use template in DockMvvmSample
- document templates in quick start guide

## Testing
- `dotnet format src/Dock.Model/Dock.Model.csproj --no-restore --include src/Dock.Model/LayoutTemplates.cs`
- `dotnet format samples/DockMvvmSample/DockMvvmSample.csproj --no-restore --include samples/DockMvvmSample/ViewModels/MainWindowViewModel.cs`
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_687b3724ee808321870d9bbb4daa9050