### PR TITLE
Add DockLayoutBuilder builder API

### DIFF
--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -113,6 +113,17 @@ public override IRootDock CreateLayout()
 }
 ```
 
+### Using DockLayoutBuilder
+
+`DockLayoutBuilder` wraps the factory methods in a fluent API. The same layout can be created as:
+
+```csharp
+var layout = new DockLayoutBuilder(new DockFactory())
+    .WithDocument(new DocumentViewModel { Id = "Document1", Title = "Document1" })
+    .WithTool(new Tool1ViewModel { Id = "Tool1", Title = "Tool1" }, Alignment.Left)
+    .Build();
+```
+
 ## Docking operations
 
 `FactoryBase` exposes many methods to manipulate the layout at runtime. Some of the most useful ones are:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -55,6 +55,14 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
            return root;
        }
    }
+  ```
+
+   Alternatively you can build the same layout using `DockLayoutBuilder`:
+
+   ```csharp
+   var layout = new DockLayoutBuilder(new DockFactory())
+       .WithDocument(new Document { Id = "Doc1", Title = "Document" })
+       .Build();
    ```
 
    Initialize this layout in `MainWindow.axaml.cs`:

--- a/src/Dock.Model/Builder/DockLayoutBuilder.cs
+++ b/src/Dock.Model/Builder/DockLayoutBuilder.cs
@@ -1,0 +1,105 @@
+using System.Linq;
+using Dock.Model.Core;
+using Dock.Model.Controls;
+
+namespace Dock.Model.Builder;
+
+/// <summary>
+/// Provides a fluent API to build simple Dock layouts.
+/// </summary>
+public class DockLayoutBuilder
+{
+    private readonly IFactory _factory;
+    private readonly IRootDock _root;
+    private readonly IProportionalDock _layout;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockLayoutBuilder"/> class.
+    /// </summary>
+    /// <param name="factory">Factory used to create dockables.</param>
+    public DockLayoutBuilder(IFactory factory)
+    {
+        _factory = factory;
+        _root = _factory.CreateRootDock();
+        _layout = _factory.CreateProportionalDock();
+        _layout.VisibleDockables = _factory.CreateList<IDockable>();
+        _root.VisibleDockables = _factory.CreateList<IDockable>(_layout);
+        _root.DefaultDockable = _layout;
+    }
+
+    private void AddDockable(IDockable dockable)
+    {
+        if (_layout.VisibleDockables is null)
+        {
+            _layout.VisibleDockables = _factory.CreateList<IDockable>();
+        }
+
+        if (_layout.VisibleDockables.Count > 0)
+        {
+            _layout.VisibleDockables.Add(_factory.CreateProportionalDockSplitter());
+        }
+
+        _layout.VisibleDockables.Add(dockable);
+    }
+
+    /// <summary>
+    /// Sets horizontal split orientation.
+    /// </summary>
+    /// <returns>The builder instance.</returns>
+    public DockLayoutBuilder SplitHorizontally()
+    {
+        _layout.Orientation = Orientation.Horizontal;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets vertical split orientation.
+    /// </summary>
+    /// <returns>The builder instance.</returns>
+    public DockLayoutBuilder SplitVertically()
+    {
+        _layout.Orientation = Orientation.Vertical;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a document dock containing the specified document.
+    /// </summary>
+    /// <param name="document">The document to add.</param>
+    /// <returns>The builder instance.</returns>
+    public DockLayoutBuilder WithDocument(IDockable document)
+    {
+        var docDock = _factory.CreateDocumentDock();
+        docDock.VisibleDockables = _factory.CreateList<IDockable>(document);
+        docDock.ActiveDockable = document;
+        AddDockable(docDock);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a tool dock containing the specified tool.
+    /// </summary>
+    /// <param name="tool">The tool to add.</param>
+    /// <param name="alignment">The tool dock alignment.</param>
+    /// <returns>The builder instance.</returns>
+    public DockLayoutBuilder WithTool(IDockable tool, Alignment alignment)
+    {
+        var toolDock = _factory.CreateToolDock();
+        toolDock.Alignment = alignment;
+        toolDock.VisibleDockables = _factory.CreateList<IDockable>(tool);
+        toolDock.ActiveDockable = tool;
+        AddDockable(toolDock);
+        return this;
+    }
+
+    /// <summary>
+    /// Finalizes the layout.
+    /// </summary>
+    /// <returns>The root dock.</returns>
+    public IRootDock Build()
+    {
+        _factory.InitLayout(_root);
+        return _root;
+    }
+}
+

--- a/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
+++ b/tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Mvvm\Dock.Model.Mvvm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dock.Model.UnitTests/DockLayoutBuilderTests.cs
+++ b/tests/Dock.Model.UnitTests/DockLayoutBuilderTests.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using Dock.Model.Builder;
+using Dock.Model.Core;
+using Dock.Model.Mvvm;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace Dock.Model.UnitTests;
+
+public class DockLayoutBuilderTests
+{
+    [Fact]
+    public void Build_SimpleLayout_ReturnsRootDock()
+    {
+        var factory = new Factory();
+        var doc = new Document { Id = "Doc1", Title = "Doc" };
+
+        var root = new DockLayoutBuilder(factory)
+            .WithDocument(doc)
+            .Build();
+
+        var layout = Assert.IsType<RootDock>(root);
+        var main = Assert.IsType<ProportionalDock>(layout.VisibleDockables?.First());
+        var documentDock = Assert.IsType<DocumentDock>(main.VisibleDockables?.First());
+        Assert.Equal(doc, documentDock.ActiveDockable);
+    }
+
+    [Fact]
+    public void Build_ComplexLayout_CreatesSplitHierarchy()
+    {
+        var factory = new Factory();
+        var doc1 = new Document { Id = "D1", Title = "One" };
+        var doc2 = new Document { Id = "D2", Title = "Two" };
+        var tool = new Tool { Id = "T1", Title = "Tool" };
+
+        var root = new DockLayoutBuilder(factory)
+            .SplitHorizontally()
+            .WithDocument(doc1)
+            .WithDocument(doc2)
+            .WithTool(tool, Alignment.Right)
+            .Build();
+
+        var main = Assert.IsType<ProportionalDock>(root.VisibleDockables?.First());
+        Assert.Equal(Orientation.Horizontal, main.Orientation);
+        Assert.Equal(5, main.VisibleDockables?.Count);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DockLayoutBuilder to build simple layouts fluently
- document the builder in quick-start and MVVM guide
- test the new builder logic

## Testing
- `dotnet build tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj --no-incremental --nologo`
- `dotnet test tests/Dock.Model.UnitTests/Dock.Model.UnitTests.csproj --no-build --verbosity minimal`
- `dotnet test --no-build` *(fails: The argument <path> is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687b3722821c8321a05ee3b3b6f73b22