### PR TITLE
Add DI options and event logger

### DIFF
--- a/docs/dock-dependency-injection.md
+++ b/docs/dock-dependency-injection.md
@@ -12,4 +12,39 @@ services.AddDock<MyDockFactory, DockSerializer>();
 
 This registers `IDockState`, your factory implementation as `IFactory`, and the serializer as `IDockSerializer`.
 
+## Configure the factory
 
+`AddDock` accepts an optional callback allowing you to provide a default layout created by the factory:
+
+```csharp
+services.AddDock<MyDockFactory, DockSerializer>(options =>
+{
+    options.Layout = new MyDockFactory().CreateLayout();
+});
+```
+
+The layout instance is registered as a singleton so it can be injected into your views or view models.
+
+## Enable event logging
+
+If you want to log docking events, use `AddDockWithLogger` instead. It registers `DockEventLogger` which subscribes to the factory events and writes them using `ILogger`:
+
+```csharp
+services.AddDockWithLogger<MyDockFactory, DockSerializer>();
+```
+
+## Dock settings options
+
+Drag distances and window magnetism can be configured through `DockSettingsOptions`:
+
+```csharp
+services.Configure<DockSettingsOptions>(o =>
+{
+    o.MinimumHorizontalDragDistance = 6;
+    o.MinimumVerticalDragDistance = 6;
+    o.EnableWindowMagnetism = true;
+    o.WindowMagnetDistance = 16;
+});
+```
+
+`AddDock` registers a configurator that applies these values to `DockSettings` when the container is built.

--- a/docs/dock-settings.md
+++ b/docs/dock-settings.md
@@ -73,6 +73,21 @@ AppBuilder.Configure<App>()
     });
 ```
 
+### Dependency injection
+
+The same options can be provided through `IOptions<DockSettingsOptions>` when using the dependency injection helpers:
+
+```csharp
+services.Configure<DockSettingsOptions>(o =>
+{
+    o.MinimumHorizontalDragDistance = 6;
+    o.MinimumVerticalDragDistance = 6;
+    o.EnableWindowMagnetism = true;
+    o.WindowMagnetDistance = 16;
+});
+```
+
+`AddDock` applies these values to `DockSettings` at startup.
 ## Hide on close
 
 `FactoryBase` exposes two properties that control whether closing a tool or

--- a/src/Dock.Model.Extensions.DependencyInjection/DockEventLogger.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/DockEventLogger.cs
@@ -1,0 +1,77 @@
+using Dock.Model.Core;
+using Dock.Model.Core.Events;
+using Microsoft.Extensions.Logging;
+
+namespace Dock.Model.Extensions.DependencyInjection;
+
+/// <summary>
+/// Logs events raised by <see cref="FactoryBase"/>.
+/// </summary>
+public sealed class DockEventLogger : IDisposable
+{
+    private readonly FactoryBase _factory;
+    private readonly ILogger<DockEventLogger> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockEventLogger"/> class.
+    /// </summary>
+    /// <param name="factory">The dock factory.</param>
+    /// <param name="logger">The logger instance.</param>
+    public DockEventLogger(FactoryBase factory, ILogger<DockEventLogger> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+
+        Subscribe();
+    }
+
+    private void Subscribe()
+    {
+        _factory.ActiveDockableChanged += OnActiveDockableChanged;
+        _factory.DockableAdded += OnDockableAdded;
+        _factory.DockableRemoved += OnDockableRemoved;
+        _factory.WindowOpened += OnWindowOpened;
+        _factory.WindowClosed += OnWindowClosed;
+    }
+
+    private void Unsubscribe()
+    {
+        _factory.ActiveDockableChanged -= OnActiveDockableChanged;
+        _factory.DockableAdded -= OnDockableAdded;
+        _factory.DockableRemoved -= OnDockableRemoved;
+        _factory.WindowOpened -= OnWindowOpened;
+        _factory.WindowClosed -= OnWindowClosed;
+    }
+
+    private void OnActiveDockableChanged(object? sender, ActiveDockableChangedEventArgs e)
+    {
+        _logger.LogInformation("Active dockable changed: {Title}", e.Dockable?.Title);
+    }
+
+    private void OnDockableAdded(object? sender, DockableAddedEventArgs e)
+    {
+        _logger.LogInformation("Dockable added: {Title}", e.Dockable?.Title);
+    }
+
+    private void OnDockableRemoved(object? sender, DockableRemovedEventArgs e)
+    {
+        _logger.LogInformation("Dockable removed: {Title}", e.Dockable?.Title);
+    }
+
+    private void OnWindowOpened(object? sender, WindowOpenedEventArgs e)
+    {
+        _logger.LogInformation("Window opened: {Title}", e.Window?.Title);
+    }
+
+    private void OnWindowClosed(object? sender, WindowClosedEventArgs e)
+    {
+        _logger.LogInformation("Window closed: {Title}", e.Window?.Title);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Unsubscribe();
+    }
+}
+

--- a/src/Dock.Model.Extensions.DependencyInjection/DockSettingsOptionsPostConfigurator.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/DockSettingsOptionsPostConfigurator.cs
@@ -1,0 +1,35 @@
+using Dock.Settings;
+using Microsoft.Extensions.Options;
+
+namespace Dock.Model.Extensions.DependencyInjection;
+
+/// <summary>
+/// Applies <see cref="DockSettingsOptions"/> values to <see cref="DockSettings"/>.
+/// </summary>
+internal sealed class DockSettingsOptionsPostConfigurator : IPostConfigureOptions<DockSettingsOptions>
+{
+    /// <inheritdoc />
+    public void PostConfigure(string? name, DockSettingsOptions options)
+    {
+        if (options.MinimumHorizontalDragDistance != null)
+        {
+            DockSettings.MinimumHorizontalDragDistance = options.MinimumHorizontalDragDistance.Value;
+        }
+
+        if (options.MinimumVerticalDragDistance != null)
+        {
+            DockSettings.MinimumVerticalDragDistance = options.MinimumVerticalDragDistance.Value;
+        }
+
+        if (options.EnableWindowMagnetism != null)
+        {
+            DockSettings.EnableWindowMagnetism = options.EnableWindowMagnetism.Value;
+        }
+
+        if (options.WindowMagnetDistance != null)
+        {
+            DockSettings.WindowMagnetDistance = options.WindowMagnetDistance.Value;
+        }
+    }
+}
+

--- a/src/Dock.Model.Extensions.DependencyInjection/FactoryOptions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/FactoryOptions.cs
@@ -1,0 +1,15 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Extensions.DependencyInjection;
+
+/// <summary>
+/// Options used when configuring Dock services.
+/// </summary>
+public class FactoryOptions
+{
+    /// <summary>
+    /// Gets or sets the default layout instance.
+    /// </summary>
+    public IRootDock? Layout { get; set; }
+}
+

--- a/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Dock.Model.Core;
+using Dock.Settings;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Dock.Model.Extensions.DependencyInjection;
 
@@ -16,8 +18,9 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="TFactory">Implementation of <see cref="IFactory"/>.</typeparam>
     /// <typeparam name="TSerializer">Implementation of <see cref="IDockSerializer"/>.</typeparam>
     /// <param name="services">The service collection.</param>
+    /// <param name="configure">Factory options configuration.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddDock<TFactory, TSerializer>(this IServiceCollection services)
+    public static IServiceCollection AddDock<TFactory, TSerializer>(this IServiceCollection services, Action<FactoryOptions>? configure = null)
         where TFactory : class, IFactory
         where TSerializer : class, IDockSerializer
     {
@@ -26,6 +29,35 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IFactory>(static sp => sp.GetRequiredService<TFactory>());
         services.AddSingleton<TSerializer>();
         services.AddSingleton<IDockSerializer>(static sp => sp.GetRequiredService<TSerializer>());
+
+        services.AddOptions<DockSettingsOptions>();
+        services.AddSingleton<IPostConfigureOptions<DockSettingsOptions>, DockSettingsOptionsPostConfigurator>();
+
+        var options = new FactoryOptions();
+        configure?.Invoke(options);
+
+        if (options.Layout is { })
+        {
+            services.AddSingleton(options.Layout);
+        }
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers Dock services and adds <see cref="DockEventLogger"/>.
+    /// </summary>
+    /// <typeparam name="TFactory">Implementation of <see cref="IFactory"/>.</typeparam>
+    /// <typeparam name="TSerializer">Implementation of <see cref="IDockSerializer"/>.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Factory options configuration.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddDockWithLogger<TFactory, TSerializer>(this IServiceCollection services, Action<FactoryOptions>? configure = null)
+        where TFactory : class, IFactory
+        where TSerializer : class, IDockSerializer
+    {
+        services.AddDock<TFactory, TSerializer>(configure);
+        services.AddSingleton<DockEventLogger>();
         return services;
     }
 }


### PR DESCRIPTION
## Summary
- add FactoryOptions for default layout registration
- add DockEventLogger and DI configurators
- support DockSettingsOptions via IOptions
- document DI setup with configuration examples

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b372ba2708321aadab386fbe15d59