### PR TITLE
Implement ResetLayout support

### DIFF
--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -129,6 +129,15 @@ var newDoc = new DocumentViewModel { Id = "Doc2", Title = "Another" };
 documentDock.AddDocument(newDoc);
 ```
 
+## Resetting the layout
+
+`IRootDock` provides a `ResetLayout` command that restores the original
+layout created during `InitLayout`.
+
+```csharp
+root.ResetLayout.Execute(null);
+```
+
 To drive a "New" command you can assign a delegate to the
 `DocumentFactory` property. The built-in `CreateDocument` command will
 invoke this factory, pass the result to `AddDocument` and activate the

--- a/docs/dock-reactiveui.md
+++ b/docs/dock-reactiveui.md
@@ -127,6 +127,15 @@ creates new documents when its `CreateDocument` command executes. The
 delegate should return an `IDockable` which is then passed to
 `AddDocument` and activated.
 
+## Resetting the layout
+
+Execute the `ResetLayout` command on the root dock to restore the
+initial layout.
+
+```csharp
+Layout?.ResetLayout.Execute(null);
+```
+
 ## Events
 
 All the events shown in the MVVM guide are present here as well. Subscribe to them in the same way using ReactiveUI commands or observables.

--- a/src/Dock.Model.Mvvm/Controls/RootDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/RootDock.cs
@@ -33,6 +33,7 @@ public class RootDock : DockBase, IRootDock
     {
         ShowWindows = new RelayCommand(() => _navigateAdapter.ShowWindows());
         ExitWindows = new RelayCommand(() => _navigateAdapter.ExitWindows());
+        ResetLayout = new RelayCommand(() => Factory?.ResetLayout(this));
     }
 
     /// <inheritdoc/>
@@ -114,4 +115,8 @@ public class RootDock : DockBase, IRootDock
     /// <inheritdoc/>
     [IgnoreDataMember]
     public ICommand ExitWindows { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand ResetLayout { get; }
 }

--- a/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/RootDock.cs
@@ -24,6 +24,7 @@ public partial class RootDock : DockBase, IRootDock
         _isFocusableRoot = true;
         ShowWindows = ReactiveCommand.Create(() => _navigateAdapter.ShowWindows());
         ExitWindows = ReactiveCommand.Create(() => _navigateAdapter.ExitWindows());
+        ResetLayout = ReactiveCommand.Create(() => Factory?.ResetLayout(this));
     }
 
     /// <inheritdoc/>
@@ -69,4 +70,8 @@ public partial class RootDock : DockBase, IRootDock
     /// <inheritdoc/>
     [IgnoreDataMember]
     public ICommand ExitWindows { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand ResetLayout { get; }
 }

--- a/src/Dock.Model/Controls/IRootDock.cs
+++ b/src/Dock.Model/Controls/IRootDock.cs
@@ -65,4 +65,9 @@ public interface IRootDock : IDock
     /// Exit windows.
     /// </summary>
     ICommand ExitWindows { get; }
+
+    /// <summary>
+    /// Reset layout to the initial state.
+    /// </summary>
+    ICommand ResetLayout { get; }
 }

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -202,13 +202,19 @@ public partial interface IFactory
     /// <param name="id">The dockable id.</param>
     /// <typeparam name="T">The dockable return type.</typeparam>
     /// <returns>The located dockable.</returns>
-    T? GetDockable<T>(string id) where T: class, IDockable;
+    T? GetDockable<T>(string id) where T : class, IDockable;
 
     /// <summary>
     /// Initialize layout.
     /// </summary>
     /// <param name="layout">The layout to initialize.</param>
     void InitLayout(IDockable layout);
+
+    /// <summary>
+    /// Reset layout to its initial state.
+    /// </summary>
+    /// <param name="root">The root dock.</param>
+    void ResetLayout(IRootDock root);
 
     /// <summary>
     /// Initialize dockable.
@@ -386,7 +392,7 @@ public partial interface IFactory
     /// </summary>
     /// <param name="dockable">The dockable to remove.</param>
     void CloseDockable(IDockable dockable);
-        
+
     /// <summary>
     /// Calls <see cref="IFactory.CloseDockable"/> on all <see cref="IDock.VisibleDockables"/> of the dockable owner, excluding the dockable itself.
     /// </summary>


### PR DESCRIPTION
## Summary
- keep a clone of the initial layout
- add `ResetLayout` to `FactoryBase` and `IFactory`
- expose `ResetLayout` command on RootDock models
- document resetting layouts

## Testing
- `dotnet format src/Dock.Model/Dock.Model.csproj --no-restore --include src/Dock.Model/FactoryBase.Init.cs src/Dock.Model/Core/IFactory.cs src/Dock.Model/Controls/IRootDock.cs`
- `dotnet format src/Dock.Model.Mvvm/Dock.Model.Mvvm.csproj --no-restore --include src/Dock.Model.Mvvm/Controls/RootDock.cs`
- `dotnet format src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj --no-restore --include src/Dock.Model.ReactiveUI/Controls/RootDock.cs`
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687b37283290832185a1e3bd710d12f1