### PR TITLE
Add factory options support

### DIFF
--- a/docs/dock-dependency-injection.md
+++ b/docs/dock-dependency-injection.md
@@ -12,4 +12,21 @@ services.AddDock<MyDockFactory, DockSerializer>();
 
 This registers `IDockState`, your factory implementation as `IFactory`, and the serializer as `IDockSerializer`.
 
+## Configure factory options
+
+`AddDock` also has an overload accepting an `IConfiguration` section. The section is bound to `FactoryOptions` which you can inject using `IOptions<FactoryOptions>`:
+
+```csharp
+var section = configuration.GetSection("Dock:Factory");
+services.AddDock<MyDockFactory, DockSerializer>(section);
+```
+
+Use the resolved options when initializing your layout:
+
+```csharp
+var options = provider.GetRequiredService<IOptions<FactoryOptions>>().Value;
+factory.InitLayout(layout, options);
+```
+
+Only the `HideToolsOnClose` and `HideDocumentsOnClose` flags can be configured through configuration. The locator dictionaries should be set programmatically.
 

--- a/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Dock.Model.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Dock.Model.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 
 namespace Dock.Model.Extensions.DependencyInjection;
 
@@ -27,5 +28,21 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<TSerializer>();
         services.AddSingleton<IDockSerializer>(static sp => sp.GetRequiredService<TSerializer>());
         return services;
+    }
+
+    /// <summary>
+    /// Registers Dock model services and binds <see cref="FactoryOptions"/> from configuration.
+    /// </summary>
+    /// <typeparam name="TFactory">Implementation of <see cref="IFactory"/>.</typeparam>
+    /// <typeparam name="TSerializer">Implementation of <see cref="IDockSerializer"/>.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configuration">Configuration section for options.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddDock<TFactory, TSerializer>(this IServiceCollection services, IConfiguration configuration)
+        where TFactory : class, IFactory
+        where TSerializer : class, IDockSerializer
+    {
+        services.Configure<FactoryOptions>(configuration);
+        return services.AddDock<TFactory, TSerializer>();
     }
 }

--- a/src/Dock.Model/FactoryBase.Init.cs
+++ b/src/Dock.Model/FactoryBase.Init.cs
@@ -34,6 +34,44 @@ public abstract partial class FactoryBase
         }
     }
 
+    /// <summary>
+    /// Initializes layout using provided <see cref="FactoryOptions"/>.
+    /// </summary>
+    /// <param name="layout">The layout to initialize.</param>
+    /// <param name="options">The options to apply.</param>
+    public virtual void InitLayout(IDockable layout, FactoryOptions? options)
+    {
+        if (options != null)
+        {
+            if (options.ContextLocator != null)
+            {
+                ContextLocator = options.ContextLocator;
+            }
+
+            if (options.DockableLocator != null)
+            {
+                DockableLocator = options.DockableLocator;
+            }
+
+            if (options.HostWindowLocator != null)
+            {
+                HostWindowLocator = options.HostWindowLocator;
+            }
+
+            if (options.HideToolsOnClose != null)
+            {
+                HideToolsOnClose = options.HideToolsOnClose.Value;
+            }
+
+            if (options.HideDocumentsOnClose != null)
+            {
+                HideDocumentsOnClose = options.HideDocumentsOnClose.Value;
+            }
+        }
+
+        InitLayout(layout);
+    }
+
     /// <inheritdoc/>
     public virtual void InitDockable(IDockable dockable, IDockable? owner)
     {

--- a/src/Dock.Model/FactoryOptions.cs
+++ b/src/Dock.Model/FactoryOptions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Dock.Model.Core;
+
+namespace Dock.Model;
+
+/// <summary>
+/// Configuration options for <see cref="FactoryBase"/>.
+/// </summary>
+public class FactoryOptions
+{
+    /// <summary>
+    /// Optional context locator dictionary.
+    /// </summary>
+    public Dictionary<string, Func<object?>>? ContextLocator { get; set; }
+
+    /// <summary>
+    /// Optional dockable locator dictionary.
+    /// </summary>
+    public IDictionary<string, Func<IDockable?>>? DockableLocator { get; set; }
+
+    /// <summary>
+    /// Optional host window locator dictionary.
+    /// </summary>
+    public Dictionary<string, Func<IHostWindow?>>? HostWindowLocator { get; set; }
+
+    /// <summary>
+    /// Optional hide tools flag.
+    /// </summary>
+    public bool? HideToolsOnClose { get; set; }
+
+    /// <summary>
+    /// Optional hide documents flag.
+    /// </summary>
+    public bool? HideDocumentsOnClose { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- add `FactoryOptions` encapsulating optional locators and hide flags
- overload `FactoryBase.InitLayout` to apply `FactoryOptions`
- allow `AddDock` to bind `FactoryOptions` from `IConfiguration`
- document the new options pattern

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687b37262b5883218fd6c6e992392fad