### PR TITLE
Add MultiWindow sample

### DIFF
--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -106,5 +106,6 @@ commands can call `SaveAsync` and `LoadAsync` to persist user changes.
 - `samples/DockReactiveUISample` – ReactiveUI variant.
 - `samples/DockXamlSample` – XAML-only layout with serialization.
 - `samples/DockCodeOnlySample` – layout defined fully in C#.
+- `samples/MultiWindowSample` – floating windows with persisted layout.
 
 For an overview of all guides see the [documentation index](README.md).

--- a/docs/multi-window-sample.md
+++ b/docs/multi-window-sample.md
@@ -1,0 +1,11 @@
+# MultiWindowSample
+
+This sample demonstrates how to open multiple top‑level windows using Dock. It follows the steps from the complex layouts guide to float dockables into separate windows and persist the resulting layout.
+
+Run the application with:
+
+```bash
+dotnet run --project samples/MultiWindowSample
+```
+
+On first start the sample creates two windows. Moving or closing them then exiting writes `layout.json`. The file is loaded on the next run so the previous window arrangement reappears.

--- a/samples/MultiWindowSample/MultiWindowSample.csproj
+++ b/samples/MultiWindowSample/MultiWindowSample.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
+  <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Newtonsoft\Dock.Serializer.Newtonsoft.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MultiWindowSample/Program.cs
+++ b/samples/MultiWindowSample/Program.cs
@@ -1,0 +1,112 @@
+using System;
+using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Dock.Model.Serialization;
+
+namespace MultiWindowSample;
+
+internal class Program
+{
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    private static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}
+
+public class App : Application
+{
+    public override void OnFrameworkInitializationCompleted()
+    {
+        Styles.Add(new FluentTheme());
+        Styles.Add(new DockFluentTheme());
+        RequestedThemeVariant = ThemeVariant.Dark;
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var dockControl = new DockControl();
+            var factory = new MultiFactory();
+            var serializer = new DockSerializer();
+            var state = new DockState();
+
+            const string path = "layout.json";
+            IRootDock layout;
+            if (File.Exists(path))
+            {
+                using var stream = File.OpenRead(path);
+                layout = serializer.Load<IRootDock?>(stream) ?? factory.CreateLayout();
+                factory.InitLayout(layout);
+                state.Restore(layout);
+            }
+            else
+            {
+                layout = factory.CreateLayout();
+                factory.InitLayout(layout);
+
+                var floating = factory.CreateLayout();
+                factory.InitLayout(floating);
+                factory.FloatDockable(layout, floating);
+            }
+
+            dockControl.Factory = factory;
+            dockControl.Layout = layout;
+
+            desktop.MainWindow = new Window
+            {
+                Width = 800,
+                Height = 600,
+                Content = dockControl
+            };
+
+            desktop.Exit += (_, _) =>
+            {
+                state.Save(layout);
+                using var stream = File.Create(path);
+                serializer.Save(stream, layout);
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}
+
+public class MultiFactory : Factory
+{
+    private int _index;
+
+    public override IRootDock CreateLayout()
+    {
+        var count = ++_index;
+        var doc = new Document { Id = $"Doc{count}", Title = $"Document {count}" };
+
+        var root = CreateRootDock();
+        root.VisibleDockables = CreateList<IDockable>(
+            new DocumentDock
+            {
+                VisibleDockables = CreateList<IDockable>(doc),
+                ActiveDockable = doc
+            });
+        return root;
+    }
+
+    public override IHostWindow CreateWindowFrom(IDockWindow source)
+    {
+        var window = base.CreateWindowFrom(source);
+        window.Title = $"Dock - {source.Id}";
+        return window;
+    }
+}


### PR DESCRIPTION
## Summary
- add MultiWindowSample illustrating floating windows and persistence
- document sample usage
- reference sample in Dock reference docs

## Testing
- `dotnet format samples/MultiWindowSample/MultiWindowSample.csproj --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b4977058c8321bc69b47f6cb1f277