### PR TITLE
Add plug-in host sample

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ application created with the .NET SDK. For build instructions and an overview of
 
 ## How-to guides
 - [Complex layout tutorials](dock-complex-layouts.md) – Multi-window and plug-in walkthroughs.
+- [Plug-in host sample](plugin-host-sample.md) – Example of dynamic plug-in loading.
 
 ## Concepts
 
@@ -79,3 +80,4 @@ including both `Dock.Avalonia` and `Dock.Model.Mvvm`.
 ## Troubleshooting
 
 - [FAQ](dock-faq.md) – Solutions to common issues.
+

--- a/docs/plugin-host-sample.md
+++ b/docs/plugin-host-sample.md
@@ -1,0 +1,23 @@
+# Plug-in host sample
+
+The `PluginHostSample` demonstrates loading dockables from external plug-ins.
+
+1. Define a shared `IPlugin` interface returning an `IDockable` instance.
+2. Build plug-in assemblies that implement this contract.
+3. At startup the host scans a `Plugins` directory, loads each assembly and adds the created dockables to the layout:
+
+```csharp
+var assembly = Assembly.LoadFrom(path);
+var plugins = assembly
+    .GetTypes()
+    .Where(t => typeof(IPlugin).IsAssignableFrom(t) && !t.IsAbstract)
+    .Select(Activator.CreateInstance)
+    .OfType<IPlugin>();
+foreach (var plugin in plugins)
+{
+    factory.AddDockable(documentDock, plugin.CreateDockable());
+}
+```
+
+Initialize the layout once and save it so that plug-in windows reappear on the next run.
+

--- a/samples/PluginHostSample/PluginContracts/IPlugin.cs
+++ b/samples/PluginHostSample/PluginContracts/IPlugin.cs
@@ -1,0 +1,9 @@
+using Dock.Model.Core;
+
+namespace PluginContracts;
+
+public interface IPlugin
+{
+    IDockable CreateDockable();
+}
+

--- a/samples/PluginHostSample/PluginContracts/PluginContracts.csproj
+++ b/samples/PluginHostSample/PluginContracts/PluginContracts.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>False</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Dock.Model\Dock.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/PluginHostSample/PluginHostSample/PluginHostSample.csproj
+++ b/samples/PluginHostSample/PluginHostSample/PluginHostSample.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <AvaloniaNameGeneratorBehavior>OnlyProperties</AvaloniaNameGeneratorBehavior>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\..\build\Avalonia.props" />
+  <Import Project="..\..\..\build\Avalonia.Themes.Fluent.props" />
+  <Import Project="..\..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\..\build\Avalonia.Diagnostics.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluginContracts\PluginContracts.csproj" />
+    <ProjectReference Include="..\..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />
+    <ProjectReference Include="..\..\..\src\Dock.Serializer.Newtonsoft\Dock.Serializer.Newtonsoft.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/PluginHostSample/PluginHostSample/Program.cs
+++ b/samples/PluginHostSample/PluginHostSample/Program.cs
@@ -1,0 +1,93 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Dock.Settings;
+using PluginContracts;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace PluginHostSample;
+
+internal class Program
+{
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace();
+}
+
+public class App : Application
+{
+    public override void OnFrameworkInitializationCompleted()
+    {
+        Styles.Add(new FluentTheme());
+        Styles.Add(new DockFluentTheme());
+        RequestedThemeVariant = ThemeVariant.Dark;
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var dockControl = new DockControl();
+            var factory = new Factory();
+
+            var documents = new DocumentDock
+            {
+                Id = "Documents",
+                Title = "Documents"
+            };
+
+            var root = factory.CreateRootDock();
+            root.VisibleDockables = factory.CreateList<IDockable>(documents);
+            root.DefaultDockable = documents;
+
+            var pluginsDir = Path.Combine(AppContext.BaseDirectory, "Plugins");
+            if (Directory.Exists(pluginsDir))
+            {
+                foreach (var path in Directory.GetFiles(pluginsDir, "*.dll"))
+                {
+                    var assembly = Assembly.LoadFrom(path);
+                    var plugins = assembly
+                        .GetTypes()
+                        .Where(t => typeof(IPlugin).IsAssignableFrom(t) && !t.IsAbstract)
+                        .Select(Activator.CreateInstance)
+                        .OfType<IPlugin>();
+
+                    foreach (var plugin in plugins)
+                    {
+                        var dockable = plugin.CreateDockable();
+                        factory.AddDockable(documents, dockable);
+                    }
+                }
+            }
+
+            factory.InitLayout(root);
+            dockControl.Factory = factory;
+            dockControl.Layout = root;
+
+            desktop.MainWindow = new Window
+            {
+                Width = 800,
+                Height = 600,
+                Content = dockControl
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}
+

--- a/samples/PluginHostSample/SamplePlugin/SamplePlugin.csproj
+++ b/samples/PluginHostSample/SamplePlugin/SamplePlugin.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>False</IsPackable>
+  </PropertyGroup>
+
+  <Import Project="..\..\..\build\ReferenceAssemblies.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluginContracts\PluginContracts.csproj" />
+    <ProjectReference Include="..\..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/PluginHostSample/SamplePlugin/TextDocumentPlugin.cs
+++ b/samples/PluginHostSample/SamplePlugin/TextDocumentPlugin.cs
@@ -1,0 +1,14 @@
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using PluginContracts;
+
+namespace SamplePlugin;
+
+public class TextDocumentPlugin : IPlugin
+{
+    public IDockable CreateDockable()
+    {
+        return new Document { Id = "PluginDoc", Title = "Plugin Document" };
+    }
+}
+


### PR DESCRIPTION
## Summary
- showcase dynamic plug-in loading in a new `PluginHostSample`
- implement `IPlugin` contract and example plug-in
- add documentation for plug-in loading steps

## Testing
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687b49764014832182bce2639cf88245