### PR TITLE
Add TitleBar tab layout

### DIFF
--- a/docs/dock-enums.md
+++ b/docs/dock-enums.md
@@ -66,6 +66,7 @@ Controls where document tabs are placed around a document dock. Setting this aff
 | `Top` | Tabs are shown above the document content. |
 | `Left` | Tabs are arranged vertically to the left. |
 | `Right` | Tabs are arranged vertically to the right. |
+| `TitleBar` | Tabs appear horizontally inside the title bar. |
 
 ## GripMode
 

--- a/docs/dock-reference.md
+++ b/docs/dock-reference.md
@@ -45,7 +45,7 @@ from a saved state.
 
 ## Document dock options
 
-`IDocumentDock` exposes two key properties for controlling its tab strip. `EnableWindowDrag` allows the entire window to be dragged via the tab area. `TabsLayout` chooses where the tabs appear using the `DocumentTabLayout` enum.
+`IDocumentDock` exposes two key properties for controlling its tab strip. `EnableWindowDrag` allows the entire window to be dragged via the tab area. `TabsLayout` chooses where the tabs appear using the `DocumentTabLayout` enum, including a `TitleBar` option that places the tabs horizontally in the window chrome.
 
 The factory provides helper methods `SetDocumentDockTabsLayoutLeft`, `SetDocumentDockTabsLayoutTop` and `SetDocumentDockTabsLayoutRight` to change the layout at runtime.
 

--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -75,11 +75,19 @@
       <Setter Property="Height" Value="NaN" />
     </Style>
     
-    <Style Selector="^[TabsLayout=Right]/template/ Grid#PART_Grid">
-      <Setter Property="DockPanel.Dock" Value="Right" />
-      <Setter Property="Width" Value="2" />
-      <Setter Property="Height" Value="NaN" />
-    </Style>
+  <Style Selector="^[TabsLayout=Right]/template/ Grid#PART_Grid">
+    <Setter Property="DockPanel.Dock" Value="Right" />
+    <Setter Property="Width" Value="2" />
+    <Setter Property="Height" Value="NaN" />
+  </Style>
+
+  <Style Selector="^[TabsLayout=TitleBar]/template/ Grid#PART_Grid">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
+
+  <Style Selector="^[TabsLayout=TitleBar]/template/ DocumentTabStrip#PART_TabStrip">
+    <Setter Property="IsVisible" Value="False" />
+  </Style>
 
     <Style Selector="^/template/ Grid#PART_Grid">
       <Setter Property="Background" Value="{DynamicResource DockThemeBorderLowBrush}" />

--- a/src/Dock.Avalonia/Controls/DocumentDockControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentDockControl.axaml
@@ -15,10 +15,28 @@
     <Setter Property="Template">
       <ControlTemplate>
         <DockableControl TrackingMode="Visible">
-          <DocumentControl IsActive="{Binding IsActive}" />
+          <DockPanel>
+            <DocumentTabStrip x:Name="PART_TitleStrip"
+                               ItemsSource="{Binding VisibleDockables}"
+                               SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
+                               CanCreateItem="{Binding CanCreateDocument}"
+                               IsActive="{Binding IsActive}"
+                               Orientation="Horizontal"
+                               DockPanel.Dock="Top"
+                               IsVisible="False" />
+            <DocumentControl x:Name="PART_Document" IsActive="{Binding IsActive}" TabsLayout="{Binding TabsLayout}" />
+          </DockPanel>
         </DockableControl>
       </ControlTemplate>
     </Setter>
+
+    <Style Selector="^[TabsLayout=TitleBar]/template/ DocumentTabStrip#PART_TitleStrip">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="^[TabsLayout=TitleBar]/template/ DocumentControl#PART_Document">
+      <Setter Property="TabsLayout" Value="TitleBar" />
+    </Style>
 
   </ControlTheme>
 

--- a/src/Dock.Avalonia/Converters/DocumentTabDockConverter.cs
+++ b/src/Dock.Avalonia/Converters/DocumentTabDockConverter.cs
@@ -28,6 +28,7 @@ public class DocumentTabDockConverter : IValueConverter
             DocumentTabLayout.Left => AC.Dock.Left,
             DocumentTabLayout.Right => AC.Dock.Right,
             DocumentTabLayout.Top => AC.Dock.Top,
+            DocumentTabLayout.TitleBar => AC.Dock.Top,
             _ => AvaloniaProperty.UnsetValue
         };
     }

--- a/src/Dock.Avalonia/Converters/DocumentTabOrientationConverter.cs
+++ b/src/Dock.Avalonia/Converters/DocumentTabOrientationConverter.cs
@@ -26,6 +26,7 @@ public class DocumentTabOrientationConverter : IValueConverter
             DocumentTabLayout.Left => global::Avalonia.Layout.Orientation.Vertical,
             DocumentTabLayout.Right => global::Avalonia.Layout.Orientation.Vertical,
             DocumentTabLayout.Top => global::Avalonia.Layout.Orientation.Horizontal,
+            DocumentTabLayout.TitleBar => global::Avalonia.Layout.Orientation.Horizontal,
             _ => AvaloniaProperty.UnsetValue
         };
     }

--- a/src/Dock.Model/Core/DocumentTabLayout.cs
+++ b/src/Dock.Model/Core/DocumentTabLayout.cs
@@ -16,5 +16,9 @@ public enum DocumentTabLayout
     /// <summary>
     /// Tabs placed on the right.
     /// </summary>
-    Right
+    Right,
+    /// <summary>
+    /// Tabs placed inside the title bar.
+    /// </summary>
+    TitleBar
 }

--- a/tests/Dock.Avalonia.HeadlessTests/ConvertersTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/ConvertersTests.cs
@@ -54,11 +54,13 @@ public class ConvertersTests
         var resultLeft = DocumentTabOrientationConverter.Instance.Convert(DocumentTabLayout.Left, typeof(LayoutOrientation), null, CultureInfo.InvariantCulture);
         var resultRight = DocumentTabOrientationConverter.Instance.Convert(DocumentTabLayout.Right, typeof(LayoutOrientation), null, CultureInfo.InvariantCulture);
         var resultTop = DocumentTabOrientationConverter.Instance.Convert(DocumentTabLayout.Top, typeof(LayoutOrientation), null, CultureInfo.InvariantCulture);
+        var resultTitle = DocumentTabOrientationConverter.Instance.Convert(DocumentTabLayout.TitleBar, typeof(LayoutOrientation), null, CultureInfo.InvariantCulture);
         var resultInvalid = DocumentTabOrientationConverter.Instance.Convert((DocumentTabLayout)123, typeof(LayoutOrientation), null, CultureInfo.InvariantCulture);
 
         Assert.Equal(LayoutOrientation.Vertical, resultLeft);
         Assert.Equal(LayoutOrientation.Vertical, resultRight);
         Assert.Equal(LayoutOrientation.Horizontal, resultTop);
+        Assert.Equal(LayoutOrientation.Horizontal, resultTitle);
         Assert.Equal(AvaloniaProperty.UnsetValue, resultInvalid);
     }
 
@@ -68,11 +70,13 @@ public class ConvertersTests
         var resultLeft = DocumentTabDockConverter.Instance.Convert(DocumentTabLayout.Left, typeof(AC.Dock), null, CultureInfo.InvariantCulture);
         var resultRight = DocumentTabDockConverter.Instance.Convert(DocumentTabLayout.Right, typeof(AC.Dock), null, CultureInfo.InvariantCulture);
         var resultTop = DocumentTabDockConverter.Instance.Convert(DocumentTabLayout.Top, typeof(AC.Dock), null, CultureInfo.InvariantCulture);
+        var resultTitle = DocumentTabDockConverter.Instance.Convert(DocumentTabLayout.TitleBar, typeof(AC.Dock), null, CultureInfo.InvariantCulture);
         var resultInvalid = DocumentTabDockConverter.Instance.Convert((DocumentTabLayout)123, typeof(AC.Dock), null, CultureInfo.InvariantCulture);
 
         Assert.Equal(AC.Dock.Left, resultLeft);
         Assert.Equal(AC.Dock.Right, resultRight);
         Assert.Equal(AC.Dock.Top, resultTop);
+        Assert.Equal(AC.Dock.Top, resultTitle);
         Assert.Equal(AvaloniaProperty.UnsetValue, resultInvalid);
     }
 

--- a/tests/Dock.Avalonia.HeadlessTests/DocumentDockPropertiesTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DocumentDockPropertiesTests.cs
@@ -52,4 +52,13 @@ public class DocumentDockPropertiesTests
 
         Assert.Equal(DocumentTabLayout.Top, dock.TabsLayout);
     }
+
+    [AvaloniaFact]
+    public void Set_TabsLayout_TitleBar()
+    {
+        var dock = new DocumentDock();
+        dock.TabsLayout = DocumentTabLayout.TitleBar;
+
+        Assert.Equal(DocumentTabLayout.TitleBar, dock.TabsLayout);
+    }
 }


### PR DESCRIPTION
## Summary
- add `TitleBar` enum value for document tabs
- map `TitleBar` to horizontal orientation and top dock
- hide tab strip in `DocumentControl` when using `TitleBar`
- show tab strip in document dock title bar
- document new layout option
- test converter and property behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b49b9b2388321ba01055207da5578