### PR TITLE
Add tab strip host to title bar

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -513,4 +513,16 @@ public class HostWindow : Window, IHostWindow
     {
         DataContext = layout;
     }
+
+    /// <summary>
+    /// Sets the tab strip displayed in the window title bar.
+    /// </summary>
+    /// <param name="tabStrip">The tab strip control.</param>
+    public void SetTitleBarTabStrip(Control? tabStrip)
+    {
+        if (_hostWindowTitleBar is { })
+        {
+            _hostWindowTitleBar.TabStrip = tabStrip;
+        }
+    }
 }

--- a/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml
+++ b/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml
@@ -20,6 +20,7 @@
           <Panel x:Name="PART_MouseTracker" Height="1" VerticalAlignment="Top" />
           <Panel x:Name="PART_Container">
             <Border x:Name="PART_Background" Background="{TemplateBinding Background}" />
+            <ContentPresenter x:Name="PART_TabStripHost" />
             <CaptionButtons x:Name="PART_CaptionButtons" VerticalAlignment="Top" HorizontalAlignment="Right" Foreground="{TemplateBinding Foreground}" />
           </Panel>
         </Panel>

--- a/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
@@ -14,9 +14,28 @@ namespace Dock.Avalonia.Controls;
 /// Interaction logic for <see cref="HostWindowTitleBar"/> xaml.
 /// </summary>
 [TemplatePart("PART_Background", typeof(Control))]
+[TemplatePart("PART_TabStripHost", typeof(ContentPresenter))]
 public class HostWindowTitleBar : TitleBar
 {
     internal Control? BackgroundControl { get; private set; }
+    internal ContentPresenter? TabStripHost { get; private set; }
+    private Control? _tabStrip;
+
+    /// <summary>
+    /// Gets or sets the tab strip displayed in the title bar.
+    /// </summary>
+    public Control? TabStrip
+    {
+        get => _tabStrip;
+        set
+        {
+            _tabStrip = value;
+            if (TabStripHost is { })
+            {
+                TabStripHost.Content = value;
+            }
+        }
+    }
 
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(HostWindowTitleBar);
@@ -27,5 +46,10 @@ public class HostWindowTitleBar : TitleBar
         base.OnApplyTemplate(e);
 
         BackgroundControl = e.NameScope.Find<Control>("PART_Background");
+        TabStripHost = e.NameScope.Find<ContentPresenter>("PART_TabStripHost");
+        if (TabStripHost is { })
+        {
+            TabStripHost.Content = TabStrip;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- include a `ContentPresenter` for tabs in `HostWindowTitleBar` template
- expose `TabStrip` property on `HostWindowTitleBar`
- add helper on `HostWindow` to assign a tab strip to the title bar

## Testing
- `dotnet test` *(fails: .NET SDK 9.0.100 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687b49b755808321bd6568ea1114f07d