### PR TITLE
Add DockManagerRulesSample showing custom DockManager

### DIFF
--- a/Dock.sln
+++ b/Dock.sln
@@ -81,6 +81,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DockXamlSample", "samples\D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DockCodeOnlySample", "samples\DockCodeOnlySample\DockCodeOnlySample.csproj", "{0A7D7571-2957-4891-A4F1-3EE5E513CE90}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DockManagerRulesSample", "samples\DockManagerRulesSample\DockManagerRulesSample.csproj", "{8B31708E-D54B-4662-864D-1B1E6D338E6F}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.Avalonia.UnitTests", "tests\Dock.Model.Avalonia.UnitTests\Dock.Model.Avalonia.UnitTests.csproj", "{EC6AB3C6-7630-40AA-84CC-3BE17E77C63B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dock.Model.UnitTests", "tests\Dock.Model.UnitTests\Dock.Model.UnitTests.csproj", "{D1354C0E-83C4-4D48-A5ED-0B153A26DC83}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Architecture overview](dock-architecture.md) – High level design of the docking system.
 - [Deep dive](dock-deep-dive.md) – Internals of `DockControl`.
 - [DockManager guide](dock-manager-guide.md) – When and how to customize `DockManager`.
+- [DockManager rules sample](dock-manager-sample.md) – Example subclass preventing certain dock actions.
 - [Styling and theming](dock-styling.md) – Customize the appearance of Dock controls.
 - [Custom themes](dock-custom-theme.md) – Build and apply your own theme.
 - [Context menus](dock-context-menus.md) – Localize or replace built in menus.

--- a/docs/dock-manager-sample.md
+++ b/docs/dock-manager-sample.md
@@ -1,0 +1,58 @@
+# DockManagerRulesSample
+
+This sample shows how to subclass `DockManager` to enforce custom docking rules.
+It builds a small layout in code and assigns the custom manager to
+`DockControl`.
+
+## RulesDockManager
+
+`RulesDockManager` derives from `DockManager` and overrides the validation
+methods for tools and documents. Tools are prevented from floating into
+separate windows while documents cannot be split vertically.
+
+```csharp
+public class RulesDockManager : DockManager
+{
+    public override bool ValidateTool(ITool sourceTool, IDockable target, DragAction action, DockOperation operation, bool execute)
+    {
+        if (operation == DockOperation.Window)
+            return false;
+        return base.ValidateTool(sourceTool, target, action, operation, execute);
+    }
+
+    public override bool ValidateDocument(IDocument sourceDocument, IDockable target, DragAction action, DockOperation operation, bool execute)
+    {
+        if (operation == DockOperation.Top || operation == DockOperation.Bottom)
+            return false;
+        return base.ValidateDocument(sourceDocument, target, action, operation, execute);
+    }
+}
+```
+
+Assign the manager before showing the window:
+
+```csharp
+var dockManager = new RulesDockManager();
+var dockControl = new DockControl
+{
+    DockManager = dockManager
+};
+```
+
+The remaining layout code matches the `DockCodeOnlySample` and demonstrates the
+restricted behaviour when dragging tabs.
+
+## Running the sample
+
+1. Navigate to `samples/DockManagerRulesSample`.
+2. Restore and build:
+   ```bash
+   dotnet build
+   ```
+3. Run the application:
+   ```bash
+   dotnet run
+   ```
+
+Try dragging a tool to float it or splitting a document vertically. The drag
+indicators will not appear because the manager disallows these operations.

--- a/samples/DockManagerRulesSample/DockManagerRulesSample.csproj
+++ b/samples/DockManagerRulesSample/DockManagerRulesSample.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
+  <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.Diagnostics.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Newtonsoft\Dock.Serializer.Newtonsoft.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/DockManagerRulesSample/Program.cs
+++ b/samples/DockManagerRulesSample/Program.cs
@@ -1,0 +1,111 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+
+namespace DockManagerRulesSample;
+
+
+internal class Program
+{
+    [STAThread]
+    static void Main(string[] args)
+    {
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+}
+
+public class App : Application
+{
+    public override void OnFrameworkInitializationCompleted()
+    {
+        Styles.Add(new FluentTheme());
+        Styles.Add(new DockFluentTheme());
+        RequestedThemeVariant = ThemeVariant.Dark;
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            var dockManager = new RulesDockManager();
+            var dockControl = new DockControl
+            {
+                DockManager = dockManager
+            };
+
+            var factory = new Factory();
+
+            var documentDock = new DocumentDock
+            {
+                Id = "Documents",
+                IsCollapsable = false,
+                CanCreateDocument = true
+            };
+
+            documentDock.DocumentFactory = () =>
+            {
+                var index = documentDock.VisibleDockables?.Count ?? 0;
+                return new Document { Id = $"Doc{index + 1}", Title = $"Document {index + 1}" };
+            };
+
+            var document = new Document { Id = "Doc1", Title = "Document 1" };
+            documentDock.VisibleDockables = factory.CreateList<IDockable>(document);
+            documentDock.ActiveDockable = document;
+
+            var leftTool = new Tool { Id = "Tool1", Title = "Tool 1" };
+            var bottomTool = new Tool { Id = "Tool2", Title = "Output" };
+
+            var mainLayout = new ProportionalDock
+            {
+                Orientation = Orientation.Horizontal,
+                VisibleDockables = factory.CreateList<IDockable>(
+                    new ToolDock
+                    {
+                        Id = "LeftPane",
+                        Alignment = Alignment.Left,
+                        Proportion = 0.25,
+                        VisibleDockables = factory.CreateList<IDockable>(leftTool),
+                        ActiveDockable = leftTool
+                    },
+                    new ProportionalDockSplitter(),
+                    documentDock,
+                    new ProportionalDockSplitter(),
+                    new ToolDock
+                    {
+                        Id = "BottomPane",
+                        Alignment = Alignment.Bottom,
+                        Proportion = 0.25,
+                        VisibleDockables = factory.CreateList<IDockable>(bottomTool),
+                        ActiveDockable = bottomTool
+                    })
+            };
+
+            var root = factory.CreateRootDock();
+            root.VisibleDockables = factory.CreateList<IDockable>(mainLayout);
+            root.DefaultDockable = mainLayout;
+
+            factory.InitLayout(root);
+            dockControl.Factory = factory;
+            dockControl.Layout = root;
+
+            desktop.MainWindow = new Window
+            {
+                Width = 800,
+                Height = 600,
+                Content = dockControl
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/samples/DockManagerRulesSample/RulesDockManager.cs
+++ b/samples/DockManagerRulesSample/RulesDockManager.cs
@@ -1,0 +1,28 @@
+using Dock.Model;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace DockManagerRulesSample;
+
+public class RulesDockManager : DockManager
+{
+    public override bool ValidateTool(ITool sourceTool, IDockable target, DragAction action, DockOperation operation, bool execute)
+    {
+        if (operation == DockOperation.Window)
+        {
+            return false;
+        }
+
+        return base.ValidateTool(sourceTool, target, action, operation, execute);
+    }
+
+    public override bool ValidateDocument(IDocument sourceDocument, IDockable target, DragAction action, DockOperation operation, bool execute)
+    {
+        if (operation == DockOperation.Top || operation == DockOperation.Bottom)
+        {
+            return false;
+        }
+
+        return base.ValidateDocument(sourceDocument, target, action, operation, execute);
+    }
+}


### PR DESCRIPTION
## Summary
- add `RulesDockManager` sample that restricts window docking and vertical splits
- document sample in `docs/dock-manager-sample.md`
- link the new doc from the docs index
- register sample in the solution

## Testing
- `dotnet format --no-restore` *(fails: Unable to fix IL2109)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b497c504c8321bbde1fb90896e1df