### PR TITLE
Enforce dockable constraint in factory lists

### DIFF
--- a/src/Dock.Model.Avalonia/Factory.cs
+++ b/src/Dock.Model.Avalonia/Factory.cs
@@ -79,7 +79,7 @@ public class Factory : FactoryBase
     /// <inheritdoc/>
     public override IRootDock CreateRootDock() => new RootDock
     {
-        LeftPinnedDockables = CreateList<IDockable>(), 
+        LeftPinnedDockables = CreateList<IDockable>(),
         RightPinnedDockables = CreateList<IDockable>(),
         TopPinnedDockables = CreateList<IDockable>(),
         BottomPinnedDockables = CreateList<IDockable>()

--- a/src/Dock.Model.Mvvm/Factory.cs
+++ b/src/Dock.Model.Mvvm/Factory.cs
@@ -67,7 +67,7 @@ public class Factory : FactoryBase
     /// <inheritdoc/>
     public override IRootDock CreateRootDock() => new RootDock
     {
-        LeftPinnedDockables = CreateList<IDockable>(), 
+        LeftPinnedDockables = CreateList<IDockable>(),
         RightPinnedDockables = CreateList<IDockable>(),
         TopPinnedDockables = CreateList<IDockable>(),
         BottomPinnedDockables = CreateList<IDockable>()

--- a/src/Dock.Model.Prism/Factory.cs
+++ b/src/Dock.Model.Prism/Factory.cs
@@ -67,7 +67,7 @@ public class Factory : FactoryBase
     /// <inheritdoc/>
     public override IRootDock CreateRootDock() => new RootDock
     {
-        LeftPinnedDockables = CreateList<IDockable>(), 
+        LeftPinnedDockables = CreateList<IDockable>(),
         RightPinnedDockables = CreateList<IDockable>(),
         TopPinnedDockables = CreateList<IDockable>(),
         BottomPinnedDockables = CreateList<IDockable>()

--- a/src/Dock.Model.ReactiveUI/Factory.cs
+++ b/src/Dock.Model.ReactiveUI/Factory.cs
@@ -67,7 +67,7 @@ public class Factory : FactoryBase
     /// <inheritdoc/>
     public override IRootDock CreateRootDock() => new RootDock
     {
-        LeftPinnedDockables = CreateList<IDockable>(), 
+        LeftPinnedDockables = CreateList<IDockable>(),
         RightPinnedDockables = CreateList<IDockable>(),
         TopPinnedDockables = CreateList<IDockable>(),
         BottomPinnedDockables = CreateList<IDockable>()

--- a/src/Dock.Model/Core/IFactory.cs
+++ b/src/Dock.Model/Core/IFactory.cs
@@ -99,10 +99,10 @@ public partial interface IFactory
     /// <summary>
     /// Creates list of type <see cref="IList{T}"/>.
     /// </summary>
-    /// <typeparam name="T">The list item type.</typeparam>
+    /// <typeparam name="T">The dockable type.</typeparam>
     /// <param name="items">The initial list items.</param>
     /// <returns>The new instance of <see cref="IList{T}"/>.</returns>
-    IList<T> CreateList<T>(params T[] items);
+    IList<T> CreateList<T>(params T[] items) where T : IDockable;
 
     /// <summary>
     /// Creates <see cref="IRootDock"/>.
@@ -202,7 +202,7 @@ public partial interface IFactory
     /// <param name="id">The dockable id.</param>
     /// <typeparam name="T">The dockable return type.</typeparam>
     /// <returns>The located dockable.</returns>
-    T? GetDockable<T>(string id) where T: class, IDockable;
+    T? GetDockable<T>(string id) where T : class, IDockable;
 
     /// <summary>
     /// Initialize layout.
@@ -386,7 +386,7 @@ public partial interface IFactory
     /// </summary>
     /// <param name="dockable">The dockable to remove.</param>
     void CloseDockable(IDockable dockable);
-        
+
     /// <summary>
     /// Calls <see cref="IFactory.CloseDockable"/> on all <see cref="IDock.VisibleDockables"/> of the dockable owner, excluding the dockable itself.
     /// </summary>

--- a/src/Dock.Model/FactoryBase.Factory.cs
+++ b/src/Dock.Model/FactoryBase.Factory.cs
@@ -36,7 +36,7 @@ public abstract partial class FactoryBase
     public abstract IList<IHostWindow> HostWindows { get; }
 
     /// <inheritdoc/>
-    public abstract IList<T> CreateList<T>(params T[] items);
+    public abstract IList<T> CreateList<T>(params T[] items) where T : IDockable;
 
     /// <inheritdoc/>
     public abstract IRootDock CreateRootDock();

--- a/src/Dock.Model/FactoryBase.Window.cs
+++ b/src/Dock.Model/FactoryBase.Window.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System.Collections.Generic;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 
@@ -13,7 +14,7 @@ public abstract partial class FactoryBase
     /// <inheritdoc/>
     public virtual void AddWindow(IRootDock rootDock, IDockWindow window)
     {
-        rootDock.Windows ??= CreateList<IDockWindow>();
+        rootDock.Windows ??= new List<IDockWindow>();
         rootDock.Windows.Add(window);
         OnWindowAdded(window);
         InitDockWindow(window, rootDock);
@@ -24,7 +25,7 @@ public abstract partial class FactoryBase
     {
         if (index >= 0)
         {
-            rootDock.Windows ??= CreateList<IDockWindow>();
+            rootDock.Windows ??= new List<IDockWindow>();
             rootDock.Windows.Insert(index, window);
             OnWindowAdded(window);
             InitDockWindow(window, rootDock);

--- a/tests/Dock.Avalonia.HeadlessTests/FactorySplitTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/FactorySplitTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Headless.XUnit;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
@@ -78,7 +79,7 @@ public class FactorySplitTests
         var root = new RootDock
         {
             VisibleDockables = factory.CreateList<IDockable>(),
-            Windows = factory.CreateList<IDockWindow>()
+            Windows = new List<IDockWindow>()
         };
         root.Factory = factory;
         var doc = new Document();

--- a/tests/Dock.Avalonia.HeadlessTests/FactoryWindowManagementTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/FactoryWindowManagementTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Avalonia.Headless.XUnit;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
@@ -13,7 +14,7 @@ public class FactoryWindowManagementTests
     public void AddWindow_Adds_To_Root_Windows()
     {
         var factory = new Factory();
-        var root = new RootDock { Windows = factory.CreateList<IDockWindow>() };
+        var root = new RootDock { Windows = new List<IDockWindow>() };
         root.Factory = factory;
 
         var window = new DockWindow();
@@ -28,7 +29,7 @@ public class FactoryWindowManagementTests
     public void InsertWindow_Inserts_Window_At_Index()
     {
         var factory = new Factory();
-        var root = new RootDock { Windows = factory.CreateList<IDockWindow>() };
+        var root = new RootDock { Windows = new List<IDockWindow>() };
         root.Factory = factory;
 
         var w1 = new DockWindow();
@@ -45,7 +46,7 @@ public class FactoryWindowManagementTests
     public void RemoveWindow_Removes_From_Root()
     {
         var factory = new Factory();
-        var root = new RootDock { Windows = factory.CreateList<IDockWindow>() };
+        var root = new RootDock { Windows = new List<IDockWindow>() };
         root.Factory = factory;
 
         var window = new DockWindow();


### PR DESCRIPTION
## Summary
- restrict `CreateList<T>` to `IDockable` items
- adjust window helper methods and tests to use standard lists

## Testing
- `dotnet format --no-restore --include src/Dock.Model/Core/IFactory.cs src/Dock.Model/FactoryBase.Factory.cs src/Dock.Model/FactoryBase.Window.cs src/Dock.Model.Avalonia/Factory.cs src/Dock.Model.Mvvm/Factory.cs src/Dock.Model.ReactiveUI/Factory.cs src/Dock.Model.Prism/Factory.cs tests/Dock.Avalonia.HeadlessTests/FactoryWindowManagementTests.cs tests/Dock.Avalonia.HeadlessTests/FactorySplitTests.cs`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b4a3ed05083219b5e8e907a117732