### PR TITLE
Use records for event arg types

### DIFF
--- a/src/Dock.Model/Core/Events/ActiveDockableChangedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/ActiveDockableChangedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Active dockable changed event args.
 /// </summary>
-public class ActiveDockableChangedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets active dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="ActiveDockableChangedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The active dockable.</param>
-    public ActiveDockableChangedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record ActiveDockableChangedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableAddedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableAddedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable added event args.
 /// </summary>
-public class DockableAddedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets added dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableAddedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The added dockable.</param>
-    public DockableAddedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableAddedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableClosedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableClosedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable closed event args.
 /// </summary>
-public class DockableClosedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets closed dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableRemovedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The closed dockable.</param>
-    public DockableClosedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableClosedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableDockedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableDockedEventArgs.cs
@@ -7,26 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable docked event args.
 /// </summary>
-public class DockableDockedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets docked dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Gets dock operation.
-    /// </summary>
-    public DockOperation Operation { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableDockedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The docked dockable.</param>
-    /// <param name="operation">Dock operation that was performed.</param>
-    public DockableDockedEventArgs(IDockable? dockable, DockOperation operation)
-    {
-        Dockable = dockable;
-        Operation = operation;
-    }
-}
+public record DockableDockedEventArgs(IDockable? Dockable, DockOperation Operation) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableHiddenEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableHiddenEventArgs.cs
@@ -5,19 +5,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable hidden event args.
 /// </summary>
-public class DockableHiddenEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets hidden dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableHiddenEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The hidden dockable.</param>
-    public DockableHiddenEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableHiddenEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableInitEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableInitEventArgs.cs
@@ -7,24 +7,10 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable init event args.
 /// </summary>
-public class DockableInitEventArgs : EventArgs
+public record DockableInitEventArgs(IDockable? Dockable) : EventArgs
 {
-    /// <summary>
-    /// Gets init dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
     /// <summary>
     /// Gets or sets dockable context.
     /// </summary>
     public object? Context { get; set; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableInitEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The init dockable.</param>
-    public DockableInitEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
 }

--- a/src/Dock.Model/Core/Events/DockableMovedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableMovedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable moved event args.
 /// </summary>
-public class DockableMovedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets moved dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableMovedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The moved dockable.</param>
-    public DockableMovedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableMovedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockablePinnedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockablePinnedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable pinned event args.
 /// </summary>
-public class DockablePinnedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets pinned dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockablePinnedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The pinned dockable.</param>
-    public DockablePinnedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockablePinnedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableRemovedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableRemovedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable removed event args.
 /// </summary>
-public class DockableRemovedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets removed dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableRemovedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The removed dockable.</param>
-    public DockableRemovedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableRemovedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableRestoredEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableRestoredEventArgs.cs
@@ -5,19 +5,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable restored event args.
 /// </summary>
-public class DockableRestoredEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets restored dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableRestoredEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The restored dockable.</param>
-    public DockableRestoredEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableRestoredEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableSwappedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableSwappedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable swapped event args.
 /// </summary>
-public class DockableSwappedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets swapped dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableSwappedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The swapped dockable.</param>
-    public DockableSwappedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableSwappedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableUndockedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableUndockedEventArgs.cs
@@ -7,26 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable undocked event args.
 /// </summary>
-public class DockableUndockedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets undocked dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Gets dock operation.
-    /// </summary>
-    public DockOperation Operation { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableUndockedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The undocked dockable.</param>
-    /// <param name="operation">Dock operation that was performed.</param>
-    public DockableUndockedEventArgs(IDockable? dockable, DockOperation operation)
-    {
-        Dockable = dockable;
-        Operation = operation;
-    }
-}
+public record DockableUndockedEventArgs(IDockable? Dockable, DockOperation Operation) : EventArgs;

--- a/src/Dock.Model/Core/Events/DockableUnpinnedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/DockableUnpinnedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Dockable unpinned event args.
 /// </summary>
-public class DockableUnpinnedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets unpinned dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="DockableUnpinnedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The unpinned dockable.</param>
-    public DockableUnpinnedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record DockableUnpinnedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/FocusedDockableChangedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/FocusedDockableChangedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Focused dockable changed event args.
 /// </summary>
-public class FocusedDockableChangedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets focused dockable.
-    /// </summary>
-    public IDockable? Dockable { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="FocusedDockableChangedEventArgs"/> class.
-    /// </summary>
-    /// <param name="dockable">The focused dockable.</param>
-    public FocusedDockableChangedEventArgs(IDockable? dockable)
-    {
-        Dockable = dockable;
-    }
-}
+public record FocusedDockableChangedEventArgs(IDockable? Dockable) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowAddedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowAddedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window added event args.
 /// </summary>
-public class WindowAddedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets added window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowAddedEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The added window.</param>
-    public WindowAddedEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowAddedEventArgs(IDockWindow? Window) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowClosedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowClosedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window closed event args.
 /// </summary>
-public class WindowClosedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets closed window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowClosedEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The closed window.</param>
-    public WindowClosedEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowClosedEventArgs(IDockWindow? Window) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowClosingEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowClosingEventArgs.cs
@@ -7,24 +7,10 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window closing event args.
 /// </summary>
-public class WindowClosingEventArgs : EventArgs
+public record WindowClosingEventArgs(IDockWindow? Window) : EventArgs
 {
-    /// <summary>
-    /// Gets closing window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
     /// <summary>
     /// Gets or sets flag indicating whether window closing should be canceled.
     /// </summary>
     public bool Cancel { get; set; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowClosingEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The closing window.</param>
-    public WindowClosingEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
 }

--- a/src/Dock.Model/Core/Events/WindowMoveDragBeginEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowMoveDragBeginEventArgs.cs
@@ -7,24 +7,10 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window begin dragging event args.
 /// </summary>
-public class WindowMoveDragBeginEventArgs : EventArgs
+public record WindowMoveDragBeginEventArgs(IDockWindow? Window) : EventArgs
 {
-    /// <summary>
-    /// Gets dragged window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
     /// <summary>
     /// Gets or sets flag indicating whether window dragging should be canceled.
     /// </summary>
     public bool Cancel { get; set; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowMoveDragBeginEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The dragged window.</param>
-    public WindowMoveDragBeginEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
 }

--- a/src/Dock.Model/Core/Events/WindowMoveDragEndEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowMoveDragEndEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window dragging ended event args.
 /// </summary>
-public class WindowMoveDragEndEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets dragged window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowMoveDragEndEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The dragged window.</param>
-    public WindowMoveDragEndEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowMoveDragEndEventArgs(IDockWindow? Window) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowMoveDragEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowMoveDragEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window dragging event args.
 /// </summary>
-public class WindowMoveDragEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets dragged window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowMoveDragEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The dragged window.</param>
-    public WindowMoveDragEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowMoveDragEventArgs(IDockWindow? Window) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowOpenedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowOpenedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window opened event args.
 /// </summary>
-public class WindowOpenedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets opened window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowOpenedEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The opened window.</param>
-    public WindowOpenedEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowOpenedEventArgs(IDockWindow? Window) : EventArgs;

--- a/src/Dock.Model/Core/Events/WindowRemovedEventArgs.cs
+++ b/src/Dock.Model/Core/Events/WindowRemovedEventArgs.cs
@@ -7,19 +7,4 @@ namespace Dock.Model.Core.Events;
 /// <summary>
 /// Window removed event args.
 /// </summary>
-public class WindowRemovedEventArgs : EventArgs
-{
-    /// <summary>
-    /// Gets removed window.
-    /// </summary>
-    public IDockWindow? Window { get; }
-
-    /// <summary>
-    /// Initializes new instance of the <see cref="WindowRemovedEventArgs"/> class.
-    /// </summary>
-    /// <param name="window">The removed window.</param>
-    public WindowRemovedEventArgs(IDockWindow? window)
-    {
-        Window = window;
-    }
-}
+public record WindowRemovedEventArgs(IDockWindow? Window) : EventArgs;


### PR DESCRIPTION
## Summary
- convert `*EventArgs` classes to records with `init` properties

## Testing
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a3cb9ec8321a375a9e262ba0c07