### PR TITLE
Add DockManagerOptions to configure docking behavior

### DIFF
--- a/docs/dock-architecture.md
+++ b/docs/dock-architecture.md
@@ -9,8 +9,8 @@ the [deep dive](dock-deep-dive.md).
 - **DockControl** – Avalonia control that hosts the layout and forwards
   pointer input to the docking pipeline.
 - **DockManager** – Implements the algorithms that move, swap or split
-  dockables during drag operations. It exposes a `PreventSizeConflicts`
-  property that stops docking tools together when their fixed sizes clash.
+  dockables during drag operations. It uses `DockManagerOptions` such as
+  `PreventSizeConflicts` to avoid docking tools with incompatible fixed sizes.
 - **DockControlState** – Tracks pointer interactions and validates potential
   drop targets using `DockManager`.
 - **Factories** – Build and initialize dock view models. They expose

--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -76,7 +76,7 @@ public override IHostWindow CreateWindowFrom(IDockWindow source)
 
 **Can I give a tool a fixed size?**
 
-Set `MinWidth` and `MaxWidth` (or the height equivalents) on the tool view model. When both values are the same the tool cannot be resized. `DockManager` has a `PreventSizeConflicts` flag which stops docking tools together if their fixed sizes are incompatible.
+Set `MinWidth` and `MaxWidth` (or the height equivalents) on the tool view model. When both values are the same the tool cannot be resized. Use the `PreventSizeConflicts` option on `DockManagerOptions` to stop docking tools together when their fixed sizes are incompatible.
 
 **Pinned tools show up on the wrong side**
 

--- a/docs/dock-manager-guide.md
+++ b/docs/dock-manager-guide.md
@@ -5,21 +5,20 @@
 ## Why use DockManager?
 
 - The manager centralises all drag-and-drop logic, keeping `DockControl` free from layout code.
-- It exposes the `PreventSizeConflicts` property which blocks two fixed-size tools from being docked together.
+- The manager is configured via `DockManagerOptions` which includes the `PreventSizeConflicts` flag to block docking tools with incompatible fixed sizes.
 - The manager calls back into the factory so your view models are updated consistently.
 
 ## Basic usage
 
-`DockControl` automatically creates a `DockManager` when constructed. To use your own instance set the `DockManager` property before displaying the control:
+`DockControl` automatically creates a `DockManager` with default options. To customise the behaviour pass an options object to the control constructor:
 
 ```csharp
-var dockManager = new DockManager
+var options = new DockManagerOptions
 {
-    PreventSizeConflicts = true
+    PreventSizeConflicts = false
 };
-var dockControl = new DockControl
+var dockControl = new DockControl(options)
 {
-    DockManager = dockManager,
     Layout = factory.CreateLayout()
 };
 ```

--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -9,6 +9,7 @@ using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Core;
+using Dock.Model;
 
 namespace DockCodeOnlySample;
 
@@ -36,7 +37,10 @@ public class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            var dockControl = new DockControl();
+            var dockControl = new DockControl(new DockManagerOptions
+            {
+                PreventSizeConflicts = false
+            });
 
             var factory = new Factory();
 

--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -24,6 +24,7 @@ public class DockControl : TemplatedControl, IDockControl
 {
     private readonly DockManager _dockManager;
     private readonly DockControlState _dockControlState;
+    private readonly DockManagerOptions _options;
     private bool _isInitialized;
 
     /// <summary>
@@ -132,11 +133,21 @@ public class DockControl : TemplatedControl, IDockControl
     }
 
     /// <summary>
-    /// Initialize the new instance of the <see cref="DockControl"/>.
+    /// Initializes a new instance of the <see cref="DockControl"/> class.
     /// </summary>
     public DockControl()
+        : this(new DockManagerOptions())
     {
-        _dockManager = new DockManager();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockControl"/> class with options.
+    /// </summary>
+    /// <param name="options">The dock manager options.</param>
+    public DockControl(DockManagerOptions options)
+    {
+        _options = options;
+        _dockManager = new DockManager(options);
         _dockControlState = new DockControlState(_dockManager, _dragOffsetCalculator);
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         AddHandler(PointerReleasedEvent, ReleasedHandler, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
@@ -189,13 +200,13 @@ public class DockControl : TemplatedControl, IDockControl
             layout.Factory.ContextLocator = new Dictionary<string, Func<object?>>();
             layout.Factory.HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
             {
-                [nameof(IDockWindow)] = () => new HostWindow()
+                [nameof(IDockWindow)] = () => new HostWindow(_options)
             };
             layout.Factory.DockableLocator = new Dictionary<string, Func<IDockable?>>();
             layout.Factory.DefaultContextLocator = GetContext;
             layout.Factory.DefaultHostWindowLocator = GetHostWindow;
- 
-            IHostWindow GetHostWindow() => new HostWindow();
+
+            IHostWindow GetHostWindow() => new HostWindow(_options);
 
             object? GetContext() => DefaultContext;
         }

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -29,6 +29,7 @@ public class HostWindow : Window, IHostWindow
 {
     private readonly DockManager _dockManager;
     private readonly HostWindowState _hostWindowState;
+    private readonly DockManagerOptions _options;
     private List<Control> _chromeGrips = new();
     private HostWindowTitleBar? _hostWindowTitleBar;
     private bool _mouseDown, _draggingWindow;
@@ -94,14 +95,24 @@ public class HostWindow : Window, IHostWindow
     public IDockWindow? Window { get; set; }
 
     /// <summary>
-    /// Initializes new instance of the <see cref="HostWindow"/> class.
+    /// Initializes a new instance of the <see cref="HostWindow"/> class.
     /// </summary>
     public HostWindow()
+        : this(new DockManagerOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="HostWindow"/> class with options.
+    /// </summary>
+    /// <param name="options">The dock manager options.</param>
+    public HostWindow(DockManagerOptions options)
     {
         PositionChanged += HostWindow_PositionChanged;
         LayoutUpdated += HostWindow_LayoutUpdated;
 
-        _dockManager = new DockManager();
+        _options = options;
+        _dockManager = new DockManager(options);
         _hostWindowState = new HostWindowState(_dockManager, this);
         UpdatePseudoClasses(IsToolWindow, ToolChromeControlsWholeWindow, DocumentChromeControlsWholeWindow);
     }

--- a/src/Dock.Model/DockManager.cs
+++ b/src/Dock.Model/DockManager.cs
@@ -12,6 +12,16 @@ namespace Dock.Model;
 public class DockManager : IDockManager
 {
     private readonly DockService _dockService = new ();
+    private readonly DockManagerOptions _options;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockManager"/> class.
+    /// </summary>
+    /// <param name="options">The dock manager options.</param>
+    public DockManager(DockManagerOptions? options = null)
+    {
+        _options = options ?? new DockManagerOptions();
+    }
 
     /// <inheritdoc/>
     public DockPoint Position { get; set; }
@@ -20,7 +30,11 @@ public class DockManager : IDockManager
     public DockPoint ScreenPosition { get; set; }
 
     /// <inheritdoc/>
-    public bool PreventSizeConflicts { get; set; } = true;
+    public bool PreventSizeConflicts
+    {
+        get => _options.PreventSizeConflicts;
+        set => _options.PreventSizeConflicts = value;
+    }
 
     private static bool IsFixed(double min, double max)
     {

--- a/src/Dock.Model/DockManagerOptions.cs
+++ b/src/Dock.Model/DockManagerOptions.cs
@@ -1,0 +1,13 @@
+namespace Dock.Model;
+
+/// <summary>
+/// Options used by <see cref="DockManager"/> to control docking behaviour.
+/// </summary>
+public class DockManagerOptions
+{
+    /// <summary>
+    /// Gets or sets a value that prevents docking tools with conflicting fixed sizes.
+    /// </summary>
+    public bool PreventSizeConflicts { get; set; } = true;
+}
+


### PR DESCRIPTION
## Summary
- introduce `DockManagerOptions` with `PreventSizeConflicts` flag
- pass the options to `DockManager`, `DockControl` and `HostWindow`
- update docs to describe the new options mechanism
- show custom option usage in the code-only sample

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a47503c83219487be528981ac93