### PR TITLE
Add async serializer API

### DIFF
--- a/samples/DockMvvmSample/Views/MainView.axaml.cs
+++ b/samples/DockMvvmSample/Views/MainView.axaml.cs
@@ -20,7 +20,7 @@ public partial class MainView : UserControl
 {
     private IDockSerializer? _serializer;
     private IDockState? _dockState;
-    
+
     public MainView()
     {
         InitializeComponent();
@@ -90,7 +90,7 @@ public partial class MainView : UserControl
             {
                 await using var stream = await file.OpenReadAsync();
                 using var reader = new StreamReader(stream);
-                var layout = _serializer.Load<IRootDock?>(stream);
+                var layout = await _serializer.LoadAsync<IRootDock?>(stream);
                 if (layout is not null)
                 {
                     _dockState.Restore(layout);
@@ -136,10 +136,10 @@ public partial class MainView : UserControl
             try
             {
                 await using var stream = await file.OpenWriteAsync();
-                
+
                 if (DataContext is MainWindowViewModel mainWindowViewModel)
                 {
-                    _serializer.Save(stream, mainWindowViewModel.Layout);
+                    await _serializer.SaveAsync(stream, mainWindowViewModel.Layout);
                 }
             }
             catch (Exception e)

--- a/samples/DockReactiveUIDiSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockReactiveUIDiSample/ViewModels/MainWindowViewModel.cs
@@ -68,7 +68,7 @@ public class MainWindowViewModel : ReactiveObject
         _state.Save(Layout);
         const string path = "layout.json";
         await using var stream = File.Create(path);
-        _serializer.Save(stream, Layout);
+        await _serializer.SaveAsync(stream, Layout);
     }
 
     public void CloseLayout()

--- a/samples/DockXamlSample/MainView.axaml.cs
+++ b/samples/DockXamlSample/MainView.axaml.cs
@@ -9,8 +9,8 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
 using Avalonia.VisualTree;
 using Dock.Model;
-using Dock.Model.Core;
 using Dock.Model.Controls;
+using Dock.Model.Core;
 using Dock.Serializer;
 
 namespace DockXamlSample;
@@ -87,7 +87,7 @@ public partial class MainView : UserControl
                 using var reader = new StreamReader(stream);
                 if (DockControl is not null)
                 {
-                    var layout = _serializer.Load<IDock?>(stream);
+                    var layout = await _serializer.LoadAsync<IDock?>(stream);
                     // TODO:
                     // var layout = await JsonSerializer.DeserializeAsync(
                     //     stream, 
@@ -136,7 +136,7 @@ public partial class MainView : UserControl
                 await using var stream = await file.OpenWriteAsync();
                 if (DockControl?.Layout is not null)
                 {
-                    _serializer.Save(stream, DockControl.Layout);
+                    await _serializer.SaveAsync(stream, DockControl.Layout);
                     // TODO:
                     // await JsonSerializer.SerializeAsync(
                     //     stream, 
@@ -190,7 +190,7 @@ public partial class MainView : UserControl
 
         _viewsMenu.Items.Clear();
 
-        if (_rootDock?.HiddenDockables is { Count: >0 } hidden)
+        if (_rootDock?.HiddenDockables is { Count: > 0 } hidden)
         {
             foreach (var dockable in hidden)
             {

--- a/src/Dock.Model.Avalonia/Json/AvaloniaDockSerializer.cs
+++ b/src/Dock.Model.Avalonia/Json/AvaloniaDockSerializer.cs
@@ -37,7 +37,7 @@ public class AvaloniaDockSerializer : IDockSerializer
             NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals,
         });
     */
-    
+
     private readonly Dictionary<Type, List<string>> _properties;
     private readonly JsonSerializerOptions _options;
 
@@ -681,5 +681,25 @@ public class AvaloniaDockSerializer : IDockSerializer
         }
         using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
         streamWriter.Write(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> LoadAsync<T>(Stream stream)
+    {
+        using var streamReader = new StreamReader(stream, Encoding.UTF8);
+        var text = await streamReader.ReadToEndAsync().ConfigureAwait(false);
+        return Deserialize<T>(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync<T>(Stream stream, T value)
+    {
+        var text = Serialize(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+        await streamWriter.WriteAsync(text).ConfigureAwait(false);
     }
 }

--- a/src/Dock.Model/Core/IDockSerializer.cs
+++ b/src/Dock.Model/Core/IDockSerializer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Dock.Model.Core;
 /// <summary>
@@ -39,4 +40,20 @@ public interface IDockSerializer
     /// <param name="value">The object to save.</param>
     /// <typeparam name="T">The type of the object to save.</typeparam>
     void Save<T>(Stream stream, T value);
+
+    /// <summary>
+    /// Asynchronously loads an object from the specified stream.
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    /// <typeparam name="T">The type of the object to load.</typeparam>
+    /// <returns>A task returning the loaded object, or null if the deserialization fails.</returns>
+    Task<T?> LoadAsync<T>(Stream stream);
+
+    /// <summary>
+    /// Asynchronously saves the specified object to the specified stream.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="value">The object to save.</param>
+    /// <typeparam name="T">The type of the object to save.</typeparam>
+    Task SaveAsync<T>(Stream stream, T value);
 }

--- a/src/Dock.Serializer.Newtonsoft/DockSerializer.cs
+++ b/src/Dock.Serializer.Newtonsoft/DockSerializer.cs
@@ -92,4 +92,24 @@ public sealed class DockSerializer : IDockSerializer
         using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
         streamWriter.Write(text);
     }
+
+    /// <inheritdoc/>
+    public async Task<T?> LoadAsync<T>(Stream stream)
+    {
+        using var streamReader = new StreamReader(stream, Encoding.UTF8);
+        var text = await streamReader.ReadToEndAsync().ConfigureAwait(false);
+        return Deserialize<T>(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync<T>(Stream stream, T value)
+    {
+        var text = Serialize(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+        await streamWriter.WriteAsync(text).ConfigureAwait(false);
+    }
 }

--- a/src/Dock.Serializer.Protobuf/ProtobufDockSerializer.cs
+++ b/src/Dock.Serializer.Protobuf/ProtobufDockSerializer.cs
@@ -61,4 +61,18 @@ public sealed class ProtobufDockSerializer : IDockSerializer
     {
         global::ProtoBuf.Serializer.Serialize(stream, value!);
     }
+
+    /// <inheritdoc/>
+    public Task<T?> LoadAsync<T>(Stream stream)
+    {
+        var result = Load<T>(stream);
+        return Task.FromResult(result);
+    }
+
+    /// <inheritdoc/>
+    public Task SaveAsync<T>(Stream stream, T value)
+    {
+        Save(stream, value);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Dock.Serializer.SystemTextJson/DockSerializer.cs
+++ b/src/Dock.Serializer.SystemTextJson/DockSerializer.cs
@@ -4,9 +4,9 @@ using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
-using Dock.Model.Core;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Dock.Model.Core;
 
 namespace Dock.Serializer.SystemTextJson;
 
@@ -72,5 +72,25 @@ public sealed class DockSerializer : IDockSerializer
         }
         using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
         streamWriter.Write(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task<T?> LoadAsync<T>(Stream stream)
+    {
+        using var streamReader = new StreamReader(stream, Encoding.UTF8);
+        var text = await streamReader.ReadToEndAsync().ConfigureAwait(false);
+        return Deserialize<T>(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync<T>(Stream stream, T value)
+    {
+        var text = Serialize(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        using var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+        await streamWriter.WriteAsync(text).ConfigureAwait(false);
     }
 }

--- a/src/Dock.Serializer.Xml/DockXmlSerializer.cs
+++ b/src/Dock.Serializer.Xml/DockXmlSerializer.cs
@@ -87,4 +87,24 @@ public sealed class DockXmlSerializer : IDockSerializer
         using var writer = new StreamWriter(stream, Encoding.UTF8);
         writer.Write(text);
     }
+
+    /// <inheritdoc/>
+    public async Task<T?> LoadAsync<T>(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var text = await reader.ReadToEndAsync().ConfigureAwait(false);
+        return Deserialize<T>(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync<T>(Stream stream, T value)
+    {
+        var text = Serialize(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        using var writer = new StreamWriter(stream, Encoding.UTF8);
+        await writer.WriteAsync(text).ConfigureAwait(false);
+    }
 }

--- a/src/Dock.Serializer.Yaml/DockYamlSerializer.cs
+++ b/src/Dock.Serializer.Yaml/DockYamlSerializer.cs
@@ -77,4 +77,24 @@ public sealed class DockYamlSerializer : IDockSerializer
         using var writer = new StreamWriter(stream, Encoding.UTF8);
         writer.Write(text);
     }
+
+    /// <inheritdoc/>
+    public async Task<T?> LoadAsync<T>(Stream stream)
+    {
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+        var text = await reader.ReadToEndAsync().ConfigureAwait(false);
+        return Deserialize<T>(text);
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync<T>(Stream stream, T value)
+    {
+        var text = Serialize(value);
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+        using var writer = new StreamWriter(stream, Encoding.UTF8);
+        await writer.WriteAsync(text).ConfigureAwait(false);
+    }
 }

--- a/tests/Dock.Serializer.UnitTests/DockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/DockSerializerTests.cs
@@ -102,4 +102,23 @@ public class DockSerializerTests
 
         Assert.Equal("null", text.Trim());
     }
+
+    [Fact]
+    public async Task SaveLoadAsync_Roundtrip_Works()
+    {
+        var serializer = new DockSerializer();
+        var sample = new Sample { Name = "Async", Numbers = new List<int> { 9, 10 } };
+        await using var stream = new NonClosingMemoryStream();
+
+        await serializer.SaveAsync(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = await serializer.LoadAsync<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
 }

--- a/tests/Dock.Serializer.UnitTests/ProtobufDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/ProtobufDockSerializerTests.cs
@@ -64,4 +64,23 @@ public class ProtobufDockSerializerTests
         Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
         Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
     }
+
+    [Fact]
+    public async Task SaveLoadAsync_Roundtrip_Works()
+    {
+        var serializer = new ProtobufDockSerializer();
+        var sample = new Sample { Name = "Async", Numbers = new List<int> { 9, 10 } };
+        await using var stream = new MemoryStream();
+
+        await serializer.SaveAsync(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = await serializer.LoadAsync<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
 }

--- a/tests/Dock.Serializer.UnitTests/SystemTextJsonDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/SystemTextJsonDockSerializerTests.cs
@@ -102,4 +102,23 @@ public class SystemTextJsonDockSerializerTests
 
         Assert.Equal("null", text.Trim());
     }
+
+    [Fact]
+    public async Task SaveLoadAsync_Roundtrip_Works()
+    {
+        var serializer = new DockSerializer();
+        var sample = new Sample { Name = "Async", Numbers = new List<int> { 9, 10 } };
+        await using var stream = new NonClosingMemoryStream();
+
+        await serializer.SaveAsync(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = await serializer.LoadAsync<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
 }

--- a/tests/Dock.Serializer.UnitTests/XmlDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/XmlDockSerializerTests.cs
@@ -75,4 +75,23 @@ public class XmlDockSerializerTests
         Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
         Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
     }
+
+    [Fact]
+    public async Task SaveLoadAsync_Roundtrip_Works()
+    {
+        var serializer = new DockXmlSerializer();
+        var sample = new Sample { Name = "Async", Numbers = new List<int> { 9, 10 } };
+        await using var stream = new NonClosingMemoryStream();
+
+        await serializer.SaveAsync(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = await serializer.LoadAsync<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
 }

--- a/tests/Dock.Serializer.UnitTests/YamlDockSerializerTests.cs
+++ b/tests/Dock.Serializer.UnitTests/YamlDockSerializerTests.cs
@@ -72,4 +72,23 @@ public class YamlDockSerializerTests
         Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
         Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
     }
+
+    [Fact]
+    public async Task SaveLoadAsync_Roundtrip_Works()
+    {
+        var serializer = new DockYamlSerializer();
+        var sample = new Sample { Name = "Async", Numbers = new List<int> { 9, 10 } };
+        await using var stream = new NonClosingMemoryStream();
+
+        await serializer.SaveAsync(stream, sample);
+        Assert.True(stream.Length > 0);
+
+        stream.Position = 0;
+        var loaded = await serializer.LoadAsync<Sample>(stream);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(sample.Name, loaded!.Name);
+        Assert.IsType<ObservableCollection<int>>(loaded.Numbers);
+        Assert.Equal(sample.Numbers, loaded.Numbers.ToList());
+    }
 }


### PR DESCRIPTION
## Summary
- expand `IDockSerializer` with asynchronous methods
- implement `LoadAsync` and `SaveAsync` in all serializers
- use the async APIs in sample layout operations
- test async roundtrips with in-memory streams

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: "The argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_687b4a325b44832196b4ad018ed179ad