### PR TITLE
Support injecting DockControl dependencies

### DIFF
--- a/docs/dock-deep-dive.md
+++ b/docs/dock-deep-dive.md
@@ -8,14 +8,12 @@ you need behaviour not covered by the default implementation.
 
 ## DockControl
 
-`DockControl` is the main Avalonia control that hosts a layout. Its constructor registers pointer handlers and creates both a `DockManager` and a `DockControlState`:
+`DockControl` is the main Avalonia control that hosts a layout. Its constructor registers pointer handlers and by default creates a `DockManager` and `DockControlState`. You can provide custom instances via the constructor or by assigning the properties:
 
 ```csharp
-_dockManager = new DockManager();
-_dockControlState = new DockControlState();
-AddHandler(PointerPressedEvent, PressedHandler);
-AddHandler(PointerReleasedEvent, ReleasedHandler);
-AddHandler(PointerMovedEvent, MovedHandler);
+var manager = new CustomDockManager();
+var state = new DockControlState(manager, new DefaultDragOffsetCalculator());
+var dockControl = new DockControl(manager, state);
 ```
 
 When the `Layout` property changes the control is reinitialised with the new root dock:

--- a/docs/dock-manager-guide.md
+++ b/docs/dock-manager-guide.md
@@ -22,6 +22,13 @@ var dockControl = new DockControl
     DockManager = dockManager,
     Layout = factory.CreateLayout()
 };
+
+// or via the constructor
+var control2 = new DockControl(dockManager);
+
+// provide a custom state
+var state = new DockControlState(dockManager, new DefaultDragOffsetCalculator());
+var control3 = new DockControl(dockManager, state);
 ```
 
 During a drag operation `DockControlState` calls `DockManager.ValidateDockable` to test potential drop targets. When the pointer is released the same call is executed with `bExecute: true` so the layout is updated.

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -48,7 +48,7 @@ internal class DockDragContext
 /// <summary>
 /// Dock control state.
 /// </summary>
-internal class DockControlState : DockManagerState, IDockControlState
+public class DockControlState : DockManagerState, IDockControlState
 {
     private readonly DockDragContext _context = new();
     private readonly DragPreviewHelper _dragPreviewHelper = new();

--- a/tests/Dock.Avalonia.HeadlessTests/DockControlStateTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockControlStateTests.cs
@@ -23,7 +23,7 @@ public class DockControlStateTests
     {
         var manager = new DockManager();
         var state = CreateState(manager);
-        var dock = new DockControl();
+        var dock = new DockControl(manager, state);
         var docks = new List<IDockControl> { dock };
 
         state.Process(new Point(0,0), new Vector(), EventType.Pressed, DragAction.Move, dock, docks);
@@ -38,7 +38,7 @@ public class DockControlStateTests
     {
         var manager = new DockManager();
         var state = CreateState(manager);
-        var dock = new DockControl();
+        var dock = new DockControl(manager, state);
         var docks = new List<IDockControl> { dock };
 
         state.Process(new Point(0,0), new Vector(), EventType.Pressed, DragAction.Move, dock, docks);

--- a/tests/Dock.Avalonia.HeadlessTests/DockControlTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockControlTests.cs
@@ -15,7 +15,9 @@ public class DockControlTests
         var layout = factory.CreateLayout();
         layout.Factory = factory;
 
-        var control = new DockControl { Factory = factory, Layout = layout };
+        var manager = new DockManager();
+        var state = new DockControlState(manager, new DefaultDragOffsetCalculator());
+        var control = new DockControl(manager, state) { Factory = factory, Layout = layout };
 
         Assert.Contains(control, factory.DockControls);
     }
@@ -27,7 +29,9 @@ public class DockControlTests
         var layout1 = factory.CreateLayout();
         layout1.Factory = factory;
 
-        var control = new DockControl { Factory = factory, Layout = layout1 };
+        var manager = new DockManager();
+        var state = new DockControlState(manager, new DefaultDragOffsetCalculator());
+        var control = new DockControl(manager, state) { Factory = factory, Layout = layout1 };
         Assert.Single(factory.DockControls);
 
         var layout2 = factory.CreateLayout();
@@ -46,7 +50,9 @@ public class DockControlTests
         var layout = factory.CreateLayout();
         layout.Factory = factory;
 
-        var control = new DockControl { Factory = factory, Layout = layout };
+        var manager = new DockManager();
+        var state = new DockControlState(manager, new DefaultDragOffsetCalculator());
+        var control = new DockControl(manager, state) { Factory = factory, Layout = layout };
         Assert.Contains(control, factory.DockControls);
 
         control.Layout = null;

--- a/tests/Dock.Avalonia.HeadlessTests/HostWindowStateTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/HostWindowStateTests.cs
@@ -68,7 +68,7 @@ public class HostWindowStateTests
         var contextField = typeof(HostWindowState)
             .GetField("_context", BindingFlags.Instance | BindingFlags.NonPublic)!;
         var context = contextField.GetValue(state)!;
-        context.GetType().GetProperty("TargetDockControl")!.SetValue(context, new DockControl());
+        context.GetType().GetProperty("TargetDockControl")!.SetValue(context, new DockControl(manager, new DockControlState(manager, new DefaultDragOffsetCalculator())));
         context.GetType().GetProperty("TargetPoint")!.SetValue(context, new Point(5,5));
         context.GetType().GetProperty("DoDragDrop")!.SetValue(context, true);
         context.GetType().GetProperty("PointerPressed")!.SetValue(context, true);

--- a/tests/Dock.Avalonia.UnitTests/Controls/ControlCtorTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ControlCtorTests.cs
@@ -1,5 +1,7 @@
 using Avalonia.Headless.XUnit;
 using Dock.Avalonia.Controls;
+using Dock.Avalonia.Internal;
+using Dock.Model;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls;
@@ -9,7 +11,9 @@ public class ControlCtorTests
     [AvaloniaFact]
     public void DockControl_Ctor()
     {
-        var control = new DockControl();
+        var manager = new DockManager();
+        var state = new DockControlState(manager, new DefaultDragOffsetCalculator());
+        var control = new DockControl(manager, state);
         Assert.NotNull(control);
     }
 


### PR DESCRIPTION
## Summary
- allow supplying `DockManager` and `DockControlState` via constructor or property
- expose `DockControlState` publicly
- update docs to show how to pass custom manager and state
- adjust tests for new constructors

## Testing
- `dotnet format --no-restore` *(fails: Required references did not load)*
- `dotnet test Dock.sln --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a261b848321a6e130920edbff63