### PR TITLE
Refactor DockManager operations with strategy pattern

### DIFF
--- a/src/Dock.Model/Strategies/BottomDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/BottomDockOperationStrategy.cs
@@ -1,0 +1,18 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class BottomDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+
+    public BottomDockOperationStrategy(DockService dockService)
+    {
+        _dockService = dockService;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.SplitDockable(source, sourceOwner, targetDock, DockOperation.Bottom, execute);
+    }
+}

--- a/src/Dock.Model/Strategies/FillDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/FillDockOperationStrategy.cs
@@ -1,0 +1,18 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class FillDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+
+    public FillDockOperationStrategy(DockService dockService)
+    {
+        _dockService = dockService;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.MoveDockable(source, sourceOwner, targetDock, execute);
+    }
+}

--- a/src/Dock.Model/Strategies/IDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/IDockOperationStrategy.cs
@@ -1,0 +1,8 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal interface IDockOperationStrategy
+{
+    bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute);
+}

--- a/src/Dock.Model/Strategies/LeftDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/LeftDockOperationStrategy.cs
@@ -1,0 +1,18 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class LeftDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+
+    public LeftDockOperationStrategy(DockService dockService)
+    {
+        _dockService = dockService;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.SplitDockable(source, sourceOwner, targetDock, DockOperation.Left, execute);
+    }
+}

--- a/src/Dock.Model/Strategies/NoneDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/NoneDockOperationStrategy.cs
@@ -1,0 +1,11 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class NoneDockOperationStrategy : IDockOperationStrategy
+{
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return false;
+    }
+}

--- a/src/Dock.Model/Strategies/RightDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/RightDockOperationStrategy.cs
@@ -1,0 +1,18 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class RightDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+
+    public RightDockOperationStrategy(DockService dockService)
+    {
+        _dockService = dockService;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.SplitDockable(source, sourceOwner, targetDock, DockOperation.Right, execute);
+    }
+}

--- a/src/Dock.Model/Strategies/TopDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/TopDockOperationStrategy.cs
@@ -1,0 +1,18 @@
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class TopDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+
+    public TopDockOperationStrategy(DockService dockService)
+    {
+        _dockService = dockService;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.SplitDockable(source, sourceOwner, targetDock, DockOperation.Top, execute);
+    }
+}

--- a/src/Dock.Model/Strategies/WindowDockOperationStrategy.cs
+++ b/src/Dock.Model/Strategies/WindowDockOperationStrategy.cs
@@ -1,0 +1,21 @@
+using System;
+using Dock.Model.Core;
+
+namespace Dock.Model.Strategies;
+
+internal class WindowDockOperationStrategy : IDockOperationStrategy
+{
+    private readonly DockService _dockService;
+    private readonly Func<DockPoint> _getScreenPosition;
+
+    public WindowDockOperationStrategy(DockService dockService, Func<DockPoint> getScreenPosition)
+    {
+        _dockService = dockService;
+        _getScreenPosition = getScreenPosition;
+    }
+
+    public bool Execute(IDockable source, IDock sourceOwner, IDock targetDock, bool execute)
+    {
+        return _dockService.DockDockableIntoWindow(source, targetDock, _getScreenPosition(), execute);
+    }
+}

--- a/tests/Dock.Avalonia.HeadlessTests/DockManagerTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockManagerTests.cs
@@ -1,5 +1,6 @@
 using Avalonia.Headless.XUnit;
 using Dock.Model;
+using Dock.Model.Avalonia;
 using Dock.Model.Core;
 using Dock.Model.Avalonia.Controls;
 using Xunit;
@@ -53,5 +54,23 @@ public class DockManagerTests
 
         var result = manager.ValidateTool(tool, targetDock, DragAction.Move, DockOperation.Fill, false);
         Assert.True(result);
+    }
+
+    [AvaloniaFact]
+    public void DockDockable_Fill_Moves_To_TargetDock()
+    {
+        var manager = new DockManager();
+        var factory = new Factory();
+        var sourceDock = new ToolDock { VisibleDockables = factory.CreateList<IDockable>(), Factory = factory };
+        var targetDock = new ToolDock { VisibleDockables = factory.CreateList<IDockable>(), Factory = factory };
+        var tool = new Tool();
+        factory.AddDockable(sourceDock, tool);
+
+        var result = manager.ValidateTool(tool, targetDock, DragAction.Move, DockOperation.Fill, true);
+
+        Assert.True(result);
+        Assert.DoesNotContain(tool, sourceDock.VisibleDockables!);
+        Assert.Contains(tool, targetDock.VisibleDockables!);
+        Assert.Same(targetDock, tool.Owner);
     }
 }


### PR DESCRIPTION
## Summary
- add `IDockOperationStrategy` and strategy implementations
- refactor `DockManager` to use strategies for dock operations
- test docking via strategies in `DockManagerTests`

## Testing
- `dotnet test -c Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687b4a17458883218fbaa0330bf0abae