### PR TITLE
Add document navigation shortcuts

### DIFF
--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -4,8 +4,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
-using Dock.Avalonia.Themes;
 using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Core;
@@ -54,7 +54,8 @@ public class App : Application
             };
 
             var document = new Document { Id = "Doc1", Title = "Document 1" };
-            documentDock.VisibleDockables = factory.CreateList<IDockable>(document);
+            var document2 = new Document { Id = "Doc2", Title = "Document 2" };
+            documentDock.VisibleDockables = factory.CreateList<IDockable>(document, document2);
             documentDock.ActiveDockable = document;
 
             var leftTool = new Tool { Id = "Tool1", Title = "Tool 1" };
@@ -91,7 +92,7 @@ public class App : Application
 
             factory.InitLayout(root);
             dockControl.Factory = factory;
-            dockControl.Layout  = root;
+            dockControl.Layout = root;
 
             desktop.MainWindow = new Window
             {

--- a/src/Dock.Avalonia/Controls/DocumentDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentDockControl.axaml.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Dock.Model.Controls;
+using Dock.Model.Avalonia.Internal;
 
 namespace Dock.Avalonia.Controls;
 
@@ -9,4 +12,33 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class DocumentDockControl : TemplatedControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentDockControl"/> class.
+    /// </summary>
+    public DocumentDockControl()
+    {
+        InputBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.Tab, KeyModifiers.Control),
+            Command = Command.Create(() =>
+            {
+                if (DataContext is IDocumentDock dock)
+                {
+                    dock.NextDocument?.Execute(null);
+                }
+            })
+        });
+
+        InputBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.Tab, KeyModifiers.Control | KeyModifiers.Shift),
+            Command = Command.Create(() =>
+            {
+                if (DataContext is IDocumentDock dock)
+                {
+                    dock.PreviousDocument?.Execute(null);
+                }
+            })
+        });
+    }
 }

--- a/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Avalonia/Controls/DocumentDock.cs
@@ -50,6 +50,8 @@ public class DocumentDock : DockBase, IDocumentDock, IDocumentDockContent
     public DocumentDock()
     {
         CreateDocument = new Command(CreateNewDocument);
+        NextDocument = new Command(ActivateNextDocument);
+        PreviousDocument = new Command(ActivatePreviousDocument);
     }
 
     /// <summary>
@@ -160,5 +162,37 @@ public class DocumentDock : DockBase, IDocumentDock, IDocumentDockContent
         Factory?.AddDockable(this, tool);
         Factory?.SetActiveDockable(tool);
         Factory?.SetFocusedDockable(this, tool);
+    }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    [JsonIgnore]
+    public ICommand? NextDocument { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    [JsonIgnore]
+    public ICommand? PreviousDocument { get; }
+
+    private void ActivateNextDocument()
+    {
+        ActivateDocumentByOffset(1);
+    }
+
+    private void ActivatePreviousDocument()
+    {
+        ActivateDocumentByOffset(-1);
+    }
+
+    private void ActivateDocumentByOffset(int offset)
+    {
+        if (VisibleDockables is { Count: > 0 } dockables)
+        {
+            var index = ActiveDockable is { } active ? dockables.IndexOf(active) : 0;
+            var nextIndex = (index + offset + dockables.Count) % dockables.Count;
+            var next = dockables[nextIndex];
+            Factory?.SetActiveDockable(next);
+            Factory?.SetFocusedDockable(this, next);
+        }
     }
 }

--- a/src/Dock.Model.Mvvm/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Mvvm/Controls/DocumentDock.cs
@@ -25,6 +25,8 @@ public class DocumentDock : DockBase, IDocumentDock
     public DocumentDock()
     {
         CreateDocument = new RelayCommand(CreateNewDocument);
+        NextDocument = new RelayCommand(ActivateNextDocument);
+        PreviousDocument = new RelayCommand(ActivatePreviousDocument);
     }
 
     /// <inheritdoc/>
@@ -92,5 +94,35 @@ public class DocumentDock : DockBase, IDocumentDock
         Factory?.AddDockable(this, tool);
         Factory?.SetActiveDockable(tool);
         Factory?.SetFocusedDockable(this, tool);
+    }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? NextDocument { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? PreviousDocument { get; }
+
+    private void ActivateNextDocument()
+    {
+        ActivateDocumentByOffset(1);
+    }
+
+    private void ActivatePreviousDocument()
+    {
+        ActivateDocumentByOffset(-1);
+    }
+
+    private void ActivateDocumentByOffset(int offset)
+    {
+        if (VisibleDockables is { Count: > 0 } dockables)
+        {
+            var index = ActiveDockable is { } active ? dockables.IndexOf(active) : 0;
+            var nextIndex = (index + offset + dockables.Count) % dockables.Count;
+            var next = dockables[nextIndex];
+            Factory?.SetActiveDockable(next);
+            Factory?.SetFocusedDockable(this, next);
+        }
     }
 }

--- a/src/Dock.Model.Prism/Controls/DocumentDock.cs
+++ b/src/Dock.Model.Prism/Controls/DocumentDock.cs
@@ -3,10 +3,10 @@
 using System;
 using System.Runtime.Serialization;
 using System.Windows.Input;
-using Prism.Commands;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Model.Prism.Core;
+using Prism.Commands;
 
 namespace Dock.Model.Prism.Controls;
 
@@ -25,6 +25,8 @@ public class DocumentDock : DockBase, IDocumentDock
     public DocumentDock()
     {
         CreateDocument = new DelegateCommand(CreateNewDocument);
+        NextDocument = new DelegateCommand(ActivateNextDocument);
+        PreviousDocument = new DelegateCommand(ActivatePreviousDocument);
     }
 
     /// <inheritdoc/>
@@ -92,5 +94,35 @@ public class DocumentDock : DockBase, IDocumentDock
         Factory?.AddDockable(this, tool);
         Factory?.SetActiveDockable(tool);
         Factory?.SetFocusedDockable(this, tool);
+    }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? NextDocument { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? PreviousDocument { get; }
+
+    private void ActivateNextDocument()
+    {
+        ActivateDocumentByOffset(1);
+    }
+
+    private void ActivatePreviousDocument()
+    {
+        ActivateDocumentByOffset(-1);
+    }
+
+    private void ActivateDocumentByOffset(int offset)
+    {
+        if (VisibleDockables is { Count: > 0 } dockables)
+        {
+            var index = ActiveDockable is { } active ? dockables.IndexOf(active) : 0;
+            var nextIndex = (index + offset + dockables.Count) % dockables.Count;
+            var next = dockables[nextIndex];
+            Factory?.SetActiveDockable(next);
+            Factory?.SetFocusedDockable(this, next);
+        }
     }
 }

--- a/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
+++ b/src/Dock.Model.ReactiveUI/Controls/DocumentDock.cs
@@ -24,6 +24,8 @@ public partial class DocumentDock : DockBase, IDocumentDock
     public DocumentDock()
     {
         CreateDocument = ReactiveCommand.Create(CreateNewDocument);
+        NextDocument = ReactiveCommand.Create(ActivateNextDocument);
+        PreviousDocument = ReactiveCommand.Create(ActivatePreviousDocument);
     }
 
     /// <inheritdoc/>
@@ -81,5 +83,35 @@ public partial class DocumentDock : DockBase, IDocumentDock
         Factory?.AddDockable(this, tool);
         Factory?.SetActiveDockable(tool);
         Factory?.SetFocusedDockable(this, tool);
+    }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? NextDocument { get; }
+
+    /// <inheritdoc/>
+    [IgnoreDataMember]
+    public ICommand? PreviousDocument { get; }
+
+    private void ActivateNextDocument()
+    {
+        ActivateDocumentByOffset(1);
+    }
+
+    private void ActivatePreviousDocument()
+    {
+        ActivateDocumentByOffset(-1);
+    }
+
+    private void ActivateDocumentByOffset(int offset)
+    {
+        if (VisibleDockables is { Count: > 0 } dockables)
+        {
+            var index = ActiveDockable is { } active ? dockables.IndexOf(active) : 0;
+            var nextIndex = (index + offset + dockables.Count) % dockables.Count;
+            var next = dockables[nextIndex];
+            Factory?.SetActiveDockable(next);
+            Factory?.SetFocusedDockable(this, next);
+        }
     }
 }

--- a/src/Dock.Model/Controls/IDocumentDock.cs
+++ b/src/Dock.Model/Controls/IDocumentDock.cs
@@ -41,4 +41,14 @@ public interface IDocumentDock : IDock
     /// </summary>
     /// <param name="tool">The tool to add.</param>
     void AddTool(IDockable tool);
+
+    /// <summary>
+    /// Activates the next document in <see cref="IDock.VisibleDockables"/>.
+    /// </summary>
+    ICommand? NextDocument { get; }
+
+    /// <summary>
+    /// Activates the previous document in <see cref="IDock.VisibleDockables"/>.
+    /// </summary>
+    ICommand? PreviousDocument { get; }
 }


### PR DESCRIPTION
## Summary
- add NextDocument and PreviousDocument commands to `IDocumentDock`
- implement commands in avalonia, mvvm, prism and reactive ui implementations
- wire Ctrl+Tab and Ctrl+Shift+Tab bindings in `DocumentDockControl`
- seed an extra document in the code-only sample to show cycling

## Testing
- `dotnet format src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj --no-restore`
- `dotnet format src/Dock.Model.Mvvm/Dock.Model.Mvvm.csproj --no-restore`
- `dotnet format src/Dock.Model.Prism/Dock.Model.Prism.csproj --no-restore`
- `dotnet format src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj --no-restore`
- `dotnet format samples/DockCodeOnlySample/DockCodeOnlySample.csproj --no-restore`
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687b49c1ab2483219f804f3e094b94ac