### PR TITLE
Support floating documents via tab strip drag

### DIFF
--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -7,8 +7,8 @@ using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
-using Dock.Model.Core;
 using Dock.Avalonia.Internal;
+using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
 
@@ -127,7 +127,7 @@ public class ToolChromeControl : ContentControl
 
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
     {
-        if (DataContext is IDock {Factory: { } factory} dock && dock.ActiveDockable is { })
+        if (DataContext is IDock { Factory: { } factory } dock && dock.ActiveDockable is { })
         {
             if (factory.FindRoot(dock.ActiveDockable, _ => true) is { } root)
             {
@@ -163,7 +163,8 @@ public class ToolChromeControl : ContentControl
 
                 return !(source is Button) &&
                        !WindowDragHelper.IsChildOfType<Button>(grip, source);
-            });
+            },
+            null);
     }
 
     private void AttachToWindow()


### PR DESCRIPTION
## Summary
- detect leaving the host window when dragging the document tab strip
- float the active document via `Factory.FloatDockable`
- snap the new window using existing magnetism logic

## Testing
- `dotnet format --no-restore --include src/Dock.Avalonia/Internal/WindowDragHelper.cs src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs`
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_687b49bfa5988321b01e7f4fbe9b5baf