### PR TITLE
Add IsModified support

### DIFF
--- a/samples/Notepad/ViewModels/Documents/FileViewModel.cs
+++ b/samples/Notepad/ViewModels/Documents/FileViewModel.cs
@@ -1,6 +1,6 @@
-﻿using Dock.Model.Mvvm.Controls;
+﻿using System.Collections.Generic;
 using Avalonia.Media;
-using System.Collections.Generic;
+using Dock.Model.Mvvm.Controls;
 
 namespace Notepad.ViewModels.Documents;
 
@@ -32,6 +32,7 @@ public class FileViewModel : Document
             {
                 _undoStack.Push(_text);
                 SetProperty(ref _text, value);
+                IsModified = true;
             }
         }
     }

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -199,6 +199,12 @@
                   <ContentPresenter ContentTemplate="{Binding $parent[DocumentControl].HeaderTemplate}"
                                     Content="{Binding}" />
                 </Panel>
+                <Ellipse Width="6"
+                         Height="6"
+                         Fill="{DynamicResource DockApplicationAccentBrushIndicator}"
+                         VerticalAlignment="Center"
+                         IsVisible="{Binding IsModified}"
+                         Margin="0,0,2,0" />
                 <Button x:Name="PART_CloseButton"
                         Command="{Binding Owner.Factory.CloseDockable}"
                         CommandParameter="{Binding}">

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -153,6 +153,12 @@ public abstract class DockableBase : ReactiveBase, IDockable
         AvaloniaProperty.RegisterDirect<DockableBase, bool>(nameof(CanDrop), o => o.CanDrop, (o, v) => o.CanDrop = v);
 
     /// <summary>
+    /// Defines the <see cref="IsModified"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockableBase, bool> IsModifiedProperty =
+        AvaloniaProperty.RegisterDirect<DockableBase, bool>(nameof(IsModified), o => o.IsModified, (o, v) => o.IsModified = v);
+
+    /// <summary>
     /// Defines the <see cref="MinWidth"/> property.
     /// </summary>
     public static readonly DirectProperty<DockableBase, double> MinWidthProperty =
@@ -202,6 +208,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
     private double _maxHeight = double.NaN;
+    private bool _isModified;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockableBase"/> class.
@@ -209,6 +216,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     protected DockableBase()
     {
         _trackingAdapter = new TrackingAdapter();
+        _isModified = false;
     }
 
     /// <inheritdoc/>
@@ -436,6 +444,15 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _canDrop;
         set => SetAndRaise(CanDropProperty, ref _canDrop, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("IsModified")]
+    public bool IsModified
+    {
+        get => _isModified;
+        set => SetAndRaise(IsModifiedProperty, ref _isModified, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Core/DockableBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockableBase.cs
@@ -38,6 +38,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
     private double _maxHeight = double.NaN;
+    private bool _isModified;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockableBase"/> class.
@@ -45,6 +46,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     protected DockableBase()
     {
         _trackingAdapter = new TrackingAdapter();
+        _isModified = false;
     }
 
     /// <inheritdoc/>
@@ -245,6 +247,14 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _canDrop;
         set => SetProperty(ref _canDrop, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool IsModified
+    {
+        get => _isModified;
+        set => SetProperty(ref _isModified, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Prism/Core/DockableBase.cs
+++ b/src/Dock.Model.Prism/Core/DockableBase.cs
@@ -38,6 +38,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private double _maxWidth = double.NaN;
     private double _minHeight = double.NaN;
     private double _maxHeight = double.NaN;
+    private bool _isModified;
 
     /// <summary>
     /// Initializes new instance of the <see cref="DockableBase"/> class.
@@ -45,6 +46,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     protected DockableBase()
     {
         _trackingAdapter = new TrackingAdapter();
+        _isModified = false;
     }
 
     /// <inheritdoc/>
@@ -245,6 +247,14 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _canDrop;
         set => SetProperty(ref _canDrop, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public bool IsModified
+    {
+        get => _isModified;
+        set => SetProperty(ref _isModified, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
@@ -38,6 +38,7 @@ public abstract partial class DockableBase : ReactiveBase, IDockable
         _maxWidth = double.NaN;
         _minHeight = double.NaN;
         _maxHeight = double.NaN;
+        _isModified = false;
         _trackingAdapter = new TrackingAdapter();
     }
 
@@ -140,6 +141,10 @@ public abstract partial class DockableBase : ReactiveBase, IDockable
     /// <inheritdoc/>
     [DataMember(IsRequired = false, EmitDefaultValue = true)]
     public partial bool CanDrop { get; set; }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial bool IsModified { get; set; }
 
     /// <inheritdoc/>
     public string? GetControlRecyclingId() => _id;

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -136,6 +136,11 @@ public interface IDockable : IControlRecyclingIdProvider
     bool CanDrop { get; set; }
 
     /// <summary>
+    /// Gets or sets whether the dockable has unsaved changes.
+    /// </summary>
+    bool IsModified { get; set; }
+
+    /// <summary>
     /// Called when the dockable is closed.
     /// </summary>
     /// <returns>true to accept the close, and false to cancel the close.</returns>


### PR DESCRIPTION
## Summary
- add `IsModified` property to `IDockable`
- implement the property across DockableBase classes
- show modification indicator in `DocumentTabStripItem`
- update Notepad sample to toggle `IsModified` on edits

## Testing
- `dotnet format --no-restore --include src/Dock.Model/Core/IDockable.cs src/Dock.Model.Mvvm/Core/DockableBase.cs src/Dock.Model.Prism/Core/DockableBase.cs src/Dock.Model.Avalonia/Core/DockableBase.cs src/Dock.Model.ReactiveUI/Core/DockableBase.cs src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml samples/Notepad/ViewModels/Documents/FileViewModel.cs`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687b49bde95c83218f832ad3300e8897