### PR TITLE
Add icon property for dockables

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -16,9 +16,14 @@
 
     <Setter Property="HeaderTemplate">
       <DataTemplate DataType="core:IDockable">
-        <TextBlock Text="{Binding Title}" 
-                   VerticalAlignment="Center"
-                   Padding="2"  />
+        <StackPanel Orientation="Horizontal"
+                    VerticalAlignment="Center"
+                    Spacing="2">
+          <ContentPresenter Content="{Binding Icon}" />
+          <TextBlock Text="{Binding Title}"
+                     VerticalAlignment="Center"
+                     Padding="2" />
+        </StackPanel>
       </DataTemplate>
     </Setter>
 

--- a/src/Dock.Avalonia/Themes/Accents/Fluent.axaml
+++ b/src/Dock.Avalonia/Themes/Accents/Fluent.axaml
@@ -29,6 +29,9 @@
     <StreamGeometry x:Key="DockIconMenuGeometry">M 352.041,32.0005L 320,0.000162761L 384,0.000162761L 352.041,32.0005 Z</StreamGeometry>
     <StreamGeometry x:Key="DockIconStatusDockGeometry">M8.41687 7.57953V2.41851C8.41687 2.18743 8.22932 1.99988 7.99823 1.99988C7.76715 1.99988 7.5796 2.18743 7.5796 2.41851V7.57953H2.41863C2.18755 7.57953 2 7.76708 2 7.99816C2 8.22925 2.18755 8.41679 2.41863 8.41679H7.5796V13.5812C7.5796 13.8123 7.76715 13.9999 7.99823 13.9999C8.22932 13.9999 8.41687 13.8123 8.41687 13.5812V8.41679L13.5799 8.41851C13.811 8.41851 13.9985 8.23096 13.9985 7.99988C13.9985 7.76879 13.811 7.58125 13.5799 7.58125L8.41687 7.57953Z</StreamGeometry>
     <StreamGeometry x:Key="DockIconStatusFloatGeometry">M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3 0,3z</StreamGeometry>
+    <!-- Sample icons -->
+    <StreamGeometry x:Key="DockIconSampleDocumentGeometry">M2 0H10L14 4V16H2Z</StreamGeometry>
+    <StreamGeometry x:Key="DockIconSampleStarGeometry">M8 0L10 6H16L11 10L13 16L8 12L3 16L5 10L0 6H6Z</StreamGeometry>
     <sys:Double x:Key="DockDragPreviewFontSize">10</sys:Double>
 
 </ResourceDictionary>

--- a/src/Dock.Avalonia/Themes/Accents/Simple.axaml
+++ b/src/Dock.Avalonia/Themes/Accents/Simple.axaml
@@ -29,6 +29,9 @@
     <StreamGeometry x:Key="DockIconMenuGeometry">M 352.041,32.0005L 320,0.000162761L 384,0.000162761L 352.041,32.0005 Z</StreamGeometry>
     <StreamGeometry x:Key="DockIconStatusDockGeometry">M8.41687 7.57953V2.41851C8.41687 2.18743 8.22932 1.99988 7.99823 1.99988C7.76715 1.99988 7.5796 2.18743 7.5796 2.41851V7.57953H2.41863C2.18755 7.57953 2 7.76708 2 7.99816C2 8.22925 2.18755 8.41679 2.41863 8.41679H7.5796V13.5812C7.5796 13.8123 7.76715 13.9999 7.99823 13.9999C8.22932 13.9999 8.41687 13.8123 8.41687 13.5812V8.41679L13.5799 8.41851C13.811 8.41851 13.9985 8.23096 13.9985 7.99988C13.9985 7.76879 13.811 7.58125 13.5799 7.58125L8.41687 7.57953Z</StreamGeometry>
     <StreamGeometry x:Key="DockIconStatusFloatGeometry">M0,0L0,9 9,9 9,0 0,0 0,3 8,3 8,8 1,8 1,3 0,3z</StreamGeometry>
+    <!-- Sample icons -->
+    <StreamGeometry x:Key="DockIconSampleDocumentGeometry">M2 0H10L14 4V16H2Z</StreamGeometry>
+    <StreamGeometry x:Key="DockIconSampleStarGeometry">M8 0L10 6H16L11 10L13 16L8 12L3 16L5 10L0 6H6Z</StreamGeometry>
     <sys:Double x:Key="DockDragPreviewFontSize">10</sys:Double>
 
 </ResourceDictionary>

--- a/src/Dock.Model.Avalonia/Core/DockableBase.cs
+++ b/src/Dock.Model.Avalonia/Core/DockableBase.cs
@@ -39,6 +39,12 @@ public abstract class DockableBase : ReactiveBase, IDockable
         AvaloniaProperty.RegisterDirect<DockableBase, string>(nameof(Title), o => o.Title, (o, v) => o.Title = v);
 
     /// <summary>
+    /// Defines the <see cref="Icon"/> property.
+    /// </summary>
+    public static readonly DirectProperty<DockableBase, object?> IconProperty =
+        AvaloniaProperty.RegisterDirect<DockableBase, object?>(nameof(Icon), o => o.Icon, (o, v) => o.Icon = v);
+
+    /// <summary>
     /// Defines the <see cref="Context"/> property.
     /// </summary>
     public static readonly DirectProperty<DockableBase, object?> ContextProperty =
@@ -179,6 +185,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private readonly TrackingAdapter _trackingAdapter;
     private string _id = string.Empty;
     private string _title = string.Empty;
+    private object? _icon;
     private object? _context;
     private IDockable? _owner;
     private IDockable? _originalOwner;
@@ -227,6 +234,15 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _title;
         set => SetAndRaise(TitleProperty, ref _title, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    [JsonPropertyName("Icon")]
+    public object? Icon
+    {
+        get => _icon;
+        set => SetAndRaise(IconProperty, ref _icon, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Mvvm/Core/DockableBase.cs
+++ b/src/Dock.Model.Mvvm/Core/DockableBase.cs
@@ -15,6 +15,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private readonly TrackingAdapter _trackingAdapter;
     private string _id = string.Empty;
     private string _title = string.Empty;
+    private object? _icon;
     private object? _context;
     private IDockable? _owner;
     private IDockable? _originalOwner;
@@ -61,6 +62,14 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _title;
         set => SetProperty(ref _title, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public object? Icon
+    {
+        get => _icon;
+        set => SetProperty(ref _icon, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.Prism/Core/DockableBase.cs
+++ b/src/Dock.Model.Prism/Core/DockableBase.cs
@@ -15,6 +15,7 @@ public abstract class DockableBase : ReactiveBase, IDockable
     private readonly TrackingAdapter _trackingAdapter;
     private string _id = string.Empty;
     private string _title = string.Empty;
+    private object? _icon;
     private object? _context;
     private IDockable? _owner;
     private IDockable? _originalOwner;
@@ -61,6 +62,14 @@ public abstract class DockableBase : ReactiveBase, IDockable
     {
         get => _title;
         set => SetProperty(ref _title, value);
+    }
+
+    /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public object? Icon
+    {
+        get => _icon;
+        set => SetProperty(ref _icon, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockableBase.cs
@@ -50,6 +50,10 @@ public abstract partial class DockableBase : ReactiveBase, IDockable
     public partial string Title { get; set; }
 
     /// <inheritdoc/>
+    [DataMember(IsRequired = false, EmitDefaultValue = true)]
+    public partial object? Icon { get; set; }
+
+    /// <inheritdoc/>
     [IgnoreDataMember]
     public partial object? Context { get; set; }
 

--- a/src/Dock.Model/Core/IDockable.cs
+++ b/src/Dock.Model/Core/IDockable.cs
@@ -21,6 +21,11 @@ public interface IDockable : IControlRecyclingIdProvider
     string Title { get; set; }
 
     /// <summary>
+    /// Gets or sets dockable icon.
+    /// </summary>
+    object? Icon { get; set; }
+
+    /// <summary>
     /// Gets or sets dockable context.
     /// </summary>
     object? Context { get; set; }


### PR DESCRIPTION
## Summary
- allow dockables to hold an optional `Icon`
- display the icon in `DocumentControl` tab headers
- provide sample geometries in accent themes

## Testing
- `dotnet format --no-restore` *(failed: Unable to fix IL2109)*
- `dotnet test --no-build` *(failed: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_687b49bd9a448321b2075c42d279409c