### PR TITLE
Add guide for displaying dock views

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [XAML guide](dock-xaml.md) – Declare layouts purely in XAML.
 - [Code-only guide](dock-code-only.md) – Build Dock layouts entirely in C#.
 - [User view model guide](dock-user-viewmodel.md) – Combine your own view models with Dock.
+- [Views guide](dock-views.md) – Display content for documents and tools.
 
 ## How-to guides
 - [Complex layout tutorials](dock-complex-layouts.md) – Multi-window and plug-in walkthroughs.

--- a/docs/dock-views.md
+++ b/docs/dock-views.md
@@ -1,0 +1,63 @@
+# Dock Views Guide
+
+Dock renders `Document` and `Tool` instances using standard Avalonia data templating. This guide shows how to present your own controls for these items.
+
+## Using `DataTemplate`
+
+The easiest approach is to define templates for the view models representing your documents and tools. Add them to `App.axaml` or another resource dictionary:
+
+```xaml
+<Application.DataTemplates>
+  <DataTemplate DataType="vm:DocumentViewModel">
+    <views:DocumentView />
+  </DataTemplate>
+  <DataTemplate DataType="vm:ToolViewModel">
+    <views:ToolView />
+  </DataTemplate>
+</Application.DataTemplates>
+```
+
+DockControl will automatically apply these templates when the corresponding view models are activated in the layout.
+
+## Using a `ViewLocator`
+
+More advanced scenarios can use a view locator. The sample `ViewLocator` in `samples/DockMvvmSample` implements `IDataTemplate` and returns views from a dictionary of factory functions:
+
+```csharp
+[StaticViewLocator]
+public partial class ViewLocator : IDataTemplate
+{
+    public Control? Build(object? data)
+    {
+        if (data is null)
+        {
+            return null;
+        }
+
+        var type = data.GetType();
+
+        if (s_views.TryGetValue(type, out var func))
+        {
+            return func.Invoke();
+        }
+
+        throw new Exception($"Unable to create view for type: {type}");
+    }
+
+    public bool Match(object? data)
+    {
+        return data is ObservableObject || data is IDockable;
+    }
+}
+```
+
+The `[StaticViewLocator]` attribute generates the `s_views` dictionary at build time. Register this locator in `App.axaml`:
+
+```xaml
+<Application.DataTemplates>
+  <local:ViewLocator />
+</Application.DataTemplates>
+```
+
+With either approach in place, documents and tools will show your custom controls when they are displayed.
+

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -77,8 +77,10 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    Add a `DockControl` placeholder to `MainWindow.axaml`:
 
    ```xaml
-   <DockControl x:Name="Dock" />
-   ```
+  <DockControl x:Name="Dock" />
+  ```
+
+   For instructions on mapping documents and tools to views see the [Views guide](dock-views.md).
 
 5. **Run the application**
 


### PR DESCRIPTION
## Summary
- add dock-views guide covering DataTemplates and ViewLocator usage
- reference the new guide in docs README and quick start

## Testing
- `dotnet format --no-restore --include docs/README.md docs/quick-start.md docs/dock-views.md`
- `dotnet test Dock.sln --no-build` *(fails: invalid argument for test assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_687cabae04cc8321909d0690cf0dfb66