### PR TITLE
Add extensible state objects

### DIFF
--- a/docs/dock-advanced.md
+++ b/docs/dock-advanced.md
@@ -36,6 +36,19 @@ public override void InitLayout(IDockable layout)
 }
 ```
 
+## Custom state classes
+
+`DockControl` and `HostWindow` instantiate default implementations that handle
+dragging logic. You can supply your own implementations when constructing the
+controls. Both `DockControlState` and `HostWindowState` are public so they can be
+derived from or replaced entirely.
+
+```csharp
+var manager = new DockManager();
+var control = new DockControl(manager, new MyDockControlState(manager, new DefaultDragOffsetCalculator()));
+var window  = new HostWindow(manager, w => new MyHostWindowState(manager, w));
+```
+
 ## Handling events
 
 `FactoryBase` exposes events for virtually every docking action. The samples subscribe to them to trace runtime changes:

--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -22,7 +22,7 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class DockControl : TemplatedControl, IDockControl
 {
-    private readonly DockManager _dockManager;
+    private readonly IDockManager _dockManager;
     private readonly DockControlState _dockControlState;
     private bool _isInitialized;
 
@@ -132,12 +132,20 @@ public class DockControl : TemplatedControl, IDockControl
     }
 
     /// <summary>
-    /// Initialize the new instance of the <see cref="DockControl"/>.
+    /// Initializes a new instance of the <see cref="DockControl"/> class.
     /// </summary>
+    /// <param name="dockManager">Optional dock manager implementation.</param>
+    /// <param name="dockControlState">Optional state implementation.</param>
     public DockControl()
+        : this(null, null)
     {
-        _dockManager = new DockManager();
-        _dockControlState = new DockControlState(_dockManager, _dragOffsetCalculator);
+    }
+
+    public DockControl(IDockManager? dockManager = null, DockControlState? dockControlState = null)
+    {
+        _dockManager = dockManager ?? new DockManager();
+        _dockControlState = dockControlState ?? new DockControlState(_dockManager, _dragOffsetCalculator);
+        _dockControlState.DragOffsetCalculator = _dragOffsetCalculator;
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         AddHandler(PointerReleasedEvent, ReleasedHandler, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
         AddHandler(PointerMovedEvent, MovedHandler, RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -27,7 +27,7 @@ namespace Dock.Avalonia.Controls;
 [TemplatePart("PART_TitleBar", typeof(HostWindowTitleBar))]
 public class HostWindow : Window, IHostWindow
 {
-    private readonly DockManager _dockManager;
+    private readonly IDockManager _dockManager;
     private readonly HostWindowState _hostWindowState;
     private List<Control> _chromeGrips = new();
     private HostWindowTitleBar? _hostWindowTitleBar;
@@ -96,13 +96,20 @@ public class HostWindow : Window, IHostWindow
     /// <summary>
     /// Initializes new instance of the <see cref="HostWindow"/> class.
     /// </summary>
+    /// <param name="dockManager">Optional dock manager implementation.</param>
+    /// <param name="stateFactory">Factory for the state object.</param>
     public HostWindow()
+        : this(null, null)
+    {
+    }
+
+    public HostWindow(IDockManager? dockManager = null, Func<HostWindow, HostWindowState>? stateFactory = null)
     {
         PositionChanged += HostWindow_PositionChanged;
         LayoutUpdated += HostWindow_LayoutUpdated;
 
-        _dockManager = new DockManager();
-        _hostWindowState = new HostWindowState(_dockManager, this);
+        _dockManager = dockManager ?? new DockManager();
+        _hostWindowState = stateFactory?.Invoke(this) ?? new HostWindowState(_dockManager, this);
         UpdatePseudoClasses(IsToolWindow, ToolChromeControlsWholeWindow, DocumentChromeControlsWholeWindow);
     }
 

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -46,9 +46,9 @@ internal class DockDragContext
 }
 
 /// <summary>
-/// Dock control state.
+/// Default implementation of <see cref="IDockControlState"/>.
 /// </summary>
-internal class DockControlState : DockManagerState, IDockControlState
+public class DockControlState : DockManagerState, IDockControlState
 {
     private readonly DockDragContext _context = new();
     private readonly DragPreviewHelper _dragPreviewHelper = new();

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -9,7 +9,10 @@ using Dock.Settings;
 
 namespace Dock.Avalonia.Internal;
 
-internal abstract class DockManagerState : IDockManagerState
+/// <summary>
+/// Base state class used by <see cref="DockControl"/> and <see cref="HostWindow"/>.
+/// </summary>
+public abstract class DockManagerState : IDockManagerState
 {
     private readonly IDockManager _dockManager;
 
@@ -17,9 +20,9 @@ internal abstract class DockManagerState : IDockManagerState
 
     protected Control? DropControl { get; set; }
 
-    protected AdornerHelper<DockTarget> LocalAdornerHelper { get; }
+    internal AdornerHelper<DockTarget> LocalAdornerHelper { get; }
 
-    protected AdornerHelper<GlobalDockTarget> GlobalAdornerHelper { get; }
+    internal AdornerHelper<GlobalDockTarget> GlobalAdornerHelper { get; }
  
     /// <summary>
     /// Initializes a new instance of the <see cref="DockManagerState"/> class.

--- a/src/Dock.Avalonia/Internal/EventType.cs
+++ b/src/Dock.Avalonia/Internal/EventType.cs
@@ -6,7 +6,7 @@ namespace Dock.Avalonia.Internal;
 /// <summary>
 /// Pointer event type.
 /// </summary>
-internal enum EventType
+public enum EventType
 {
     /// <summary>
     /// Pointer pressed.

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -49,9 +49,9 @@ internal class WindowDragContext
 }
     
 /// <summary>
-/// Host window state.
+/// Default implementation of <see cref="IHostWindowState"/>.
 /// </summary>
-internal class HostWindowState : DockManagerState, IHostWindowState
+public class HostWindowState : DockManagerState, IHostWindowState
 {
     private readonly HostWindow _hostWindow;
     private readonly WindowDragContext _context = new();

--- a/tests/Dock.Avalonia.UnitTests/Controls/ControlCtorTests.cs
+++ b/tests/Dock.Avalonia.UnitTests/Controls/ControlCtorTests.cs
@@ -1,5 +1,11 @@
 using Avalonia.Headless.XUnit;
 using Dock.Avalonia.Controls;
+using Dock.Avalonia.Internal;
+using Dock.Avalonia.Contract;
+using Avalonia;
+using Avalonia.Controls;
+using Dock.Model;
+using Dock.Model.Core;
 using Xunit;
 
 namespace Dock.Avalonia.UnitTests.Controls;
@@ -11,6 +17,28 @@ public class ControlCtorTests
     {
         var control = new DockControl();
         Assert.NotNull(control);
+    }
+
+    private sealed class DummyCalculator : IDragOffsetCalculator
+    {
+        public PixelPoint CalculateOffset(Control dragControl, DockControl dockControl, Point pointerPosition) => new PixelPoint();
+    }
+
+    private sealed class CustomDockState : DockControlState
+    {
+        public CustomDockState(IDockManager manager, IDragOffsetCalculator calc)
+            : base(manager, calc)
+        {
+        }
+    }
+
+    [AvaloniaFact]
+    public void DockControl_CustomState_Ctor()
+    {
+        var manager = new DockManager();
+        var state = new CustomDockState(manager, new DummyCalculator());
+        var control = new DockControl(manager, state);
+        Assert.Same(state, control.DockControlState);
     }
 
     [AvaloniaFact]
@@ -95,6 +123,22 @@ public class ControlCtorTests
     {
         var control = new HostWindow();
         Assert.NotNull(control);
+    }
+
+    private sealed class CustomWindowState : HostWindowState
+    {
+        public CustomWindowState(IDockManager manager, HostWindow window)
+            : base(manager, window)
+        {
+        }
+    }
+
+    [AvaloniaFact]
+    public void HostWindow_CustomState_Ctor()
+    {
+        var manager = new DockManager();
+        var window = new HostWindow(manager, w => new CustomWindowState(manager, w));
+        Assert.IsType<CustomWindowState>(window.HostWindowState);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary
- make DockManagerState and default states public
- allow supplying custom state objects via DockControl and HostWindow constructors
- document extensibility in advanced guide
- add tests for custom state constructors

## Testing
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687cabae73c48321b2ad219b9aea6f3e