### PR TITLE
Ensure documents close when HostWindow exits

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -36,7 +36,7 @@ public class HostWindow : Window, IHostWindow
     /// <summary>
     /// Define <see cref="IsToolWindow"/> property.
     /// </summary>
-    public static readonly StyledProperty<bool> IsToolWindowProperty = 
+    public static readonly StyledProperty<bool> IsToolWindowProperty =
         AvaloniaProperty.Register<HostWindow, bool>(nameof(IsToolWindow));
 
     /// <summary>
@@ -50,7 +50,7 @@ public class HostWindow : Window, IHostWindow
     /// </summary>
     public static readonly StyledProperty<bool> DocumentChromeControlsWholeWindowProperty =
         AvaloniaProperty.Register<HostWindow, bool>(nameof(DocumentChromeControlsWholeWindow));
-    
+
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(HostWindow);
 
@@ -337,11 +337,14 @@ public class HostWindow : Window, IHostWindow
     {
         switch (dockable)
         {
-            case ITool: return 1;
-            case IDocument: return 1;
+            case ITool:
+                return 1;
+            case IDocument:
+                return 1;
             case IDock dock:
                 return dock.VisibleDockables?.Sum(CountVisibleToolsAndDocuments) ?? 0;
-            default: return 0;
+            default:
+                return 0;
         }
     }
 
@@ -397,6 +400,19 @@ public class HostWindow : Window, IHostWindow
 
             if (Window.Layout is IDock root)
             {
+                var documents = Window.Factory?
+                    .Find(root, d => d is IDocument)
+                    .OfType<IDockable>()
+                    .ToList();
+
+                if (documents is not null)
+                {
+                    foreach (var document in documents)
+                    {
+                        Window.Factory.CloseDockable(document);
+                    }
+                }
+
                 if (root.Close.CanExecute(null))
                 {
                     root.Close.Execute(null);

--- a/tests/Dock.Avalonia.HeadlessTests/HostWindowDocumentCloseTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/HostWindowDocumentCloseTests.cs
@@ -1,0 +1,55 @@
+using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Controls;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class HostWindowDocumentCloseTests
+{
+    private class ClosingDocument : Document
+    {
+        public bool Closed { get; private set; }
+
+        public override bool OnClose()
+        {
+            Closed = true;
+            return base.OnClose();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Closing_HostWindow_Closes_Document()
+    {
+        var factory = new Factory
+        {
+            DefaultHostWindowLocator = () => new HostWindow()
+        };
+        var root = new RootDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>(),
+            Windows = factory.CreateList<IDockWindow>()
+        };
+        root.Factory = factory;
+
+        var docDock = new DocumentDock { VisibleDockables = factory.CreateList<IDockable>() };
+        factory.AddDockable(root, docDock);
+        docDock.Factory = factory;
+        root.ActiveDockable = docDock;
+
+        var doc = new ClosingDocument();
+        factory.AddDockable(docDock, doc);
+        docDock.ActiveDockable = doc;
+
+        factory.SplitToWindow(docDock, doc, 0, 0, 100, 100);
+
+        var window = Assert.IsType<DockWindow>(root.Windows![0]);
+        Assert.IsType<HostWindow>(window.Host);
+        ((HostWindow)window.Host!).Exit();
+
+        Assert.True(doc.Closed);
+    }
+}


### PR DESCRIPTION
## Summary
- close documents via `Factory.CloseDockable` when a `HostWindow` closes
- add regression test to verify `Document.OnClose` is called when closing a detached window

## Testing
- `dotnet format --no-restore --include tests/Dock.Avalonia.HeadlessTests/HostWindowDocumentCloseTests.cs src/Dock.Avalonia/Controls/HostWindow.axaml.cs`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687cabaf028c83218b96788e603521ce