### PR TITLE
Fix tool dock collapse on move

### DIFF
--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -216,6 +216,10 @@ public abstract partial class FactoryBase
                 OnDockableDocked(sourceDockable, DockOperation.Fill);
                 InitDockable(sourceDockable, targetDock);
                 targetDock.ActiveDockable = sourceDockable;
+                if (targetDock is IToolDock targetToolDock)
+                {
+                    targetToolDock.IsExpanded = true;
+                }
             }
         }
     }

--- a/tests/Dock.Model.Mvvm.UnitTests/ToolMovementTests.cs
+++ b/tests/Dock.Model.Mvvm.UnitTests/ToolMovementTests.cs
@@ -1,0 +1,42 @@
+using Dock.Model.Core;
+using Dock.Model.Mvvm;
+using Dock.Model.Mvvm.Controls;
+using Xunit;
+
+namespace Dock.Model.Mvvm.UnitTests;
+
+public class ToolMovementTests
+{
+    [Fact]
+    public void Moving_Tool_To_AutoHide_Dock_Expands_Target()
+    {
+        var factory = new Factory();
+
+        var left = new ToolDock { Alignment = Alignment.Left, IsExpanded = true, AutoHide = false };
+        var right = new ToolDock { Alignment = Alignment.Right, IsExpanded = false, AutoHide = true };
+        left.VisibleDockables = factory.CreateList<IDockable>();
+        right.VisibleDockables = factory.CreateList<IDockable>();
+
+        var leftTool = new Tool { Id = "left" };
+        var rightTool = new Tool { Id = "right" };
+
+        factory.AddDockable(left, leftTool);
+        factory.AddDockable(right, rightTool);
+
+        var layout = new ProportionalDock
+        {
+            Orientation = Orientation.Horizontal,
+            VisibleDockables = factory.CreateList<IDockable>(left, right)
+        };
+
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>(layout) };
+        factory.InitLayout(root);
+
+        factory.MoveDockable(left, right, leftTool, null);
+
+        Assert.True(right.IsExpanded);
+        Assert.Contains(leftTool, right.VisibleDockables!);
+        Assert.Null(root.HiddenDockables);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand tool dock when moving a tool
- add regression test for tool movement

## Testing
- `dotnet format --no-restore --include src/Dock.Model/FactoryBase.Dockable.cs tests/Dock.Model.Mvvm.UnitTests/ToolMovementTests.cs`
- `dotnet test --no-build --nologo`

------
https://chatgpt.com/codex/tasks/task_e_687cabb062688321a8282a9100ccc801