### PR TITLE
Fix focus for floating windows

### DIFF
--- a/src/Dock.Model/FactoryBase.Init.cs
+++ b/src/Dock.Model/FactoryBase.Init.cs
@@ -44,7 +44,7 @@ public abstract partial class FactoryBase
                 dockable.Context = context;
             }
         }
- 
+
         dockable.Owner = owner;
 
         if (dockable is IDock dock)
@@ -139,9 +139,9 @@ public abstract partial class FactoryBase
         if (dockable is { })
         {
             SetFocusedDockable(owner, dockable);
-        } 
+        }
     }
-    
+
     /// <inheritdoc/>
     public virtual void SetActiveDockable(IDockable dockable)
     {
@@ -170,11 +170,12 @@ public abstract partial class FactoryBase
 
                 foreach (var result in results)
                 {
-                    if (result is IRootDock rootDock 
+                    if (result is IRootDock rootDock
                         && rootDock.IsFocusableRoot
                         && rootDock != root)
                     {
-                        if (rootDock.FocusedDockable?.Owner is not null)
+                        if (rootDock.Window is null
+                            && rootDock.FocusedDockable?.Owner is not null)
                         {
                             SetIsActive(rootDock.FocusedDockable.Owner, false);
                         }
@@ -182,7 +183,7 @@ public abstract partial class FactoryBase
                 }
             }
 
-            if (root.FocusedDockable?.Owner is not null)
+            if (root.Window is null && root.FocusedDockable?.Owner is not null)
             {
                 SetIsActive(root.FocusedDockable.Owner, false);
             }

--- a/tests/Dock.Avalonia.HeadlessTests/FocusFloatingWindowTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/FocusFloatingWindowTests.cs
@@ -1,0 +1,53 @@
+using Avalonia.Headless.XUnit;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Avalonia.Core;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class FocusFloatingWindowTests
+{
+    [AvaloniaFact]
+    public void Focusing_Tool_In_Floating_Window_Does_Not_Close_Window()
+    {
+        var factory = new Factory();
+        var root = new RootDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>(),
+            Windows = factory.CreateList<IDockWindow>()
+        };
+        root.Factory = factory;
+
+        var mainDock = new DocumentDock { VisibleDockables = factory.CreateList<IDockable>() };
+        mainDock.Factory = factory;
+        factory.AddDockable(root, mainDock);
+        root.ActiveDockable = mainDock;
+        root.FocusedDockable = mainDock;
+
+        var floatingRoot = new RootDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        floatingRoot.Factory = factory;
+        var toolDock = new ToolDock { VisibleDockables = factory.CreateList<IDockable>() };
+        toolDock.Factory = factory;
+        factory.AddDockable(floatingRoot, toolDock);
+        floatingRoot.ActiveDockable = toolDock;
+        floatingRoot.FocusedDockable = toolDock;
+
+        var tool = new Tool();
+        factory.AddDockable(toolDock, tool);
+        factory.SetActiveDockable(tool);
+        factory.SetFocusedDockable(toolDock, tool);
+
+        var window = new DockWindow { Layout = floatingRoot };
+        factory.AddWindow(root, window);
+
+        factory.SetFocusedDockable(toolDock, tool);
+
+        Assert.Contains(window, root.Windows);
+    }
+}
+


### PR DESCRIPTION
## Summary
- keep floating windows active when changing focus
- test focusing a tool in a floating window

## Testing
- `dotnet test --no-build --no-restore` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_687cabb5471483219d5b0c6ea25ea572