### PR TITLE
Add ShowPinMenu setting

### DIFF
--- a/docs/dock-pinned-window.md
+++ b/docs/dock-pinned-window.md
@@ -8,3 +8,10 @@ DockSettings.UsePinnedDockWindow = true;
 ```
 
 When enabled the `PinnedDockControl` places the preview content inside a lightweight `PinnedDockWindow`. The window follows the host layout and closes automatically when the tool is hidden.
+
+`ToolChromeControl` exposes a `ShowPinMenu` option that hides pin and unpin commands when set to `false`.
+
+```csharp
+// Hide pin options
+ToolChromeControl.ShowPinMenu = false;
+```

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml
@@ -27,8 +27,14 @@
     <MenuItem Header="{DynamicResource ToolChromeControlDockString}"
               Command="{Binding Owner.Factory.PinDockable}"
               CommandParameter="{Binding ActiveDockable}"
-              IsEnabled="{Binding ActiveDockable.OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}"
-              IsVisible="{Binding ActiveDockable.CanPin, FallbackValue=False}"/>
+              IsEnabled="{Binding ActiveDockable.OriginalOwner, Converter={x:Static ObjectConverters.IsNotNull}, FallbackValue=False}">
+      <MenuItem.IsVisible>
+        <MultiBinding Converter="{x:Static BoolConverters.And}">
+          <Binding Path="ActiveDockable.CanPin" FallbackValue="{x:False}" />
+          <Binding Path="$parent[ToolChromeControl].ShowPinMenu" />
+        </MultiBinding>
+      </MenuItem.IsVisible>
+    </MenuItem>
     <MenuItem Header="{DynamicResource ToolChromeControlDockAsDocumentString}"
               Command="{Binding Owner.Factory.DockAsDocument}"
               CommandParameter="{Binding ActiveDockable}"
@@ -41,6 +47,7 @@
         <MultiBinding Converter="{x:Static BoolConverters.And}">
           <Binding Path="ActiveDockable.CanPin" FallbackValue="{x:False}" />
           <Binding Path="$parent[ToolChromeControl].IsFloating" Converter="{x:Static BoolConverters.Not}" />
+          <Binding Path="$parent[ToolChromeControl].ShowPinMenu" />
         </MultiBinding>
       </MenuItem.IsVisible>
     </MenuItem>
@@ -121,6 +128,7 @@
                       <MultiBinding Converter="{x:Static BoolConverters.And}">
                         <Binding Path="ActiveDockable.CanPin" FallbackValue="{x:False}" />
                         <TemplateBinding Property="IsFloating" Converter="{x:Static BoolConverters.Not}" />
+                        <TemplateBinding Property="ShowPinMenu" />
                       </MultiBinding>
                     </Button.IsVisible>
                     <Viewbox>

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -55,6 +55,21 @@ public class ToolChromeControl : ContentControl
         AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(IsMaximized));
 
     /// <summary>
+    /// Define the <see cref="ShowPinMenu"/> property.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowPinMenuProperty =
+        AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(ShowPinMenu), true);
+
+    /// <summary>
+    /// Gets or sets if pin menu options are visible.
+    /// </summary>
+    public bool ShowPinMenu
+    {
+        get => GetValue(ShowPinMenuProperty);
+        set => SetValue(ShowPinMenuProperty, value);
+    }
+
+    /// <summary>
     /// Gets or sets is pinned
     /// </summary>
     public bool IsPinned

--- a/tests/Dock.Avalonia.HeadlessTests/ToolChromeControlTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/ToolChromeControlTests.cs
@@ -1,0 +1,23 @@
+using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Controls;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class ToolChromeControlTests
+{
+    [AvaloniaFact]
+    public void ShowPinMenu_Defaults_To_True()
+    {
+        var control = new ToolChromeControl();
+        Assert.True(control.ShowPinMenu);
+    }
+
+    [AvaloniaFact]
+    public void ShowPinMenu_Can_Be_Disabled()
+    {
+        var control = new ToolChromeControl { ShowPinMenu = false };
+        Assert.False(control.ShowPinMenu);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `ShowPinMenu` property to `ToolChromeControl`
- hide pin button and menu items when `ShowPinMenu` is disabled
- document how to hide pin options
- add tests for the new property

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687cabb8cb708321844f3da5a1eaad05