### PR TITLE
Enable floating drag preview option

### DIFF
--- a/docs/dock-window-drag.md
+++ b/docs/dock-window-drag.md
@@ -31,3 +31,19 @@ With the property enabled, `DocumentTabStrip` listens for pointer events on its 
 - **Tabbed layouts** – When multiple documents share a single window, the tab strip becomes the primary handle for moving that window.
 
 See the [Advanced guide](dock-advanced.md) for details on customizing floating windows.
+
+## Floating preview window
+
+`DockSettings` exposes an option to show the dragged item in a floating preview window. This keeps the preview visible when dragging over native controls.
+
+```csharp
+DockSettings.UseFloatingDragPreview = true;
+```
+
+Enable it via the app builder with:
+
+```csharp
+AppBuilder.Configure<App>()
+    .UsePlatformDetect()
+    .UseFloatingDragPreview();
+```

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -51,7 +51,6 @@ internal class DockDragContext
 internal class DockControlState : DockManagerState, IDockControlState
 {
     private readonly DockDragContext _context = new();
-    private readonly DragPreviewHelper _dragPreviewHelper = new();
 
     public IDragOffsetCalculator DragOffsetCalculator { get; set; }
 
@@ -296,7 +295,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                     }
                 }
 
-                _dragPreviewHelper.Hide();
+                DragPreviewHelper.Hide();
 
                 Leave();
                 _context.End();
@@ -325,7 +324,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                             _context.DragOffset = DragOffsetCalculator.CalculateOffset(
                                 _context.DragControl, inputActiveDockControl, _context.DragStartPoint);
 
-                            _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
+                            DragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
                         }
                         _context.DoDragDrop = true;
                     }
@@ -439,7 +438,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                         preview = "Float";
                     }
 
-                    _dragPreviewHelper.Move(screenPoint, _context.DragOffset, preview);
+                    DragPreviewHelper.Move(screenPoint, _context.DragOffset, preview);
                 }
                 break;
             }
@@ -453,7 +452,7 @@ internal class DockControlState : DockManagerState, IDockControlState
             }
             case EventType.CaptureLost:
             {
-                _dragPreviewHelper.Hide();
+                DragPreviewHelper.Hide();
                 Leave();
                 _context.End();
                 DropControl = null;

--- a/src/Dock.Avalonia/Internal/DockManagerState.cs
+++ b/src/Dock.Avalonia/Internal/DockManagerState.cs
@@ -20,6 +20,8 @@ internal abstract class DockManagerState : IDockManagerState
     protected AdornerHelper<DockTarget> LocalAdornerHelper { get; }
 
     protected AdornerHelper<GlobalDockTarget> GlobalAdornerHelper { get; }
+
+    protected DragPreviewHelper DragPreviewHelper { get; }
  
     /// <summary>
     /// Initializes a new instance of the <see cref="DockManagerState"/> class.
@@ -30,6 +32,7 @@ internal abstract class DockManagerState : IDockManagerState
         _dockManager = dockManager;
         LocalAdornerHelper = new AdornerHelper<DockTarget>(DockSettings.UseFloatingDockAdorner);
         GlobalAdornerHelper = new AdornerHelper<GlobalDockTarget>(DockSettings.UseFloatingDockAdorner);
+        DragPreviewHelper = new DragPreviewHelper(DockSettings.UseFloatingDragPreview);
     }
 
     protected void AddAdorners(bool isLocalValid, bool isGlobalValid)

--- a/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
+++ b/src/Dock.Avalonia/Internal/DragPreviewHelper.cs
@@ -7,8 +7,14 @@ namespace Dock.Avalonia.Internal;
 
 internal class DragPreviewHelper
 {
+    private readonly bool _useFloatingDragPreview;
     private DragPreviewWindow? _window;
     private DragPreviewControl? _control;
+
+    public DragPreviewHelper(bool useFloatingDragPreview)
+    {
+        _useFloatingDragPreview = useFloatingDragPreview;
+    }
 
     private static PixelPoint GetPositionWithinWindow(Window window, PixelPoint position, PixelPoint offset)
     {
@@ -26,6 +32,11 @@ internal class DragPreviewHelper
 
     public void Show(IDockable dockable, PixelPoint position, PixelPoint offset)
     {
+        if (!_useFloatingDragPreview)
+        {
+            return;
+        }
+
         Hide();
 
         _control = new DragPreviewControl
@@ -46,7 +57,7 @@ internal class DragPreviewHelper
 
     public void Move(PixelPoint position, PixelPoint offset, string status)
     {
-        if (_window is null || _control is null)
+        if (!_useFloatingDragPreview || _window is null || _control is null)
         {
             return;
         }
@@ -57,7 +68,7 @@ internal class DragPreviewHelper
 
     public void Hide()
     {
-        if (_window is null)
+        if (!_useFloatingDragPreview || _window is null)
         {
             return;
         }

--- a/src/Dock.Settings/AppBuilderExtensions.cs
+++ b/src/Dock.Settings/AppBuilderExtensions.cs
@@ -40,6 +40,11 @@ public static class AppBuilderExtensions
             DockSettings.UseFloatingDockAdorner = options.UseFloatingDockAdorner.Value;
         }
 
+        if (options.UseFloatingDragPreview != null)
+        {
+            DockSettings.UseFloatingDragPreview = options.UseFloatingDragPreview.Value;
+        }
+
         if (options.UsePinnedDockWindow != null)
         {
             DockSettings.UsePinnedDockWindow = options.UsePinnedDockWindow.Value;
@@ -79,6 +84,20 @@ public static class AppBuilderExtensions
         bool enable = true)
     {
         DockSettings.UseFloatingDockAdorner = enable;
+        return builder;
+    }
+
+    /// <summary>
+    /// Sets <see cref="DockSettings.UseFloatingDragPreview"/> to the given value.
+    /// </summary>
+    /// <param name="builder">The app builder.</param>
+    /// <param name="enable">Whether to use a floating preview window.</param>
+    /// <returns>The app builder instance.</returns>
+    public static AppBuilder UseFloatingDragPreview(
+        this AppBuilder builder,
+        bool enable = true)
+    {
+        DockSettings.UseFloatingDragPreview = enable;
         return builder;
     }
 

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -27,6 +27,11 @@ public static class DockSettings
     public static bool UseFloatingDockAdorner = false;
 
     /// <summary>
+    /// Show drag preview using a floating window.
+    /// </summary>
+    public static bool UseFloatingDragPreview = false;
+
+    /// <summary>
     /// Show auto-hidden dockables inside a floating window.
     /// </summary>
     public static bool UsePinnedDockWindow = false;

--- a/src/Dock.Settings/DockSettingsOptions.cs
+++ b/src/Dock.Settings/DockSettingsOptions.cs
@@ -24,6 +24,11 @@ public class DockSettingsOptions
     public bool? UseFloatingDockAdorner { get; set; }
 
     /// <summary>
+    /// Optional floating drag preview flag.
+    /// </summary>
+    public bool? UseFloatingDragPreview { get; set; }
+
+    /// <summary>
     /// Optional floating pinned dock window flag.
     /// </summary>
     public bool? UsePinnedDockWindow { get; set; }

--- a/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
+++ b/tests/Dock.Settings.UnitTests/AppBuilderExtensionsTests.cs
@@ -20,6 +20,7 @@ public class AppBuilderExtensionsTests
             MinimumHorizontalDragDistance = 10,
             MinimumVerticalDragDistance = 12,
             UseFloatingDockAdorner = true,
+            UseFloatingDragPreview = true,
             UsePinnedDockWindow = true,
             EnableGlobalDocking = false,
             UseOwnerForFloatingWindows = false
@@ -31,6 +32,7 @@ public class AppBuilderExtensionsTests
         Assert.Equal(10, DockSettings.MinimumHorizontalDragDistance);
         Assert.Equal(12, DockSettings.MinimumVerticalDragDistance);
         Assert.True(DockSettings.UseFloatingDockAdorner);
+        Assert.True(DockSettings.UseFloatingDragPreview);
         Assert.True(DockSettings.UsePinnedDockWindow);
         Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);
@@ -62,11 +64,13 @@ public class AppBuilderExtensionsTests
         var builder = CreateBuilder();
 
         builder.UseFloatingDockAdorner(true)
+               .UseFloatingDragPreview(true)
                .UsePinnedDockWindow(true)
                .EnableGlobalDocking(false)
                .UseOwnerForFloatingWindows(false);
 
         Assert.True(DockSettings.UseFloatingDockAdorner);
+        Assert.True(DockSettings.UseFloatingDragPreview);
         Assert.True(DockSettings.UsePinnedDockWindow);
         Assert.False(DockSettings.EnableGlobalDocking);
         Assert.False(DockSettings.UseOwnerForFloatingWindows);


### PR DESCRIPTION
## Summary
- add `UseFloatingDragPreview` flag to DockSettings
- configure via AppBuilderExtensions
- integrate preview helper in DockManagerState and DockControlState
- document floating drag preview window
- test new option

## Testing
- `dotnet format --no-restore`
- `dotnet test Dock.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687cabb8064c832187080bd10a60cd47