### PR TITLE
Fix pinned tool restoration

### DIFF
--- a/src/Dock.Model/DockState.cs
+++ b/src/Dock.Model/DockState.cs
@@ -150,6 +150,11 @@ public class DockState : IDockState
         {
             RestoreDockable(dockable);
 
+            if (dockable.OriginalOwner is { })
+            {
+                dockable.Owner = dockable.OriginalOwner;
+            }
+
             if (dockable is IDock childDock)
             {
                 Restore(childDock);
@@ -162,35 +167,35 @@ public class DockState : IDockState
         switch (dockable)
         {
             case IToolContent tool:
-            {
-                var id = tool.Id;
-                if (!string.IsNullOrEmpty(id))
                 {
-                    _toolContents[id] = tool.Content;
-                }
+                    var id = tool.Id;
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        _toolContents[id] = tool.Content;
+                    }
 
-                break;
-            }
+                    break;
+                }
             case IDocumentContent document:
-            {
-                var id = document.Id;
-                if (!string.IsNullOrEmpty(id))
                 {
-                    _documentContents[id] = document.Content;
-                }
+                    var id = document.Id;
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        _documentContents[id] = document.Content;
+                    }
 
-                break;
-            }
+                    break;
+                }
             case IDocumentDockContent documentDock:
-            {
-                var id = documentDock.Id;
-                if (!string.IsNullOrEmpty(id))
                 {
-                    _documentTemplates[id] = documentDock.DocumentTemplate;
-                }
+                    var id = documentDock.Id;
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        _documentTemplates[id] = documentDock.DocumentTemplate;
+                    }
 
-                break;
-            }
+                    break;
+                }
         }
     }
 
@@ -199,57 +204,57 @@ public class DockState : IDockState
         switch (dockable)
         {
             case IToolContent tool:
-            {
-                var id = tool.Id;
-                if (!string.IsNullOrEmpty(id))
                 {
-                    if (_toolContents.TryGetValue(id, out var content))
+                    var id = tool.Id;
+                    if (!string.IsNullOrEmpty(id))
                     {
-                        tool.Content = content;
-                    }
-                }
-
-                break;
-            }
-            case IDocumentContent document:
-            {
-                var haveContent = false;
-                var id = document.Id;
-                if (!string.IsNullOrEmpty(id))
-                {
-                    if (_documentContents.TryGetValue(id, out var content))
-                    {
-                        document.Content = content;
-                        haveContent = true;
-                    }
-                }
-
-                if (haveContent == false)
-                {
-                    if (document.Owner is IDocumentDockContent documentDock)
-                    {
-                        if (documentDock.DocumentTemplate is { })
+                        if (_toolContents.TryGetValue(id, out var content))
                         {
-                           document.Content = documentDock.DocumentTemplate.Content;
+                            tool.Content = content;
                         }
                     }
-                }
 
-                break;
-            }
-            case IDocumentDockContent documentDock:
-            {
-                var id = documentDock.Id;
-                if (!string.IsNullOrEmpty(id))
+                    break;
+                }
+            case IDocumentContent document:
                 {
-                    if (_documentTemplates.TryGetValue(id, out var content))
+                    var haveContent = false;
+                    var id = document.Id;
+                    if (!string.IsNullOrEmpty(id))
                     {
-                        documentDock.DocumentTemplate = content;
+                        if (_documentContents.TryGetValue(id, out var content))
+                        {
+                            document.Content = content;
+                            haveContent = true;
+                        }
                     }
-                }
 
-                break;
-            }
+                    if (haveContent == false)
+                    {
+                        if (document.Owner is IDocumentDockContent documentDock)
+                        {
+                            if (documentDock.DocumentTemplate is { })
+                            {
+                                document.Content = documentDock.DocumentTemplate.Content;
+                            }
+                        }
+                    }
+
+                    break;
+                }
+            case IDocumentDockContent documentDock:
+                {
+                    var id = documentDock.Id;
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        if (_documentTemplates.TryGetValue(id, out var content))
+                        {
+                            documentDock.DocumentTemplate = content;
+                        }
+                    }
+
+                    break;
+                }
         }
     }
 

--- a/src/Dock.Model/FactoryBase.Dockable.cs
+++ b/src/Dock.Model/FactoryBase.Dockable.cs
@@ -375,186 +375,190 @@ public abstract partial class FactoryBase
         switch (dockable.Owner)
         {
             case IToolDock toolDock:
-            {
-                var rootDock = FindRoot(dockable, _ => true);
-                if (rootDock is null)
                 {
-                    return;
-                }
-
-                var isVisible = false;
-
-                if (toolDock.VisibleDockables is not null)
-                {
-                    isVisible = toolDock.VisibleDockables.Contains(dockable);
-                }
-
-                var isPinned = IsDockablePinned(dockable, rootDock);
-
-                var originalToolDock = dockable.OriginalOwner as IToolDock;
-
-                var alignment = originalToolDock?.Alignment ?? toolDock.Alignment;
-
-                if (isVisible && !isPinned)
-                {
-                    // Pin dockable.
-
-                    switch (alignment)
+                    var rootDock = FindRoot(dockable, _ => true);
+                    if (rootDock is null)
                     {
-                        case Alignment.Unset:
-                        case Alignment.Left:
-                        {
-                            rootDock.LeftPinnedDockables ??= CreateList<IDockable>();
-                            break;
-                        }
-                        case Alignment.Right:
-                        {
-                            rootDock.RightPinnedDockables ??= CreateList<IDockable>();
-                            break;
-                        }
-                        case Alignment.Top:
-                        {
-                            rootDock.TopPinnedDockables ??= CreateList<IDockable>();
-                            break;
-                        }
-                        case Alignment.Bottom:
-                        {
-                            rootDock.BottomPinnedDockables ??= CreateList<IDockable>();
-                            break;
-                        }
+                        return;
                     }
+
+                    var isVisible = false;
 
                     if (toolDock.VisibleDockables is not null)
                     {
-                        RemoveVisibleDockable(toolDock, dockable);
-                        OnDockableRemoved(dockable);
+                        isVisible = toolDock.VisibleDockables.Contains(dockable);
                     }
 
-                    switch (alignment)
+                    var isPinned = IsDockablePinned(dockable, rootDock);
+
+                    var originalToolDock = dockable.OriginalOwner as IToolDock;
+
+                    var alignment = originalToolDock?.Alignment ?? toolDock.Alignment;
+
+                    if (isVisible && !isPinned)
                     {
-                        case Alignment.Unset:
-                        case Alignment.Left:
+                        if (dockable.OriginalOwner is null)
                         {
-                            if (rootDock.LeftPinnedDockables is not null)
-                            {
-                                rootDock.LeftPinnedDockables.Add(dockable);
-                                OnDockablePinned(dockable);
-                            }
-
-                            break;
+                            dockable.OriginalOwner = dockable.Owner;
                         }
-                        case Alignment.Right:
+                        // Pin dockable.
+
+                        switch (alignment)
                         {
-                            if (rootDock.RightPinnedDockables is not null)
-                            {
-                                rootDock.RightPinnedDockables.Add(dockable);
-                                OnDockablePinned(dockable);
-                            }
-
-                            break;
+                            case Alignment.Unset:
+                            case Alignment.Left:
+                                {
+                                    rootDock.LeftPinnedDockables ??= CreateList<IDockable>();
+                                    break;
+                                }
+                            case Alignment.Right:
+                                {
+                                    rootDock.RightPinnedDockables ??= CreateList<IDockable>();
+                                    break;
+                                }
+                            case Alignment.Top:
+                                {
+                                    rootDock.TopPinnedDockables ??= CreateList<IDockable>();
+                                    break;
+                                }
+                            case Alignment.Bottom:
+                                {
+                                    rootDock.BottomPinnedDockables ??= CreateList<IDockable>();
+                                    break;
+                                }
                         }
-                        case Alignment.Top:
+
+                        if (toolDock.VisibleDockables is not null)
                         {
-                            if (rootDock.TopPinnedDockables is not null)
-                            {
-                                rootDock.TopPinnedDockables.Add(dockable);
-                                OnDockablePinned(dockable);
-                            }
-
-                            break;
+                            RemoveVisibleDockable(toolDock, dockable);
+                            OnDockableRemoved(dockable);
                         }
-                        case Alignment.Bottom:
+
+                        switch (alignment)
                         {
-                            if (rootDock.BottomPinnedDockables is not null)
-                            {
-                                rootDock.BottomPinnedDockables.Add(dockable);
-                                OnDockablePinned(dockable);
-                            }
+                            case Alignment.Unset:
+                            case Alignment.Left:
+                                {
+                                    if (rootDock.LeftPinnedDockables is not null)
+                                    {
+                                        rootDock.LeftPinnedDockables.Add(dockable);
+                                        OnDockablePinned(dockable);
+                                    }
 
-                            break;
+                                    break;
+                                }
+                            case Alignment.Right:
+                                {
+                                    if (rootDock.RightPinnedDockables is not null)
+                                    {
+                                        rootDock.RightPinnedDockables.Add(dockable);
+                                        OnDockablePinned(dockable);
+                                    }
+
+                                    break;
+                                }
+                            case Alignment.Top:
+                                {
+                                    if (rootDock.TopPinnedDockables is not null)
+                                    {
+                                        rootDock.TopPinnedDockables.Add(dockable);
+                                        OnDockablePinned(dockable);
+                                    }
+
+                                    break;
+                                }
+                            case Alignment.Bottom:
+                                {
+                                    if (rootDock.BottomPinnedDockables is not null)
+                                    {
+                                        rootDock.BottomPinnedDockables.Add(dockable);
+                                        OnDockablePinned(dockable);
+                                    }
+
+                                    break;
+                                }
                         }
+
+                        // TODO: Handle ActiveDockable state.
+                        // TODO: Handle IsExpanded property of IToolDock.
+                        // TODO: Handle AutoHide property of IToolDock.
                     }
-
-                    // TODO: Handle ActiveDockable state.
-                    // TODO: Handle IsExpanded property of IToolDock.
-                    // TODO: Handle AutoHide property of IToolDock.
-                }
-                else if (isPinned)
-                {
-                    // Unpin dockable.
-
-                    toolDock.VisibleDockables ??= CreateList<IDockable>();
-
-                    switch (alignment)
+                    else if (isPinned)
                     {
-                        case Alignment.Unset:
-                        case Alignment.Left:
+                        // Unpin dockable.
+
+                        toolDock.VisibleDockables ??= CreateList<IDockable>();
+
+                        switch (alignment)
                         {
-                            if (rootDock.LeftPinnedDockables is not null)
-                            {
-                                rootDock.LeftPinnedDockables.Remove(dockable);
-                                OnDockableUnpinned(dockable);
-                            }
+                            case Alignment.Unset:
+                            case Alignment.Left:
+                                {
+                                    if (rootDock.LeftPinnedDockables is not null)
+                                    {
+                                        rootDock.LeftPinnedDockables.Remove(dockable);
+                                        OnDockableUnpinned(dockable);
+                                    }
 
-                            break;
+                                    break;
+                                }
+                            case Alignment.Right:
+                                {
+                                    if (rootDock.RightPinnedDockables is not null)
+                                    {
+                                        rootDock.RightPinnedDockables.Remove(dockable);
+                                        OnDockableUnpinned(dockable);
+                                    }
+
+                                    break;
+                                }
+                            case Alignment.Top:
+                                {
+                                    if (rootDock.TopPinnedDockables is not null)
+                                    {
+                                        rootDock.TopPinnedDockables.Remove(dockable);
+                                        OnDockableUnpinned(dockable);
+                                    }
+
+                                    break;
+                                }
+                            case Alignment.Bottom:
+                                {
+                                    if (rootDock.BottomPinnedDockables is not null)
+                                    {
+                                        rootDock.BottomPinnedDockables.Remove(dockable);
+                                        OnDockableUnpinned(dockable);
+                                    }
+
+                                    break;
+                                }
                         }
-                        case Alignment.Right:
+
+                        if (!isVisible)
                         {
-                            if (rootDock.RightPinnedDockables is not null)
-                            {
-                                rootDock.RightPinnedDockables.Remove(dockable);
-                                OnDockableUnpinned(dockable);
-                            }
-
-                            break;
+                            AddVisibleDockable(toolDock, dockable);
                         }
-                        case Alignment.Top:
+                        else
                         {
-                            if (rootDock.TopPinnedDockables is not null)
-                            {
-                                rootDock.TopPinnedDockables.Remove(dockable);
-                                OnDockableUnpinned(dockable);
-                            }
-
-                            break;
+                            Debug.Assert(dockable.OriginalOwner is IDock);
+                            var originalOwner = (IDock)dockable.OriginalOwner!;
+                            HidePreviewingDockables(rootDock);
+                            AddVisibleDockable(originalOwner, dockable);
                         }
-                        case Alignment.Bottom:
-                        {
-                            if (rootDock.BottomPinnedDockables is not null)
-                            {
-                                rootDock.BottomPinnedDockables.Remove(dockable);
-                                OnDockableUnpinned(dockable);
-                            }
 
-                            break;
-                        }
-                    }
+                        OnDockableAdded(dockable);
 
-                    if (!isVisible)
-                    {
-                        AddVisibleDockable(toolDock, dockable);
+                        // TODO: Handle ActiveDockable state.
+                        // TODO: Handle IsExpanded property of IToolDock.
+                        // TODO: Handle AutoHide property of IToolDock.
                     }
                     else
                     {
-                        Debug.Assert(dockable.OriginalOwner is IDock);
-                        var originalOwner = (IDock)dockable.OriginalOwner!;
-                        HidePreviewingDockables(rootDock);
-                        AddVisibleDockable(originalOwner, dockable);
+                        // TODO: Handle invalid state.
                     }
 
-                    OnDockableAdded(dockable);
-
-                    // TODO: Handle ActiveDockable state.
-                    // TODO: Handle IsExpanded property of IToolDock.
-                    // TODO: Handle AutoHide property of IToolDock.
+                    break;
                 }
-                else
-                {
-                    // TODO: Handle invalid state.
-                }
-
-                break;
-            }
         }
     }
 
@@ -869,7 +873,7 @@ public abstract partial class FactoryBase
 
     /// <inheritdoc/>
     public void SetDocumentDockTabsLayoutRight(IDockable dockable) => SetDocumentDockTabsLayout(dockable, DocumentTabLayout.Right);
-    
+
     /// <inheritdoc/>
     public virtual void NewVerticalDocumentDock(IDockable dockable)
     {

--- a/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
+++ b/tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
     <ProjectReference Include="..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.SystemTextJson\Dock.Serializer.SystemTextJson.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Dock.Model.Avalonia.UnitTests/PinnedToolTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/PinnedToolTests.cs
@@ -1,0 +1,41 @@
+using System.Linq;
+using Avalonia.Headless.XUnit;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Dock.Model.Avalonia.Json;
+using Xunit;
+
+namespace Dock.Model.Avalonia.UnitTests;
+
+public class PinnedToolTests
+{
+    [AvaloniaFact]
+    public void PinnedTool_RestoredLayout_CanBeOpened()
+    {
+        var factory = new Factory();
+        var root = factory.CreateRootDock();
+
+        var toolDock = factory.CreateToolDock();
+        toolDock.Alignment = Alignment.Left;
+        var tool = new Tool { Id = "tool" };
+        toolDock.VisibleDockables = factory.CreateList<IDockable>(tool);
+        root.VisibleDockables = factory.CreateList<IDockable>(toolDock);
+
+        factory.InitLayout(root);
+        factory.PinDockable(tool);
+
+        var serializer = new AvaloniaDockSerializer();
+        var json = serializer.Serialize(root);
+        var loaded = serializer.Deserialize<RootDock>(json)!;
+        factory.InitLayout(loaded);
+        var state = new DockState();
+        state.Restore(loaded);
+
+        var loadedTool = loaded.LeftPinnedDockables!.OfType<Tool>().First();
+        factory.PreviewPinnedDockable(loadedTool);
+
+        Assert.NotNull(loaded.PinnedDock);
+        Assert.Contains(loadedTool, loaded.PinnedDock!.VisibleDockables!);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure pinning a dockable records its original owner
- restore pinned dockable ownership when restoring state
- add regression test for pinned tool restore
- reference json serializer project for tests

## Testing
- `dotnet format --no-restore`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687cabb498208321900eee2e4c7356be