### PR TITLE
Add drop indicators to tab items

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -181,20 +181,25 @@
 
     <Setter Property="Template">
       <ControlTemplate>
-          <Border Background="{TemplateBinding Background}"
-                  TextElement.FontFamily="{TemplateBinding FontFamily}"
-                  TextElement.FontSize="{TemplateBinding FontSize}"
-                  TextElement.FontWeight="{TemplateBinding FontWeight}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  Padding="{TemplateBinding Padding}"
-                  ContextMenu="{DynamicResource DocumentTabStripItemContextMenu}">
-            <DockableControl TrackingMode="Tab">
-              <StackPanel Background="Transparent"
-                          Orientation="Horizontal"
-                          Spacing="2"
-                          DockProperties.IsDragArea="True"
-                          DockProperties.IsDropArea="True">
+          <Grid>
+            <Border Background="{TemplateBinding Background}"
+                    TextElement.FontFamily="{TemplateBinding FontFamily}"
+                    TextElement.FontSize="{TemplateBinding FontSize}"
+                    TextElement.FontWeight="{TemplateBinding FontWeight}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    Padding="{TemplateBinding Padding}"
+                    ContextMenu="{DynamicResource DocumentTabStripItemContextMenu}">
+              <DockableControl TrackingMode="Tab">
+                <StackPanel Background="Transparent"
+                            Orientation="Horizontal"
+                            Spacing="2"
+                            DockProperties.IsDragArea="True"
+                            DockProperties.IsDropArea="True"
+                            DockProperties.IsDockTarget="True"
+                            DockProperties.ShowDockIndicatorOnly="True"
+                            DockProperties.IndicatorDockOperation="Fill"
+                            DockProperties.DockAdornerHost="{Binding $parent[DocumentTabStrip].DockAdornerHost}">
                 <Panel Margin="2">
                   <ContentPresenter ContentTemplate="{Binding $parent[DocumentControl].HeaderTemplate}"
                                     Content="{Binding}" />
@@ -237,7 +242,24 @@
                 </Button>
               </StackPanel>
             </DockableControl>
-          </Border>
+            </Border>
+            <Border x:Name="PART_DropHighlight"
+                    IsHitTestVisible="False"
+                    Background="{DynamicResource DockApplicationAccentBrushIndicator}"
+                    Opacity="0">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                  <Binding Path="$parent[DockControl].IsDraggingDock" />
+                  <Binding Path="CanDrop" />
+                </MultiBinding>
+              </Border.IsVisible>
+              <Border.Styles>
+                <Style Selector="^:pointerover">
+                  <Setter Property="Opacity" Value="0.3" />
+                </Style>
+              </Border.Styles>
+            </Border>
+          </Grid>
       </ControlTemplate>
     </Setter>
 

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -98,28 +98,50 @@
 
     <Setter Property="Template">
       <ControlTemplate>
-          <Border Background="{TemplateBinding Background}"
-                  TextElement.FontFamily="{TemplateBinding FontFamily}"
-                  TextElement.FontSize="{TemplateBinding FontSize}"
-                  TextElement.FontWeight="{TemplateBinding FontWeight}"
-                  BorderBrush="{TemplateBinding BorderBrush}"
-                  BorderThickness="{TemplateBinding BorderThickness}"
-                  Padding="{TemplateBinding Padding}"
-                  ContextMenu="{DynamicResource ToolTabStripItemContextMenu}">
-            <DockableControl TrackingMode="Tab">
-              <StackPanel x:Name="DragTool"
-                          Background="Transparent"
-                          Orientation="Horizontal"
-                          Spacing="2"
-                          DockProperties.IsDragArea="True"
-                          DockProperties.IsDropArea="True">
+          <Grid>
+            <Border Background="{TemplateBinding Background}"
+                    TextElement.FontFamily="{TemplateBinding FontFamily}"
+                    TextElement.FontSize="{TemplateBinding FontSize}"
+                    TextElement.FontWeight="{TemplateBinding FontWeight}"
+                    BorderBrush="{TemplateBinding BorderBrush}"
+                    BorderThickness="{TemplateBinding BorderThickness}"
+                    Padding="{TemplateBinding Padding}"
+                    ContextMenu="{DynamicResource ToolTabStripItemContextMenu}">
+              <DockableControl TrackingMode="Tab">
+                <StackPanel x:Name="DragTool"
+                            Background="Transparent"
+                            Orientation="Horizontal"
+                            Spacing="2"
+                            DockProperties.IsDragArea="True"
+                            DockProperties.IsDropArea="True"
+                            DockProperties.IsDockTarget="True"
+                            DockProperties.ShowDockIndicatorOnly="True"
+                            DockProperties.IndicatorDockOperation="Fill"
+                            DockProperties.DockAdornerHost="{Binding $parent[ToolTabStrip].DockAdornerHost}">
                 <Panel Margin="2">
                   <ContentPresenter ContentTemplate="{Binding $parent[ToolControl].HeaderTemplate}"
                                     Content="{Binding}" />
                 </Panel>
               </StackPanel>
             </DockableControl>
-          </Border>
+            </Border>
+            <Border x:Name="PART_DropHighlight"
+                    IsHitTestVisible="False"
+                    Background="{DynamicResource DockApplicationAccentBrushIndicator}"
+                    Opacity="0">
+              <Border.IsVisible>
+                <MultiBinding Converter="{x:Static BoolConverters.And}">
+                  <Binding Path="$parent[DockControl].IsDraggingDock" />
+                  <Binding Path="CanDrop" />
+                </MultiBinding>
+              </Border.IsVisible>
+              <Border.Styles>
+                <Style Selector="^:pointerover">
+                  <Setter Property="Opacity" Value="0.3" />
+                </Style>
+              </Border.Styles>
+            </Border>
+          </Grid>
       </ControlTemplate>
     </Setter>
 


### PR DESCRIPTION
## Summary
- highlight tab item drop areas with a subtle overlay
- overlay appears on pointer over so drop locations are clearer
- host each tab item drop adorner on the parent strip
- show drop overlay only while dragging

## Testing
- `dotnet format --no-restore --include src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml src/Dock.Avalonia/Controls/ToolTabStripItem.axaml`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687bfecce2ec8321af0ffa5f887f2d81