### PR TITLE
Add tabbed host window

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Floating windows](dock-windows.md) – Detach dockables into separate windows.
 - [Enable window drag](dock-window-drag.md) – Drag the host window via the document tab strip.
 - [Host window locators](dock-host-window-locator.md) – Provide platform windows for floating docks.
+- [Custom host window](dock-custom-host-window.md) – Use an Avalonia title bar on all windows.
+- [Tabbed host window](dock-tabbed-host-window.md) – Title bar with document tabs.
 - [Drag offset calculator](dock-drag-offset-calculator.md) – Control where the drag preview window appears.
 - [Floating dock adorners](dock-floating-adorners.md) – Display drop indicators in a transparent window.
 - [Pinned dock window](dock-pinned-window.md) – Show auto-hidden tools in a floating window.

--- a/docs/dock-custom-host-window.md
+++ b/docs/dock-custom-host-window.md
@@ -1,0 +1,20 @@
+# Custom host window
+
+`CustomHostWindow` is a convenience class that always uses a custom Avalonia title bar. It derives from `HostWindow` and enables the pseudo classes that remove the system chrome.
+
+Use it when you want floating or main windows to share the same look and allow drag operations over the entire title bar.
+
+```csharp
+var host = new CustomHostWindow();
+```
+
+Register the type through the factory to use it for floating docks:
+
+```csharp
+factory.HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
+{
+    [nameof(IDockWindow)] = () => new CustomHostWindow()
+};
+```
+
+The window supports dragging and dropping on dock targets via the built in pointer handlers.

--- a/docs/dock-tabbed-host-window.md
+++ b/docs/dock-tabbed-host-window.md
@@ -1,0 +1,17 @@
+# Tabbed host window
+
+`TabbedHostWindow` combines the custom Avalonia chrome with a `DocumentTabStrip` inside the title bar. The tabs come from the active root document dock and allow dragging the window by the empty tab area.
+
+```csharp
+var host = new TabbedHostWindow();
+```
+
+Register the type through the factory to use it for floating docks:
+
+```csharp
+factory.HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
+{
+    [nameof(IDockWindow)] = () => new TabbedHostWindow()
+};
+```
+

--- a/src/Dock.Avalonia/Controls/CustomHostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/CustomHostWindow.axaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:DataType="controls:IRootDock"
+                    xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <CustomHostWindow Width="300" Height="400" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type CustomHostWindow}" TargetType="CustomHostWindow" BasedOn="{StaticResource {x:Type HostWindow}}">
+    <Setter Property="ToolChromeControlsWholeWindow" Value="True" />
+    <Setter Property="DocumentChromeControlsWholeWindow" Value="True" />
+    <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+    <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/CustomHostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/CustomHostWindow.axaml.cs
@@ -1,0 +1,18 @@
+using Avalonia.Controls.Metadata;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Host window with a custom Avalonia title bar.
+/// </summary>
+public class CustomHostWindow : HostWindow
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CustomHostWindow"/> class.
+    /// </summary>
+    public CustomHostWindow()
+    {
+        ToolChromeControlsWholeWindow = true;
+        DocumentChromeControlsWholeWindow = true;
+    }
+}

--- a/src/Dock.Avalonia/Controls/TabbedHostWindow.axaml
+++ b/src/Dock.Avalonia/Controls/TabbedHostWindow.axaml
@@ -1,0 +1,53 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:dmc="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+                    x:CompileBindings="True"
+                    x:DataType="dmc:IRootDock">
+  <Design.PreviewWith>
+    <TabbedHostWindow Width="300" Height="400" />
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type TabbedHostWindow}" TargetType="TabbedHostWindow" BasedOn="{StaticResource {x:Type CustomHostWindow}}">
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+          <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+          <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+          <VisualLayerManager>
+            <VisualLayerManager.ChromeOverlayLayer>
+              <DockPanel>
+                <DocumentTabStrip x:Name="PART_TabStrip"
+                                  DataContext="{Binding ActiveDockable}"
+                                  ItemsSource="{Binding VisibleDockables}"
+                                  SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
+                                  CanCreateItem="{Binding CanCreateDocument}"
+                                  EnableWindowDrag="True"
+                                  DockProperties.IsDropArea="True"
+                                  DockProperties.DockAdornerHost="{Binding #PART_ContentPresenter}"
+                                  DockPanel.Dock="Top" />
+                <HostWindowTitleBar Name="PART_TitleBar" />
+              </DockPanel>
+            </VisualLayerManager.ChromeOverlayLayer>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Content="{TemplateBinding Content}"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </VisualLayerManager>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Setter Property="Content">
+      <Template>
+        <Panel Margin="{Binding $parent[HostWindow].OffScreenMargin}">
+          <Panel Margin="{Binding $parent[HostWindow].WindowDecorationMargin}">
+            <DockControl Layout="{Binding}" />
+          </Panel>
+        </Panel>
+      </Template>
+    </Setter>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/TabbedHostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/TabbedHostWindow.axaml.cs
@@ -1,0 +1,10 @@
+using Avalonia.Controls.Metadata;
+
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Host window with the document tab strip in the title bar.
+/// </summary>
+public class TabbedHostWindow : CustomHostWindow
+{
+}

--- a/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockFluentTheme.axaml
@@ -32,6 +32,8 @@
         <ResourceInclude Source="/Controls/DockControl.axaml" />
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
+        <ResourceInclude Source="/Controls/CustomHostWindow.axaml" />
+        <ResourceInclude Source="/Controls/TabbedHostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockWindow.axaml" />

--- a/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
+++ b/src/Dock.Avalonia/Themes/DockSimpleTheme.axaml
@@ -32,6 +32,8 @@
         <ResourceInclude Source="/Controls/DockControl.axaml" />
         <ResourceInclude Source="/Controls/HostWindowTitleBar.axaml" />
         <ResourceInclude Source="/Controls/HostWindow.axaml" />
+        <ResourceInclude Source="/Controls/CustomHostWindow.axaml" />
+        <ResourceInclude Source="/Controls/TabbedHostWindow.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewControl.axaml" />
         <ResourceInclude Source="/Controls/DragPreviewWindow.axaml" />
         <ResourceInclude Source="/Controls/PinnedDockWindow.axaml" />


### PR DESCRIPTION
## Summary
- add `TabbedHostWindow` with a document tab strip in the title bar
- load the new style from both themes
- document the tabbed host window

## Testing
- ❌ `dotnet test` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfe566fd08321999953f2fb2fdd12