### PR TITLE
Add docs for RootDockDebug extension

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Floating dock adorners](dock-floating-adorners.md) – Display drop indicators in a transparent window.
 - [Pinned dock window](dock-pinned-window.md) – Show auto-hidden tools in a floating window.
 - [Floating window owner](dock-window-owner.md) – Keep floating windows in front of the main window.
+- [RootDockDebug window](dock-root-dock-debug.md) – Toggle a runtime inspector for Dock layouts.
 - [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
 - [Custom Dock.Model implementations](dock-custom-model.md) – Integrate Dock with other MVVM frameworks.
 

--- a/docs/dock-root-dock-debug.md
+++ b/docs/dock-root-dock-debug.md
@@ -1,0 +1,16 @@
+# RootDockDebug window
+
+`RootDockDebug` is a visual helper that displays the hierarchy of docks and dockables at runtime. The `AttachDockDebug` extension method makes it easy to toggle this window from any `TopLevel`.
+
+## Usage
+
+Call `AttachDockDebug` on your main window during application startup. The window appears when the user presses <kbd>F11</kbd> by default.
+
+```csharp
+mainWindow.AttachDockDebug(
+    viewModel.Layout,
+    new KeyGesture(Key.F11));
+```
+
+Pass a custom `KeyGesture` to use another shortcut. The method returns an `IDisposable` that unregisters the hotkey and closes the window when disposed.
+


### PR DESCRIPTION
## Summary
- document `AttachDockDebug` in a new page
- reference the new page from the docs index

## Testing
- `dotnet format --no-restore`
- `./build.sh --target test --verbosity minimal` *(fails: Process 'dotnet' exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_687d5a92671c8321a6567be39e716cc6