### PR TITLE
Add converter for TreeView title fallback

### DIFF
--- a/src/Dock.Avalonia/Controls/RootDockDebug.axaml
+++ b/src/Dock.Avalonia/Controls/RootDockDebug.axaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
              xmlns:core="clr-namespace:Dock.Model.Core;assembly=Dock.Model"
+               xmlns:converters="clr-namespace:Dock.Avalonia.Converters;assembly=Dock.Avalonia"
              mc:Ignorable="d"
              d:DesignWidth="300" d:DesignHeight="680"
              x:DataType="controls:IRootDock"
@@ -261,68 +262,68 @@
         <TreeView.DataTemplates>
           <TreeDataTemplate DataType="controls:IRootDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IProportionalDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IStackDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDockDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IGridDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IUniformGridDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IWrapDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IToolDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDocumentDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDocumentDockContent"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="core:IDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <DataTemplate DataType="controls:IGridDockSplitter">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IProportionalDockSplitter">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:ITool">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IToolContent">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IDocument">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IDocumentContent">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="core:IDockable">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
         </TreeView.DataTemplates>
       </TreeView>
@@ -343,72 +344,72 @@
         <TreeView.DataTemplates>
           <TreeDataTemplate DataType="controls:IRootDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IProportionalDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IStackDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDockDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IGridDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IUniformGridDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IWrapDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IToolDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDocumentDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="controls:IDocumentDockContent"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <TreeDataTemplate DataType="core:IDock"
                             ItemsSource="{Binding VisibleDockables}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
           <DataTemplate DataType="controls:IGridDockSplitter">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IProportionalDockSplitter">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:ITool">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IToolContent">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IDocument">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="controls:IDocumentContent">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <DataTemplate DataType="core:IDockable">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </DataTemplate>
           <TreeDataTemplate DataType="core:IDockWindow" 
                             ItemsSource="{Binding Layout.VisibleDockables, FallbackValue={x:Null}}">
-            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
           </TreeDataTemplate>
         </TreeView.DataTemplates>
       </TreeView>

--- a/src/Dock.Avalonia/Converters/TitleOrTypeNameConverter.cs
+++ b/src/Dock.Avalonia/Converters/TitleOrTypeNameConverter.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Data.Converters;
+using Dock.Model.Core;
+
+namespace Dock.Avalonia.Converters;
+
+/// <summary>
+/// Converts dockable objects to display title with a fallback to type name.
+/// </summary>
+public class TitleOrTypeNameConverter : IValueConverter
+{
+    /// <summary>
+    /// Gets <see cref="TitleOrTypeNameConverter"/> instance.
+    /// </summary>
+    public static readonly TitleOrTypeNameConverter Instance = new();
+
+    /// <inheritdoc/>
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is IDockable dockable)
+        {
+            return string.IsNullOrEmpty(dockable.Title) ? dockable.GetType().Name : dockable.Title;
+        }
+
+        if (value is IDockWindow window)
+        {
+            return string.IsNullOrEmpty(window.Title) ? window.GetType().Name : window.Title;
+        }
+
+        return value?.GetType().Name ?? AvaloniaProperty.UnsetValue;
+    }
+
+    /// <inheritdoc/>
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
## Summary
- use `TitleOrTypeNameConverter` to show type name when title is missing
- add new converter

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687d5dc4f9008321b681ed6ec540ea9f