### PR TITLE
Refactor RootDockDebug templates

### DIFF
--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml
@@ -1,0 +1,42 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:core="clr-namespace:Dock.Model.Core;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DockDebugView"
+             x:DataType="core:IDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+        ColumnDefinitions="Auto,*">
+    <TextBlock Text="{DynamicResource RootDockDebugIdString}" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugTitleString}" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugContextString}" Grid.Row="2" Grid.Column="0" />
+    <TextBox Text="{Binding Context, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugOwnerString}" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugActiveDockableString}" Grid.Row="4" Grid.Column="0" />
+    <TextBox Text="{Binding ActiveDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugDefaultDockableString}" Grid.Row="5" Grid.Column="0" />
+    <TextBox Text="{Binding DefaultDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugFocusedDockableString}" Grid.Row="6" Grid.Column="0" />
+    <TextBox Text="{Binding FocusedDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="6" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugProportionString}" Grid.Row="7" Grid.Column="0" />
+    <TextBox Text="{Binding Proportion, Mode=TwoWay}" Margin="2" Grid.Row="7" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugIsActiveString}" Grid.Row="8" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsActive, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="8" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugIsCollapsableString}" Grid.Row="9" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsCollapsable, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="9" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugCanGoBackString}" Grid.Row="10" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanGoBack, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="10" Grid.Column="1" />
+    <TextBlock Text="{DynamicResource RootDockDebugCanGoForwardString}" Grid.Row="11" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanGoForward, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="11" Grid.Column="1" />
+    <TextBlock Text="OpenedDockablesCount" Grid.Row="12" Grid.Column="0" />
+    <TextBox Text="{Binding OpenedDockablesCount, Mode=TwoWay}" Margin="2" Grid.Row="12" Grid.Column="1" />
+    <TextBlock Text="CanCloseLastDockable" Grid.Row="13" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanCloseLastDockable, Mode=TwoWay}" Margin="2" Grid.Row="13" Grid.Column="1" />
+    <TextBlock Text="Dock" Grid.Row="14" Grid.Column="0" />
+    <TextBox Text="{Binding Dock, Mode=TwoWay}" Margin="2" Grid.Row="14" Grid.Column="1" />
+    <TextBlock Text="Column" Grid.Row="15" Grid.Column="0" />
+    <TextBox Text="{Binding Column, Mode=TwoWay}" Margin="2" Grid.Row="15" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DockDebugView : UserControl
+{
+    public DockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DockDockDebugView"
+             x:DataType="controls:IDockDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="LastChildFill" Grid.Row="0" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding LastChildFill, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DockDockDebugView : UserControl
+{
+    public DockDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml
@@ -1,0 +1,31 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:core="clr-namespace:Dock.Model.Core;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DockWindowDebugView"
+             x:DataType="core:IDockWindow"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Id" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="X" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding X, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="Y" Grid.Row="2" Grid.Column="0" />
+    <TextBox Text="{Binding Y, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="Width" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding Width, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
+    <TextBlock Text="Height" Grid.Row="4" Grid.Column="0" />
+    <TextBox Text="{Binding Height, Mode=TwoWay}" Margin="2" Grid.Row="4" Grid.Column="1" />
+    <TextBlock Text="Topmost" Grid.Row="5" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding Topmost, Mode=TwoWay}" Margin="2" Grid.Row="5" Grid.Column="1" />
+    <TextBlock Text="Title" Grid.Row="6" Grid.Column="0" />
+    <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="6" Grid.Column="1" />
+    <TextBlock Text="Owner" Grid.Row="7" Grid.Column="0" />
+    <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="7" Grid.Column="1" />
+    <TextBlock Text="Factory" Grid.Row="8" Grid.Column="0" />
+    <TextBox Text="{Binding Factory, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="8" Grid.Column="1" />
+    <TextBlock Text="Layout" Grid.Row="9" Grid.Column="0" />
+    <TextBox Text="{Binding Layout.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="9" Grid.Column="1" />
+    <TextBlock Text="Host" Grid.Row="10" Grid.Column="0" />
+    <TextBox Text="{Binding Host, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="10" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DockWindowDebugView : UserControl
+{
+    public DockWindowDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml
@@ -1,0 +1,60 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:core="clr-namespace:Dock.Model.Core;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DockableDebugView"
+             x:DataType="core:IDockable"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+        ColumnDefinitions="Auto,*">
+    <TextBlock Text="Id" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="Title" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="Context" Grid.Row="2" Grid.Column="0" />
+    <TextBox Text="{Binding Context, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="Owner" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
+    <TextBlock Text="OriginalOwner" Grid.Row="4" Grid.Column="0" />
+    <TextBox Text="{Binding OriginalOwner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
+    <TextBlock Text="Factory" Grid.Row="5" Grid.Column="0" />
+    <TextBox Text="{Binding Factory, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
+    <TextBlock Text="IsEmpty" Grid.Row="6" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsEmpty, Mode=TwoWay}" Margin="2" Grid.Row="6" Grid.Column="1" />
+    <TextBlock Text="IsCollapsable" Grid.Row="7" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsCollapsable, Mode=TwoWay}" Margin="2" Grid.Row="7" Grid.Column="1" />
+    <TextBlock Text="Proportion" Grid.Row="8" Grid.Column="0" />
+    <TextBox Text="{Binding Proportion, Mode=TwoWay}" Margin="2" Grid.Row="8" Grid.Column="1" />
+    <TextBlock Text="Dock" Grid.Row="9" Grid.Column="0" />
+    <TextBox Text="{Binding Dock, Mode=TwoWay}" Margin="2" Grid.Row="9" Grid.Column="1" />
+    <TextBlock Text="Column" Grid.Row="10" Grid.Column="0" />
+    <TextBox Text="{Binding Column, Mode=TwoWay}" Margin="2" Grid.Row="10" Grid.Column="1" />
+    <TextBlock Text="Row" Grid.Row="11" Grid.Column="0" />
+    <TextBox Text="{Binding Row, Mode=TwoWay}" Margin="2" Grid.Row="11" Grid.Column="1" />
+    <TextBlock Text="ColumnSpan" Grid.Row="12" Grid.Column="0" />
+    <TextBox Text="{Binding ColumnSpan, Mode=TwoWay}" Margin="2" Grid.Row="12" Grid.Column="1" />
+    <TextBlock Text="RowSpan" Grid.Row="13" Grid.Column="0" />
+    <TextBox Text="{Binding RowSpan, Mode=TwoWay}" Margin="2" Grid.Row="13" Grid.Column="1" />
+    <TextBlock Text="IsSharedSizeScope" Grid.Row="14" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsSharedSizeScope, Mode=TwoWay}" Margin="2" Grid.Row="14" Grid.Column="1" />
+    <TextBlock Text="CollapsedProportion" Grid.Row="15" Grid.Column="0" />
+    <TextBox Text="{Binding CollapsedProportion, Mode=TwoWay}" Margin="2" Grid.Row="15" Grid.Column="1" />
+    <TextBlock Text="MinWidth" Grid.Row="16" Grid.Column="0" />
+    <TextBox Text="{Binding MinWidth, Mode=TwoWay}" Margin="2" Grid.Row="16" Grid.Column="1" />
+    <TextBlock Text="MaxWidth" Grid.Row="17" Grid.Column="0" />
+    <TextBox Text="{Binding MaxWidth, Mode=TwoWay}" Margin="2" Grid.Row="17" Grid.Column="1" />
+    <TextBlock Text="MinHeight" Grid.Row="18" Grid.Column="0" />
+    <TextBox Text="{Binding MinHeight, Mode=TwoWay}" Margin="2" Grid.Row="18" Grid.Column="1" />
+    <TextBlock Text="MaxHeight" Grid.Row="19" Grid.Column="0" />
+    <TextBox Text="{Binding MaxHeight, Mode=TwoWay}" Margin="2" Grid.Row="19" Grid.Column="1" />
+    <TextBlock Text="CanClose" Grid.Row="20" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanClose, Mode=TwoWay}" Margin="2" Grid.Row="20" Grid.Column="1" />
+    <TextBlock Text="CanPin" Grid.Row="21" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanPin, Mode=TwoWay}" Margin="2" Grid.Row="21" Grid.Column="1" />
+    <TextBlock Text="CanFloat" Grid.Row="22" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanFloat, Mode=TwoWay}" Margin="2" Grid.Row="22" Grid.Column="1" />
+    <TextBlock Text="CanDrag" Grid.Row="23" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanDrag, Mode=TwoWay}" Margin="2" Grid.Row="23" Grid.Column="1" />
+    <TextBlock Text="CanDrop" Grid.Row="24" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanDrop, Mode=TwoWay}" Margin="2" Grid.Row="24" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DockableDebugView : UserControl
+{
+    public DockableDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DocumentContentDebugView"
+             x:DataType="controls:IDocumentContent"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DocumentContentDebugView : UserControl
+{
+    public DocumentContentDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DocumentDockContentDebugView"
+             x:DataType="controls:IDocumentDockContent"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="DocumentTemplate" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding DocumentTemplate, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DocumentDockContentDebugView : UserControl
+{
+    public DocumentDockContentDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml
@@ -1,0 +1,17 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DocumentDockDebugView"
+             x:DataType="controls:IDocumentDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="CanCreateDocument" Grid.Row="0" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanCreateDocument, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="CreateDocument" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding CreateDocument, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="EnableWindowDrag" Grid.Row="2" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding EnableWindowDrag, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="TabsLayout" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding TabsLayout, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DocumentDockDebugView : UserControl
+{
+    public DocumentDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.DocumentTemplateDebugView"
+             x:DataType="controls:IDocumentTemplate"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class DocumentTemplateDebugView : UserControl
+{
+    public DocumentTemplateDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.GridDockDebugView"
+             x:DataType="controls:IGridDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="ColumnDefinitions" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding ColumnDefinitions, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="RowDefinitions" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding RowDefinitions, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class GridDockDebugView : UserControl
+{
+    public GridDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.GridDockSplitterDebugView"
+             x:DataType="controls:IGridDockSplitter"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="ResizeDirection" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding ResizeDirection, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class GridDockSplitterDebugView : UserControl
+{
+    public GridDockSplitterDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.ProportionalDockDebugView"
+             x:DataType="controls:IProportionalDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class ProportionalDockDebugView : UserControl
+{
+    public ProportionalDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.ProportionalDockSplitterDebugView"
+             x:DataType="controls:IProportionalDockSplitter"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="CanResize" Grid.Row="0" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding CanResize, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class ProportionalDockSplitterDebugView : UserControl
+{
+    public ProportionalDockSplitterDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebug.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebug.axaml
@@ -11,243 +11,239 @@
              x:DataType="controls:IRootDock"
              x:CompileBindings="True" >
   <UserControl.DataTemplates>
+  <TabControl>
+    <TabItem Header="{DynamicResource RootDockDebugLayoutTabString}">
+      <TreeView x:Name="Visible" 
+                ItemsSource="{Binding VisibleDockables}">
+        <TreeView.Styles>
+          <Style Selector="TreeViewItem">
+            <Setter Property="IsExpanded" Value="True" />
+          </Style>
+        </TreeView.Styles>
+        <TreeView.DataTemplates>
+          <TreeDataTemplate DataType="controls:IRootDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IProportionalDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IStackDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDockDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IGridDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IUniformGridDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IWrapDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IToolDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDocumentDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDocumentDockContent"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="core:IDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <DataTemplate DataType="controls:IGridDockSplitter">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IProportionalDockSplitter">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:ITool">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IToolContent">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IDocument">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IDocumentContent">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="core:IDockable">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+        </TreeView.DataTemplates>
+      </TreeView>
+    </TabItem>
+    <TabItem Header="{DynamicResource RootDockDebugSelectedTabString}">
+      <ContentControl Content="{Binding #Visible.SelectedItem}" />
+    </TabItem>
+    <TabItem Header="{DynamicResource RootDockDebugWindowsTabString}">
+      <TreeView x:Name="Windows" 
+                DataContext="{Binding #Visible.SelectedItem}" 
+                ItemsSource="{Binding Windows}"
+                x:DataType="controls:IRootDock">
+        <TreeView.Styles>
+          <Style Selector="TreeViewItem">
+            <Setter Property="IsExpanded" Value="True" />
+          </Style>
+        </TreeView.Styles>
+        <TreeView.DataTemplates>
+          <TreeDataTemplate DataType="controls:IRootDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IProportionalDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IStackDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDockDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IGridDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IUniformGridDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IWrapDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IToolDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDocumentDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="controls:IDocumentDockContent"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <TreeDataTemplate DataType="core:IDock"
+                            ItemsSource="{Binding VisibleDockables}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+          <DataTemplate DataType="controls:IGridDockSplitter">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IProportionalDockSplitter">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:ITool">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IToolContent">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IDocument">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="controls:IDocumentContent">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <DataTemplate DataType="core:IDockable">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </DataTemplate>
+          <TreeDataTemplate DataType="core:IDockWindow" 
+                            ItemsSource="{Binding Layout.VisibleDockables, FallbackValue={x:Null}}">
+            <TextBlock Text="{Binding Converter={x:Static converters:TitleOrTypeNameConverter.Instance}}" />
+          </TreeDataTemplate>
+        </TreeView.DataTemplates>
+      </TreeView>
+    </TabItem>
+    <TabItem Header="{DynamicResource RootDockDebugEventsTabString}">
+      <DockPanel DataContext="{Binding #Root}">
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="0,0,0,4">
+          <TextBlock Text="{DynamicResource RootDockDebugFilterString}" VerticalAlignment="Center"/>
+          <TextBox Width="120" Margin="2" Text="{Binding Filter, UpdateSourceTrigger=PropertyChanged}"/>
+          <Button Content="{DynamicResource RootDockDebugResetString}" Margin="2" Click="OnClearEvents"/>
+        </StackPanel>
+        <ListBox ItemsSource="{Binding FilteredEvents}" FontFamily="Consolas"/>
+      </DockPanel>
+    </TabItem>
+    <TabItem Header="{DynamicResource RootDockDebugRootTabString}">
+      <ContentControl Content="{Binding}" />
+    </TabItem>
+  </TabControl>
+</UserControl>
+  <UserControl.DataTemplates>
     <DataTemplate DataType="core:IDock">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="{DynamicResource RootDockDebugIdString}" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugTitleString}" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugContextString}" Grid.Row="2" Grid.Column="0" />
-        <TextBox Text="{Binding Context, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugOwnerString}" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugActiveDockableString}" Grid.Row="4" Grid.Column="0" />
-        <TextBox Text="{Binding ActiveDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugDefaultDockableString}" Grid.Row="5" Grid.Column="0" />
-        <TextBox Text="{Binding DefaultDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugFocusedDockableString}" Grid.Row="6" Grid.Column="0" />
-        <TextBox Text="{Binding FocusedDockable.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="6" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugProportionString}" Grid.Row="7" Grid.Column="0" />
-        <TextBox Text="{Binding Proportion, Mode=TwoWay}" Margin="2" Grid.Row="7" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugIsActiveString}" Grid.Row="8" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsActive, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="8" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugIsCollapsableString}" Grid.Row="9" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsCollapsable, Mode=TwoWay}" Margin="2" IsEnabled="True" Grid.Row="9" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugCanGoBackString}" Grid.Row="10" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanGoBack, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="10" Grid.Column="1" />
-        <TextBlock Text="{DynamicResource RootDockDebugCanGoForwardString}" Grid.Row="11" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanGoForward, Mode=OneWay}" Margin="2" IsEnabled="False" Grid.Row="11" Grid.Column="1" />
-        <TextBlock Text="OpenedDockablesCount" Grid.Row="12" Grid.Column="0" />
-        <TextBox Text="{Binding OpenedDockablesCount, Mode=TwoWay}" Margin="2" Grid.Row="12" Grid.Column="1" />
-        <TextBlock Text="CanCloseLastDockable" Grid.Row="13" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanCloseLastDockable, Mode=TwoWay}" Margin="2" Grid.Row="13" Grid.Column="1" />
-        <TextBlock Text="Dock" Grid.Row="14" Grid.Column="0" />
-        <TextBox Text="{Binding Dock, Mode=TwoWay}" Margin="2" Grid.Row="14" Grid.Column="1" />
-        <TextBlock Text="Column" Grid.Row="15" Grid.Column="0" />
-        <TextBox Text="{Binding Column, Mode=TwoWay}" Margin="2" Grid.Row="15" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DockDebugView />
     </DataTemplate>
     <DataTemplate DataType="core:IDockable">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Id" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="Title" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="Context" Grid.Row="2" Grid.Column="0" />
-        <TextBox Text="{Binding Context, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="Owner" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
-        <TextBlock Text="OriginalOwner" Grid.Row="4" Grid.Column="0" />
-        <TextBox Text="{Binding OriginalOwner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
-        <TextBlock Text="Factory" Grid.Row="5" Grid.Column="0" />
-        <TextBox Text="{Binding Factory, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
-        <TextBlock Text="IsEmpty" Grid.Row="6" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsEmpty, Mode=TwoWay}" Margin="2" Grid.Row="6" Grid.Column="1" />
-        <TextBlock Text="IsCollapsable" Grid.Row="7" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsCollapsable, Mode=TwoWay}" Margin="2" Grid.Row="7" Grid.Column="1" />
-        <TextBlock Text="Proportion" Grid.Row="8" Grid.Column="0" />
-        <TextBox Text="{Binding Proportion, Mode=TwoWay}" Margin="2" Grid.Row="8" Grid.Column="1" />
-        <TextBlock Text="Dock" Grid.Row="9" Grid.Column="0" />
-        <TextBox Text="{Binding Dock, Mode=TwoWay}" Margin="2" Grid.Row="9" Grid.Column="1" />
-        <TextBlock Text="Column" Grid.Row="10" Grid.Column="0" />
-        <TextBox Text="{Binding Column, Mode=TwoWay}" Margin="2" Grid.Row="10" Grid.Column="1" />
-        <TextBlock Text="Row" Grid.Row="11" Grid.Column="0" />
-        <TextBox Text="{Binding Row, Mode=TwoWay}" Margin="2" Grid.Row="11" Grid.Column="1" />
-        <TextBlock Text="ColumnSpan" Grid.Row="12" Grid.Column="0" />
-        <TextBox Text="{Binding ColumnSpan, Mode=TwoWay}" Margin="2" Grid.Row="12" Grid.Column="1" />
-        <TextBlock Text="RowSpan" Grid.Row="13" Grid.Column="0" />
-        <TextBox Text="{Binding RowSpan, Mode=TwoWay}" Margin="2" Grid.Row="13" Grid.Column="1" />
-        <TextBlock Text="IsSharedSizeScope" Grid.Row="14" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsSharedSizeScope, Mode=TwoWay}" Margin="2" Grid.Row="14" Grid.Column="1" />
-        <TextBlock Text="CollapsedProportion" Grid.Row="15" Grid.Column="0" />
-        <TextBox Text="{Binding CollapsedProportion, Mode=TwoWay}" Margin="2" Grid.Row="15" Grid.Column="1" />
-        <TextBlock Text="MinWidth" Grid.Row="16" Grid.Column="0" />
-        <TextBox Text="{Binding MinWidth, Mode=TwoWay}" Margin="2" Grid.Row="16" Grid.Column="1" />
-        <TextBlock Text="MaxWidth" Grid.Row="17" Grid.Column="0" />
-        <TextBox Text="{Binding MaxWidth, Mode=TwoWay}" Margin="2" Grid.Row="17" Grid.Column="1" />
-        <TextBlock Text="MinHeight" Grid.Row="18" Grid.Column="0" />
-        <TextBox Text="{Binding MinHeight, Mode=TwoWay}" Margin="2" Grid.Row="18" Grid.Column="1" />
-        <TextBlock Text="MaxHeight" Grid.Row="19" Grid.Column="0" />
-        <TextBox Text="{Binding MaxHeight, Mode=TwoWay}" Margin="2" Grid.Row="19" Grid.Column="1" />
-        <TextBlock Text="CanClose" Grid.Row="20" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanClose, Mode=TwoWay}" Margin="2" Grid.Row="20" Grid.Column="1" />
-        <TextBlock Text="CanPin" Grid.Row="21" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanPin, Mode=TwoWay}" Margin="2" Grid.Row="21" Grid.Column="1" />
-        <TextBlock Text="CanFloat" Grid.Row="22" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanFloat, Mode=TwoWay}" Margin="2" Grid.Row="22" Grid.Column="1" />
-        <TextBlock Text="CanDrag" Grid.Row="23" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanDrag, Mode=TwoWay}" Margin="2" Grid.Row="23" Grid.Column="1" />
-        <TextBlock Text="CanDrop" Grid.Row="24" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanDrop, Mode=TwoWay}" Margin="2" Grid.Row="24" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DockableDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IProportionalDock">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:ProportionalDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IStackDock">
-      <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="Spacing" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding Spacing, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-      </Grid>
+      <diagnostics:StackDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IDockDock">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="LastChildFill" Grid.Row="0" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding LastChildFill, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DockDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IGridDock">
-      <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="ColumnDefinitions" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding ColumnDefinitions, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="RowDefinitions" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding RowDefinitions, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-      </Grid>
+      <diagnostics:GridDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IUniformGridDock">
-      <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Rows" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Rows, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="Columns" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding Columns, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-      </Grid>
+      <diagnostics:UniformGridDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IWrapDock">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:WrapDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IToolDock">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Alignment" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Alignment, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="IsExpanded" Grid.Row="1" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="AutoHide" Grid.Row="2" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding AutoHide, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="GripMode" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding GripMode, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
-      </Grid>
+      <diagnostics:ToolDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IDocumentDock">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="CanCreateDocument" Grid.Row="0" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanCreateDocument, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="CreateDocument" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding CreateDocument, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="EnableWindowDrag" Grid.Row="2" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding EnableWindowDrag, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="TabsLayout" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding TabsLayout, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DocumentDockDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IDocumentDockContent">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="DocumentTemplate" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding DocumentTemplate, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DocumentDockContentDebugView />
     </DataTemplate>
     <DataTemplate DataType="core:IDockWindow">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Id" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Id, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="X" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding X, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="Y" Grid.Row="2" Grid.Column="0" />
-        <TextBox Text="{Binding Y, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="Width" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding Width, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
-        <TextBlock Text="Height" Grid.Row="4" Grid.Column="0" />
-        <TextBox Text="{Binding Height, Mode=TwoWay}" Margin="2" Grid.Row="4" Grid.Column="1" />
-        <TextBlock Text="Topmost" Grid.Row="5" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding Topmost, Mode=TwoWay}" Margin="2" Grid.Row="5" Grid.Column="1" />
-        <TextBlock Text="Title" Grid.Row="6" Grid.Column="0" />
-        <TextBox Text="{Binding Title, Mode=TwoWay}" Margin="2" Grid.Row="6" Grid.Column="1" />
-        <TextBlock Text="Owner" Grid.Row="7" Grid.Column="0" />
-        <TextBox Text="{Binding Owner.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="7" Grid.Column="1" />
-        <TextBlock Text="Factory" Grid.Row="8" Grid.Column="0" />
-        <TextBox Text="{Binding Factory, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="8" Grid.Column="1" />
-        <TextBlock Text="Layout" Grid.Row="9" Grid.Column="0" />
-        <TextBox Text="{Binding Layout.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="9" Grid.Column="1" />
-        <TextBlock Text="Host" Grid.Row="10" Grid.Column="0" />
-        <TextBox Text="{Binding Host, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="10" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DockWindowDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IProportionalDockSplitter">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="CanResize" Grid.Row="0" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding CanResize, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:ProportionalDockSplitterDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IGridDockSplitter">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="ResizeDirection" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding ResizeDirection, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:GridDockSplitterDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IToolContent">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:ToolContentDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IDocumentContent">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DocumentContentDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IDocumentTemplate">
-      <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
-        <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
-      </Grid>
+      <diagnostics:DocumentTemplateDebugView />
     </DataTemplate>
     <DataTemplate DataType="controls:IRootDock">
-      <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
-        <TextBlock Text="IsFocusableRoot" Grid.Row="0" Grid.Column="0" />
-        <CheckBox IsChecked="{Binding IsFocusableRoot, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
-        <TextBlock Text="HiddenDockables" Grid.Row="1" Grid.Column="0" />
-        <TextBox Text="{Binding HiddenDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="1" Grid.Column="1" />
-        <TextBlock Text="LeftPinnedDockables" Grid.Row="2" Grid.Column="0" />
-        <TextBox Text="{Binding LeftPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
-        <TextBlock Text="RightPinnedDockables" Grid.Row="3" Grid.Column="0" />
-        <TextBox Text="{Binding RightPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
-        <TextBlock Text="TopPinnedDockables" Grid.Row="4" Grid.Column="0" />
-        <TextBox Text="{Binding TopPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
-        <TextBlock Text="BottomPinnedDockables" Grid.Row="5" Grid.Column="0" />
-        <TextBox Text="{Binding BottomPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
-        <TextBlock Text="PinnedDock" Grid.Row="6" Grid.Column="0" />
-        <TextBox Text="{Binding PinnedDock.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="6" Grid.Column="1" />
-        <TextBlock Text="Window" Grid.Row="7" Grid.Column="0" />
-        <TextBox Text="{Binding Window.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="7" Grid.Column="1" />
-      </Grid>
+      <diagnostics:RootDockInfoDebugView />
     </DataTemplate>
   </UserControl.DataTemplates>
   <TabControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml
@@ -1,0 +1,25 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.RootDockInfoDebugView"
+             x:DataType="controls:IRootDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="IsFocusableRoot" Grid.Row="0" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsFocusableRoot, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="HiddenDockables" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding HiddenDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="LeftPinnedDockables" Grid.Row="2" Grid.Column="0" />
+    <TextBox Text="{Binding LeftPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="RightPinnedDockables" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding RightPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="3" Grid.Column="1" />
+    <TextBlock Text="TopPinnedDockables" Grid.Row="4" Grid.Column="0" />
+    <TextBox Text="{Binding TopPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="4" Grid.Column="1" />
+    <TextBlock Text="BottomPinnedDockables" Grid.Row="5" Grid.Column="0" />
+    <TextBox Text="{Binding BottomPinnedDockables.Count, Mode=OneWay}" Margin="2" IsReadOnly="True" Grid.Row="5" Grid.Column="1" />
+    <TextBlock Text="PinnedDock" Grid.Row="6" Grid.Column="0" />
+    <TextBox Text="{Binding PinnedDock.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="6" Grid.Column="1" />
+    <TextBlock Text="Window" Grid.Row="7" Grid.Column="0" />
+    <TextBox Text="{Binding Window.Title, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="7" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class RootDockInfoDebugView : UserControl
+{
+    public RootDockInfoDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.StackDockDebugView"
+             x:DataType="controls:IStackDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="Spacing" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding Spacing, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class StackDockDebugView : UserControl
+{
+    public StackDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.ToolContentDebugView"
+             x:DataType="controls:IToolContent"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Content" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Content, Mode=OneWay, FallbackValue={x:Null}}" Margin="2" IsReadOnly="True" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class ToolContentDebugView : UserControl
+{
+    public ToolContentDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml
@@ -1,0 +1,17 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.ToolDockDebugView"
+             x:DataType="controls:IToolDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Alignment" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Alignment, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="IsExpanded" Grid.Row="1" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding IsExpanded, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+    <TextBlock Text="AutoHide" Grid.Row="2" Grid.Column="0" />
+    <CheckBox IsChecked="{Binding AutoHide, Mode=TwoWay}" Margin="2" Grid.Row="2" Grid.Column="1" />
+    <TextBlock Text="GripMode" Grid.Row="3" Grid.Column="0" />
+    <TextBox Text="{Binding GripMode, Mode=TwoWay}" Margin="2" Grid.Row="3" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class ToolDockDebugView : UserControl
+{
+    public ToolDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.UniformGridDockDebugView"
+             x:DataType="controls:IUniformGridDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Rows" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Rows, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+    <TextBlock Text="Columns" Grid.Row="1" Grid.Column="0" />
+    <TextBox Text="{Binding Columns, Mode=TwoWay}" Margin="2" Grid.Row="1" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class UniformGridDockDebugView : UserControl
+{
+    public UniformGridDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml
+++ b/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+             x:Class="Dock.Avalonia.Controls.Diagnostics.WrapDockDebugView"
+             x:DataType="controls:IWrapDock"
+             x:CompileBindings="True">
+  <Grid RowDefinitions="Auto" ColumnDefinitions="Auto,*">
+    <TextBlock Text="Orientation" Grid.Row="0" Grid.Column="0" />
+    <TextBox Text="{Binding Orientation, Mode=TwoWay}" Margin="2" Grid.Row="0" Grid.Column="1" />
+  </Grid>
+</UserControl>

--- a/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Dock.Avalonia.Controls.Diagnostics;
+
+public partial class WrapDockDebugView : UserControl
+{
+    public WrapDockDebugView()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- extract debug grids into dedicated UserControls
- reference new UserControls from `RootDockDebug`

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687dfcee75808321b26d82be4747b499