### PR TITLE
Add diagnostics xml docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ application created with the .NET SDK. For build instructions and an overview of
 - [Pinned dock window](dock-pinned-window.md) – Show auto-hidden tools in a floating window.
 - [Floating window owner](dock-window-owner.md) – Keep floating windows in front of the main window.
 - [RootDockDebug window](dock-root-dock-debug.md) – Toggle a runtime inspector for Dock layouts.
+- [Debug views](dock-debug-views.md) – Reusable controls used by RootDockDebug.
 - [Advanced guide](dock-advanced.md) – Custom factories and runtime features.
 - [Custom Dock.Model implementations](dock-custom-model.md) – Integrate Dock with other MVVM frameworks.
 

--- a/docs/dock-debug-views.md
+++ b/docs/dock-debug-views.md
@@ -1,0 +1,25 @@
+# Debug views
+
+`RootDockDebug` uses several helper controls located under `Dock.Avalonia.Controls.Diagnostics`. These views expose properties of docks, dockables and windows in a simple grid and can be reused to build custom inspection tools.
+
+## Available views
+
+- `DockDebugView` – Shows information about a `DockControl`.
+- `DockDockDebugView` – Displays details of a `DockDockControl`.
+- `DockWindowDebugView` – Inspects an `IDockWindow` instance.
+- `DockableDebugView` – Lists common properties of dockables.
+- `DocumentContentDebugView` – Shows a document's content.
+- `DocumentDockContentDebugView` – Displays the contents of a document dock.
+- `DocumentDockDebugView` – Debugs a document dock.
+- `DocumentTemplateDebugView` – Renders document templates.
+- `GridDockDebugView` – Visualizes a `GridDockControl`.
+- `GridDockSplitterDebugView` – Shows grid splitter information.
+- `ProportionalDockDebugView` – Displays proportions of a proportional dock.
+- `ProportionalDockSplitterDebugView` – Lists proportional splitter values.
+- `RootDockInfoDebugView` – Shows root dock properties.
+- `StackDockDebugView` – Debug view for stack docks.
+- `ToolContentDebugView` – Inspects tool content.
+- `ToolDockDebugView` – Displays tool dock properties.
+- `UniformGridDockDebugView` – Visualizes uniform grid layout.
+- `WrapDockDebugView` – Shows wrap dock configuration.
+

--- a/src/Dock.Avalonia/Controls/Diagnostics/DebugOverlayAdorner.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DebugOverlayAdorner.cs
@@ -11,6 +11,9 @@ using Dock.Settings;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Adorner that highlights docking areas for debugging purposes.
+/// </summary>
 internal class DebugOverlayAdorner : Control
 {
     private static readonly Pen s_dockTargetPen = new(Brushes.Red);
@@ -27,6 +30,10 @@ internal class DebugOverlayAdorner : Control
 
     private Control? _pointerOver;
 
+    /// <summary>
+    /// Sets the control currently under the pointer.
+    /// </summary>
+    /// <param name="control">The hovered control or <c>null</c>.</param>
     public void SetPointerOver(Control? control)
     {
         if (_pointerOver != control)
@@ -36,6 +43,10 @@ internal class DebugOverlayAdorner : Control
         }
     }
 
+    /// <summary>
+    /// Draws the overlay using the given drawing context.
+    /// </summary>
+    /// <param name="context">The drawing context.</param>
     public override void Render(DrawingContext context)
     {
         base.Render(context);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Displays debug information for a <see cref="DockControl"/>.
+/// </summary>
 public partial class DockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockDebugView"/> class.
+    /// </summary>
     public DockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view showing properties of a <see cref="DockDockControl"/>.
+/// </summary>
 public partial class DockDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockDockDebugView"/> class.
+    /// </summary>
     public DockDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockWindowDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Displays debug information for an <see cref="IDockWindow"/>.
+/// </summary>
 public partial class DockWindowDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockWindowDebugView"/> class.
+    /// </summary>
     public DockWindowDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DockableDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Shows debug information common to all dockables.
+/// </summary>
 public partial class DockableDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockableDebugView"/> class.
+    /// </summary>
     public DockableDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentContentDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view that displays information about a document's content.
+/// </summary>
 public partial class DocumentContentDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentContentDebugView"/> class.
+    /// </summary>
     public DocumentContentDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockContentDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Shows the contents of a document dock for debugging.
+/// </summary>
 public partial class DocumentDockContentDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentDockContentDebugView"/> class.
+    /// </summary>
     public DocumentDockContentDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view showing the state of a document dock.
+/// </summary>
 public partial class DocumentDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentDockDebugView"/> class.
+    /// </summary>
     public DocumentDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DocumentTemplateDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Displays a document template for debugging purposes.
+/// </summary>
 public partial class DocumentTemplateDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentTemplateDebugView"/> class.
+    /// </summary>
     public DocumentTemplateDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view for <see cref="GridDockControl"/> instances.
+/// </summary>
 public partial class GridDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GridDockDebugView"/> class.
+    /// </summary>
     public GridDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/GridDockSplitterDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view displaying splitter information for a grid dock.
+/// </summary>
 public partial class GridDockSplitterDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GridDockSplitterDebugView"/> class.
+    /// </summary>
     public GridDockSplitterDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view for a <see cref="ProportionalDockControl"/>.
+/// </summary>
 public partial class ProportionalDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProportionalDockDebugView"/> class.
+    /// </summary>
     public ProportionalDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ProportionalDockSplitterDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view showing splitter positions in proportional docks.
+/// </summary>
 public partial class ProportionalDockSplitterDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProportionalDockSplitterDebugView"/> class.
+    /// </summary>
     public ProportionalDockSplitterDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebug.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebug.axaml.cs
@@ -16,7 +16,7 @@ using ModelWindowClosingEventArgs = Dock.Model.Core.Events.WindowClosingEventArg
 namespace Dock.Avalonia.Controls.Diagnostics;
 
 /// <summary>
-/// 
+/// Window that logs Dock events and displays layout information.
 /// </summary>
 public partial class RootDockDebug : UserControl, INotifyPropertyChanged
 {
@@ -66,7 +66,7 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
     {
         AvaloniaXamlLoader.Load(this);
     }
-    
+
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
         if (_subscriptions is not null)
@@ -182,6 +182,11 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
     private void OnWindowMoveDragEnd(object? sender, WindowMoveDragEndEventArgs e) =>
         AddEvent($"WindowMoveDragEnd {e.Window?.Title}");
 
+    /// <summary>
+    /// Clears the event log.
+    /// </summary>
+    /// <param name="sender">Event source.</param>
+    /// <param name="e">The routed event args.</param>
     private void OnClearEvents(object? sender, RoutedEventArgs e)
     {
         Events.Clear();
@@ -200,6 +205,9 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
 
         public ActionDisposable(Action dispose) => _dispose = dispose;
 
+        /// <summary>
+        /// Executes the stored dispose action.
+        /// </summary>
         public void Dispose() => _dispose();
     }
 }

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebugExtensions.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockDebugExtensions.cs
@@ -8,7 +8,7 @@ using Avalonia.Interactivity;
 namespace Dock.Avalonia.Controls.Diagnostics;
 
 /// <summary>
-/// Provides extension method to attach <see cref="RootDockDebug"/> window.
+/// Provides extension method to attach a <see cref="RootDockDebug"/> window.
 /// </summary>
 public static class RootDockDebugExtensions
 {
@@ -68,6 +68,9 @@ public static class RootDockDebugExtensions
 
         public ActionDisposable(Action dispose) => _dispose = dispose;
 
+        /// <summary>
+        /// Executes the stored dispose action.
+        /// </summary>
         public void Dispose() => _dispose();
     }
 }

--- a/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/RootDockInfoDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Displays information about the root dock.
+/// </summary>
 public partial class RootDockInfoDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RootDockInfoDebugView"/> class.
+    /// </summary>
     public RootDockInfoDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/StackDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view for stack dock layouts.
+/// </summary>
 public partial class StackDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StackDockDebugView"/> class.
+    /// </summary>
     public StackDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolContentDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view displaying tool content properties.
+/// </summary>
 public partial class ToolContentDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolContentDebugView"/> class.
+    /// </summary>
     public ToolContentDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/ToolDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view showing properties of a tool dock.
+/// </summary>
 public partial class ToolDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolDockDebugView"/> class.
+    /// </summary>
     public ToolDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/UniformGridDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view for uniform grid dock layouts.
+/// </summary>
 public partial class UniformGridDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UniformGridDockDebugView"/> class.
+    /// </summary>
     public UniformGridDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/WrapDockDebugView.axaml.cs
@@ -5,13 +5,22 @@ using Avalonia.Markup.Xaml;
 
 namespace Dock.Avalonia.Controls.Diagnostics;
 
+/// <summary>
+/// Debug view for wrap dock layouts.
+/// </summary>
 public partial class WrapDockDebugView : UserControl
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WrapDockDebugView"/> class.
+    /// </summary>
     public WrapDockDebugView()
     {
         InitializeComponent();
     }
 
+    /// <summary>
+    /// Loads the control's XAML.
+    /// </summary>
     private void InitializeComponent()
     {
         AvaloniaXamlLoader.Load(this);


### PR DESCRIPTION
## Summary
- document debug overlay adorner and debug view classes
- add debug views docs page
- link to debug views from main docs

## Testing
- `dotnet format src/Dock.Avalonia --no-restore --verbosity minimal`
- `dotnet test --no-build` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_687e0cf9621483218eb0d6ff09dbe12f