### PR TITLE
Fix debug overlay flicker

### DIFF
--- a/src/Dock.Avalonia/Controls/Diagnostics/DebugOverlayAdorner.cs
+++ b/src/Dock.Avalonia/Controls/Diagnostics/DebugOverlayAdorner.cs
@@ -31,6 +31,14 @@ internal class DebugOverlayAdorner : Control
     private Control? _pointerOver;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="DebugOverlayAdorner"/> class.
+    /// </summary>
+    public DebugOverlayAdorner()
+    {
+        IsHitTestVisible = false;
+    }
+
+    /// <summary>
     /// Sets the control currently under the pointer.
     /// </summary>
     /// <param name="control">The hovered control or <c>null</c>.</param>


### PR DESCRIPTION
## Summary
- keep DebugOverlayAdorner from intercepting pointer events by setting `IsHitTestVisible` to false

## Testing
- `dotnet format --no-restore`
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687e24a59c2883219dd79bb5c608e617