### PR TITLE
Add toggleable Dock debug overlay

### DIFF
--- a/docs/dock-debug-overlay.md
+++ b/docs/dock-debug-overlay.md
@@ -10,13 +10,15 @@ When enabled each `DockControl` gets an adorner that draws:
 Hovering over an area fills it with a translucent color and shows the hovered
 control's data context in the bottom-right corner.
 
-Enable the overlay in your application just like Avalonia's dev tools:
+Attach the overlay in your application just like Avalonia's dev tools. It can be
+toggled at runtime using <kbd>F10</kbd> by default:
 
 ```csharp
 #if DEBUG
-this.AttachDockDebugOverlay();
+var disposable = this.AttachDockDebugOverlay();
 #endif
 ```
 
 Call the extension method on your `App` or on a specific `Window`/`TopLevel` to
-activate the overlay.
+register the hot key. Optionally pass your own `KeyGesture` to change the
+shortcut.

--- a/src/Dock.Avalonia/Diagnostics/DockDebugOverlayExtensions.cs
+++ b/src/Dock.Avalonia/Diagnostics/DockDebugOverlayExtensions.cs
@@ -4,6 +4,8 @@ using System;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 using Dock.Avalonia.Controls;
 
 namespace Dock.Avalonia.Diagnostics;
@@ -14,31 +16,77 @@ namespace Dock.Avalonia.Diagnostics;
 public static class DockDebugOverlayExtensions
 {
     /// <summary>
-    /// Attaches a debug overlay to all <see cref="DockControl"/> instances in the given top level.
+    /// Attaches a debug overlay to all <see cref="DockControl"/> instances in the
+    /// given top level and toggles it with <paramref name="gesture"/>.
     /// </summary>
     /// <param name="topLevel">The visual root.</param>
-    /// <returns>An <see cref="IDisposable"/> that removes the overlay when disposed.</returns>
-    public static IDisposable AttachDockDebugOverlay(this TopLevel topLevel)
+    /// <param name="gesture">The key gesture used to toggle the overlay.</param>
+    /// <returns>An <see cref="IDisposable"/> that unregisters the hotkey and
+    /// removes the overlay when disposed.</returns>
+    public static IDisposable AttachDockDebugOverlay(
+        this TopLevel topLevel,
+        KeyGesture? gesture = null)
     {
-        return new DockDebugOverlayManager(topLevel);
+        var keyGesture = gesture ?? new KeyGesture(Key.F10);
+        DockDebugOverlayManager? manager = null;
+
+        void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (!keyGesture.Matches(e))
+            {
+                return;
+            }
+
+            if (manager is null)
+            {
+                manager = new DockDebugOverlayManager(topLevel);
+            }
+            else
+            {
+                manager.Dispose();
+                manager = null;
+            }
+        }
+
+        topLevel.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+
+        return new ActionDisposable(() =>
+        {
+            topLevel.RemoveHandler(InputElement.KeyDownEvent, OnKeyDown);
+            manager?.Dispose();
+            manager = null;
+        });
     }
 
     /// <summary>
     /// Attaches a debug overlay to each window created by the application.
     /// </summary>
     /// <param name="app">The Avalonia application.</param>
-    public static void AttachDockDebugOverlay(this Application app)
+    /// <param name="gesture">The key gesture used to toggle the overlay.</param>
+    public static void AttachDockDebugOverlay(this Application app, KeyGesture? gesture = null)
     {
         if (app.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             foreach (var window in desktop.Windows)
             {
-                window.AttachDockDebugOverlay();
+                window.AttachDockDebugOverlay(gesture);
             }
         }
         else if (app.ApplicationLifetime is ISingleViewApplicationLifetime single && single.MainView is TopLevel tl)
         {
-            tl.AttachDockDebugOverlay();
+            tl.AttachDockDebugOverlay(gesture);
         }
+    }
+
+    private sealed class ActionDisposable : IDisposable
+    {
+        private readonly Action _dispose;
+
+        public ActionDisposable(Action dispose) => _dispose = dispose;
+
+        /// <summary>
+        /// Executes the stored dispose action.
+        /// </summary>
+        public void Dispose() => _dispose();
     }
 }


### PR DESCRIPTION
## Summary
- add optional key gesture toggle for debug overlay
- hook up key to TopLevel and Application
- document the F10 hotkey and usage

## Testing
- `dotnet format --include src/Dock.Avalonia/Diagnostics/DockDebugOverlayExtensions.cs -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687e285187088321b26c5ec9d2aa7395