### PR TITLE
Fix debug overlay enumeration

### DIFF
--- a/src/Dock.Avalonia/Diagnostics/DockDebugOverlayManager.cs
+++ b/src/Dock.Avalonia/Diagnostics/DockDebugOverlayManager.cs
@@ -25,7 +25,7 @@ internal sealed class DockDebugOverlayManager : IDisposable
 
     private void AttachExisting(Visual root)
     {
-        foreach (var dock in root.GetVisualDescendants().OfType<DockControl>())
+        foreach (var dock in root.GetVisualDescendants().OfType<DockControl>().ToList())
         {
             AttachOverlay(dock);
         }


### PR DESCRIPTION
## Summary
- stabilize enumeration in `DockDebugOverlayManager`

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: invalid test arguments)*
- `./build.sh --target=Test --verbosity=normal` *(fails: build error)*

------
https://chatgpt.com/codex/tasks/task_e_687e2c3dfb148321a5336c86df15ee20