### PR TITLE
Fix tab strip item gaps

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml
@@ -195,7 +195,7 @@
                           Spacing="2"
                           DockProperties.IsDragArea="True"
                           DockProperties.IsDropArea="True">
-                <Panel Margin="2">
+                <Panel Margin="0">
                   <ContentPresenter ContentTemplate="{Binding $parent[DocumentControl].HeaderTemplate}"
                                     Content="{Binding}" />
                 </Panel>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml
@@ -113,7 +113,7 @@
                           Spacing="2"
                           DockProperties.IsDragArea="True"
                           DockProperties.IsDropArea="True">
-                <Panel Margin="2">
+                <Panel Margin="0">
                   <ContentPresenter ContentTemplate="{Binding $parent[ToolControl].HeaderTemplate}"
                                     Content="{Binding}" />
                 </Panel>


### PR DESCRIPTION
## Summary
- remove internal margins from `DocumentTabStripItem` template
- remove internal margins from `ToolTabStripItem` template

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687e34446cb88321972f648b8b746d0d