### PR TITLE
Remove unnecessary DockAdornerHost control properties.

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentControl.axaml
@@ -51,7 +51,7 @@
                             Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
                             DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"
                             DockProperties.IsDropArea="True"
-                            DockAdornerHost="{Binding #PART_DockPanel}">
+                            DockProperties.DockAdornerHost="{Binding #PART_DockPanel}">
             <DocumentTabStrip.Styles>
               <Style Selector="DocumentTabStripItem">
                 <Setter Property="IsActive" Value="{Binding $parent[DocumentTabStrip].IsActive}" />

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml
@@ -71,8 +71,7 @@
                   DockProperties.IsDropArea="True"
                   DockProperties.IsDockTarget="True"
                   DockProperties.ShowDockIndicatorOnly="True"
-                  DockProperties.IndicatorDockOperation="Fill"
-                  DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
+                  DockProperties.IndicatorDockOperation="Fill" />
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -22,12 +22,6 @@ public class DocumentTabStrip : TabStrip
     private HostWindow? _attachedWindow;
     private Control? _grip;
     private WindowDragHelper? _windowDragHelper;
-
-    /// <summary>
-    /// Defines the <see cref="DockAdornerHost"/> property.
-    /// </summary>
-    public static readonly StyledProperty<Control?> DockAdornerHostProperty =
-        AvaloniaProperty.Register<DocumentTabStrip, Control?>(nameof(DockAdornerHost));
     
     /// <summary>
     /// Defines the <see cref="CanCreateItem"/> property.
@@ -87,15 +81,6 @@ public class DocumentTabStrip : TabStrip
     {
         get => GetValue(OrientationProperty);
         set => SetValue(OrientationProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the control that should host the dock adorner.
-    /// </summary>
-    public Control? DockAdornerHost
-    {
-        get => GetValue(DockAdornerHostProperty);
-        set => SetValue(DockAdornerHostProperty, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ToolControl.axaml
+++ b/src/Dock.Avalonia/Controls/ToolControl.axaml
@@ -47,7 +47,7 @@
                         SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
                         DockPanel.Dock="Bottom"
                         DockProperties.IsDropArea="True"
-                        DockAdornerHost="{Binding #PART_DockPanel}" />
+                        DockProperties.DockAdornerHost="{Binding #PART_DockPanel}" />
           <Border x:Name="PART_Border">
             <DockableControl DataContext="{Binding ActiveDockable}"
                              TrackingMode="Visible">

--- a/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
+++ b/src/Dock.Avalonia/Controls/ToolTabStrip.axaml
@@ -40,8 +40,7 @@
                  DockProperties.IsDropArea="True"
                  DockProperties.IsDockTarget="True"
                  DockProperties.ShowDockIndicatorOnly="True"
-                 DockProperties.IndicatorDockOperation="Fill"
-                 DockProperties.DockAdornerHost="{TemplateBinding DockAdornerHost}" />
+                 DockProperties.IndicatorDockOperation="Fill" />
         </DockPanel>
       </ControlTemplate>
     </Setter>

--- a/src/Dock.Avalonia/Controls/ToolTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStrip.axaml.cs
@@ -17,12 +17,6 @@ namespace Dock.Avalonia.Controls;
 public class ToolTabStrip : TabStrip
 {
     /// <summary>
-    /// Defines the <see cref="DockAdornerHost"/> property.
-    /// </summary>
-    public static readonly StyledProperty<Control?> DockAdornerHostProperty =
-        AvaloniaProperty.Register<ToolTabStrip, Control?>(nameof(DockAdornerHost));
-
-    /// <summary>
     /// Defines the <see cref="CanCreateItem"/> property.
     /// </summary>
     public static readonly StyledProperty<bool> CanCreateItemProperty =
@@ -35,15 +29,6 @@ public class ToolTabStrip : TabStrip
     {
         get => GetValue(CanCreateItemProperty);
         set => SetValue(CanCreateItemProperty, value);
-    }
-
-    /// <summary>
-    /// Gets or sets the control that should host the dock adorner.
-    /// </summary>
-    public Control? DockAdornerHost
-    {
-        get => GetValue(DockAdornerHostProperty);
-        set => SetValue(DockAdornerHostProperty, value);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Settings/DockProperties.cs
+++ b/src/Dock.Settings/DockProperties.cs
@@ -64,7 +64,7 @@ public class DockProperties : AvaloniaObject
     /// the dock target adorner instead of the adorned control itself.
     /// </summary>
     public static readonly AttachedProperty<Control?> DockAdornerHostProperty =
-        AvaloniaProperty.RegisterAttached<DockProperties, Control, Control?>("DockAdornerHost", null, false, BindingMode.TwoWay);
+        AvaloniaProperty.RegisterAttached<DockProperties, Control, Control?>("DockAdornerHost", null, true, BindingMode.TwoWay);
 
     /// <summary>
     /// Gets the value of the IsDockTarget attached property on the specified control.


### PR DESCRIPTION
We can just use attached property inheritance and this will be inherited to all controls inside the tabstrip.

This is the first step to allowing the indicator to show when over tabstrip items.