### PR TITLE
window drag helper fix dragging by the main window on win32

### DIFF
--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -136,6 +136,9 @@ internal class WindowDragHelper
             if (root is Window window)
             {
                 window.BeginMoveDrag(_lastPointerPressedArgs);
+                _pointerPressed = false;
+                _isDragging = false;
+                e.Handled = true;
             }
             return;
         }


### PR DESCRIPTION
Currently if you drag a non-hostwindow i.e. your apps main window by the tabstrip, then the window drag helper state is not reset when BeginMoveDrag is called. 

on win32 platforms in this scenario we will not receive a pointer released event. This means that you cant drag out tabs after dragging the main window, until the user clicks somewhere in the tabstrip without moving.

This PR fixes this by resetting the flags and handling the event, once we call BeginMoveDrag.