### PR TITLE
Enable floating via tab double-click

### DIFF
--- a/docs/dock-faq.md
+++ b/docs/dock-faq.md
@@ -143,4 +143,9 @@ you.
 Dockables may still be floated programmatically unless their `CanFloat` property
 is set to `false`.
 
+**How do I float a dockable from its tab?**
+
+Double-click the tab of a document or tool to detach it into a separate window.
+The dockable must have `CanFloat` enabled.
+
 For a general overview of Dock see the [documentation index](README.md).

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -49,6 +49,7 @@ public class DocumentTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
+        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel);
     }
 
     /// <inheritdoc/>
@@ -57,6 +58,7 @@ public class DocumentTabStripItem : TabStripItem
         base.OnDetachedFromVisualTree(e);
 
         RemoveHandler(PointerPressedEvent, PressedHandler);
+        RemoveHandler(DoubleTappedEvent, DoubleTappedHandler);
     }
 
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
@@ -67,6 +69,14 @@ public class DocumentTabStripItem : TabStripItem
             {
                 factory.CloseDockable(dockable);
             }
+        }
+    }
+
+    private void DoubleTappedHandler(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is IDockable { Owner: IDock { Factory: { } factory }, CanFloat: true } dockable)
+        {
+            factory.FloatDockable(dockable);
         }
     }
 

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -49,7 +49,7 @@ public class DocumentTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
-        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel);
+        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -23,7 +23,7 @@ public class ToolTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
-        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel);
+        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
     }
 
     /// <inheritdoc/>

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -23,6 +23,7 @@ public class ToolTabStripItem : TabStripItem
         base.OnAttachedToVisualTree(e);
 
         AddHandler(PointerPressedEvent, PressedHandler, RoutingStrategies.Tunnel);
+        AddHandler(DoubleTappedEvent, DoubleTappedHandler, RoutingStrategies.Tunnel);
     }
 
     /// <inheritdoc/>
@@ -31,6 +32,7 @@ public class ToolTabStripItem : TabStripItem
         base.OnDetachedFromVisualTree(e);
 
         RemoveHandler(PointerPressedEvent, PressedHandler);
+        RemoveHandler(DoubleTappedEvent, DoubleTappedHandler);
     }
 
     private void PressedHandler(object? sender, PointerPressedEventArgs e)
@@ -41,6 +43,14 @@ public class ToolTabStripItem : TabStripItem
             {
                 factory.CloseDockable(dockable);
             }
+        }
+    }
+
+    private void DoubleTappedHandler(object? sender, TappedEventArgs e)
+    {
+        if (DataContext is IDockable { Owner: IDock { Factory: { } factory }, CanFloat: true } dockable)
+        {
+            factory.FloatDockable(dockable);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add DoubleTapped handler to DocumentTabStripItem
- add DoubleTapped handler to ToolTabStripItem
- document how to float a dockable by double-clicking its tab

## Testing
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_688128a4f2588321aee3ad842a956f3c