### PR TITLE
fix docktarget not getting its state reset when being reused. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,4 +289,3 @@ tools/**
 
 # macOS
 .DS_Store
-*.cs

--- a/src/Dock.Avalonia/Controls/DockTargetBase.cs
+++ b/src/Dock.Avalonia/Controls/DockTargetBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
@@ -25,7 +26,7 @@ namespace Dock.Avalonia.Controls;
 [TemplatePart("PART_LeftSelector", typeof(Control))]
 [TemplatePart("PART_RightSelector", typeof(Control))]
 [TemplatePart("PART_CenterSelector", typeof(Control))]
-public abstract class DockTargetBase : TemplatedControl
+public abstract class DockTargetBase : TemplatedControl, IDockTarget
 {
     private static readonly string[] s_indicators =
     [
@@ -337,5 +338,13 @@ public abstract class DockTargetBase : TemplatedControl
 
         indicator.Opacity = 0;
         return false;
+    }
+
+    void IDockTarget.Reset()
+    {
+        foreach (var control in IndicatorOperations.Values.Concat(SelectorsOperations.Values))
+        {
+            control.Opacity = 0;
+        }
     }
 }

--- a/src/Dock.Avalonia/Controls/IDockTarget.cs
+++ b/src/Dock.Avalonia/Controls/IDockTarget.cs
@@ -1,0 +1,13 @@
+namespace Dock.Avalonia.Controls;
+
+/// <summary>
+/// Interface all DockTargets should implement.
+/// </summary>
+public interface IDockTarget
+{
+    /// <summary>
+    /// Resets the state of the DockTarget to be reused.
+    /// </summary>
+    void Reset();
+}
+    

--- a/src/Dock.Avalonia/Internal/AdornerHelper.cs
+++ b/src/Dock.Avalonia/Internal/AdornerHelper.cs
@@ -9,9 +9,9 @@ using Dock.Avalonia.Controls;
 namespace Dock.Avalonia.Internal;
 
 internal class AdornerHelper<T>(bool useFloatingDockAdorner)
-    where T : Control, new()
+    where T : Control, IDockTarget, new()
 {
-    private readonly Control _adorner = new T();
+    private readonly T _adorner = new T();
     public Control? Adorner;
     private DockAdornerWindow? _window;
     private AdornerLayer? _layer;
@@ -133,6 +133,7 @@ internal class AdornerHelper<T>(bool useFloatingDockAdorner)
         }
 
         Adorner = null;
+        _adorner.Reset();
     }
 
     private void RemoveRegularAdorner()
@@ -142,8 +143,9 @@ internal class AdornerHelper<T>(bool useFloatingDockAdorner)
             _layer.Children.Remove(Adorner);
             ((ISetLogicalParent)Adorner).SetParent(null);
         }
-
+        
         Adorner = null;
         _layer = null;
+        _adorner.Reset();
     }
 }


### PR DESCRIPTION
This was causing indicators and selectors to stay on when they shouldnt be.