### PR TITLE
Fix HostWindow pointer event handling

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -171,6 +171,11 @@ public class HostWindow : Window, IHostWindow
     {
         base.OnPointerPressed(e);
 
+        if (e.Handled)
+        {
+            return;
+        }
+
         if (_chromeGrips.Any(grip => grip.IsPointerOver))
         {
             if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
@@ -184,6 +189,11 @@ public class HostWindow : Window, IHostWindow
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
+
+        if (e.Handled)
+        {
+            return;
+        }
 
         if (_draggingWindow)
         {


### PR DESCRIPTION
## Summary
- skip HostWindow drag logic when pointer event already handled

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6882539b81d88321a557924bc5b26808