### PR TITLE
Handle pointer capture loss in drag helper

### DIFF
--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -39,6 +39,7 @@ internal class WindowDragHelper
         _owner.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
         _owner.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
         _owner.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel);
+        _owner.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Tunnel);
     }
 
     public void Detach()
@@ -46,6 +47,12 @@ internal class WindowDragHelper
         _owner.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
         _owner.RemoveHandler(InputElement.PointerReleasedEvent, OnPointerReleased);
         _owner.RemoveHandler(InputElement.PointerMovedEvent, OnPointerMoved);
+        _owner.RemoveHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost);
+
+        if (_isDragging || _dragWindow is not null)
+        {
+            ResetDragState();
+        }
     }
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -105,6 +112,28 @@ internal class WindowDragHelper
         _dragWindow = null;
 
         e.Handled = true;
+    }
+
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        ResetDragState();
+    }
+
+    private void ResetDragState()
+    {
+        _pointerPressed = false;
+        _isDragging = false;
+
+        if (_dragWindow is not null)
+        {
+            if (_positionChangedHandler is not null)
+            {
+                _dragWindow.PositionChanged -= _positionChangedHandler;
+                _positionChangedHandler = null;
+            }
+
+            _dragWindow = null;
+        }
     }
 
     private void OnPointerMoved(object? sender, PointerEventArgs e)

--- a/tests/Dock.Avalonia.HeadlessTests/WindowDragHelperTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/WindowDragHelperTests.cs
@@ -1,0 +1,74 @@
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Dock.Avalonia.Internal;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class WindowDragHelperTests
+{
+    private static FieldInfo DragWindowField => typeof(WindowDragHelper).GetField("_dragWindow", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static FieldInfo PositionHandlerField => typeof(WindowDragHelper).GetField("_positionChangedHandler", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static FieldInfo PointerPressedField => typeof(WindowDragHelper).GetField("_pointerPressed", BindingFlags.NonPublic | BindingFlags.Instance)!;
+    private static FieldInfo IsDraggingField => typeof(WindowDragHelper).GetField("_isDragging", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    private static int GetPositionChangedCount(WindowBase window)
+    {
+        var field = typeof(WindowBase).GetField("PositionChanged", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var del = field.GetValue(window) as Delegate;
+        return del?.GetInvocationList().Length ?? 0;
+    }
+
+    [AvaloniaFact]
+    public void CaptureLost_Cleans_Drag_State()
+    {
+        var owner = new Control();
+        var helper = new WindowDragHelper(owner, () => true, _ => true);
+        var window = new Window();
+        EventHandler<PixelPointEventArgs> handler = (_, _) => { };
+        window.PositionChanged += handler;
+
+        DragWindowField.SetValue(helper, window);
+        PositionHandlerField.SetValue(helper, handler);
+        PointerPressedField.SetValue(helper, true);
+        IsDraggingField.SetValue(helper, true);
+
+        Assert.Equal(1, GetPositionChangedCount(window));
+
+        var pointer = new Pointer(0, PointerType.Mouse, true);
+        var args = new PointerCaptureLostEventArgs(owner, pointer);
+        var method = typeof(WindowDragHelper).GetMethod("OnPointerCaptureLost", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        method.Invoke(helper, new object?[] { owner, args });
+
+        Assert.Equal(0, GetPositionChangedCount(window));
+        Assert.False((bool)PointerPressedField.GetValue(helper)!);
+        Assert.False((bool)IsDraggingField.GetValue(helper)!);
+        Assert.Null(DragWindowField.GetValue(helper));
+        Assert.Null(PositionHandlerField.GetValue(helper));
+    }
+
+    [AvaloniaFact]
+    public void Detach_WhenDragging_Cleans_State()
+    {
+        var owner = new Control();
+        var helper = new WindowDragHelper(owner, () => true, _ => true);
+        var window = new Window();
+        EventHandler<PixelPointEventArgs> handler = (_, _) => { };
+        window.PositionChanged += handler;
+
+        DragWindowField.SetValue(helper, window);
+        PositionHandlerField.SetValue(helper, handler);
+        IsDraggingField.SetValue(helper, true);
+
+        Assert.Equal(1, GetPositionChangedCount(window));
+
+        helper.Detach();
+
+        Assert.Equal(0, GetPositionChangedCount(window));
+        Assert.Null(DragWindowField.GetValue(helper));
+        Assert.Null(PositionHandlerField.GetValue(helper));
+    }
+}


### PR DESCRIPTION
## Summary
- clean up drag state on pointer capture loss
- invoke cleanup when detaching while dragging
- test that drag handlers are removed on capture loss or detach

## Testing
- `dotnet test --no-build -c Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688258d708d083219df0fb4d82a0608d