### PR TITLE
Fix dragging capture loss cleanup

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -99,6 +99,9 @@ public class HostWindow : Window, IHostWindow
     {
         PositionChanged += HostWindow_PositionChanged;
         LayoutUpdated += HostWindow_LayoutUpdated;
+        AddHandler(PointerCaptureLostEvent,
+            (_, e) => OnPointerCaptureLost(e),
+            RoutingStrategies.Direct | RoutingStrategies.Tunnel | RoutingStrategies.Bubble);
 
         _dockManager = new DockManager(new DockService());
         _hostWindowState = new HostWindowState(_dockManager, this);
@@ -189,6 +192,22 @@ public class HostWindow : Window, IHostWindow
         {
             EndDrag(e);
         }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPointerCaptureLost(PointerCaptureLostEventArgs e)
+    {
+        base.OnPointerCaptureLost(e);
+
+        if (_draggingWindow)
+        {
+            PseudoClasses.Set(":dragging", false);
+            Window?.Factory?.OnWindowMoveDragEnd(Window);
+        }
+
+        _hostWindowState.Process(new PixelPoint(), EventType.CaptureLost);
+        _mouseDown = false;
+        _draggingWindow = false;
     }
 
     private void HostWindow_PositionChanged(object? sender, PixelPointEventArgs e)

--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -27,6 +27,28 @@ internal class WindowDragHelper
     private Window? _dragWindow;
     private EventHandler<PixelPointEventArgs>? _positionChangedHandler;
 
+    private void CancelDrag()
+    {
+        _pointerPressed = false;
+        _isDragging = false;
+
+        if (_dragWindow is not null)
+        {
+            if (_positionChangedHandler is not null)
+            {
+                _dragWindow.PositionChanged -= _positionChangedHandler;
+                _positionChangedHandler = null;
+            }
+
+            if (_dragWindow is HostWindow hostWindow)
+            {
+                hostWindow.Window?.Factory?.OnWindowMoveDragEnd(hostWindow.Window);
+            }
+
+            _dragWindow = null;
+        }
+    }
+
     public WindowDragHelper(Control owner, Func<bool> isEnabled, Func<Control?, bool> canStartDrag)
     {
         _owner = owner;
@@ -39,6 +61,7 @@ internal class WindowDragHelper
         _owner.AddHandler(InputElement.PointerPressedEvent, OnPointerPressed, RoutingStrategies.Tunnel);
         _owner.AddHandler(InputElement.PointerReleasedEvent, OnPointerReleased, RoutingStrategies.Tunnel);
         _owner.AddHandler(InputElement.PointerMovedEvent, OnPointerMoved, RoutingStrategies.Tunnel);
+        _owner.AddHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost, RoutingStrategies.Tunnel);
     }
 
     public void Detach()
@@ -46,6 +69,12 @@ internal class WindowDragHelper
         _owner.RemoveHandler(InputElement.PointerPressedEvent, OnPointerPressed);
         _owner.RemoveHandler(InputElement.PointerReleasedEvent, OnPointerReleased);
         _owner.RemoveHandler(InputElement.PointerMovedEvent, OnPointerMoved);
+        _owner.RemoveHandler(InputElement.PointerCaptureLostEvent, OnPointerCaptureLost);
+
+        if (_dragWindow is not null || _pointerPressed || _isDragging)
+        {
+            CancelDrag();
+        }
     }
 
     private void OnPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -105,6 +134,11 @@ internal class WindowDragHelper
         _dragWindow = null;
 
         e.Handled = true;
+    }
+
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e)
+    {
+        CancelDrag();
     }
 
     private void OnPointerMoved(object? sender, PointerEventArgs e)

--- a/tests/Dock.Avalonia.HeadlessTests/HostWindowCaptureTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/HostWindowCaptureTests.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+using Avalonia.Input;
+using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Controls;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class HostWindowCaptureTests
+{
+    [AvaloniaFact]
+    public void CaptureLost_Resets_Dragging_State()
+    {
+        var window = new HostWindow();
+        typeof(HostWindow).GetField("_mouseDown", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, true);
+        typeof(HostWindow).GetField("_draggingWindow", BindingFlags.Instance | BindingFlags.NonPublic)!.SetValue(window, true);
+
+        var ctor = typeof(PointerCaptureLostEventArgs).GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new[] { typeof(object), typeof(IPointer) }, null)!;
+        var args = (PointerCaptureLostEventArgs)ctor.Invoke(new object?[] { window, new global::Avalonia.Input.Pointer(0, PointerType.Mouse, true) });
+        args.RoutedEvent = InputElement.PointerCaptureLostEvent;
+
+        typeof(HostWindow).GetMethod("OnPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, new object?[] { args });
+
+        var mouseDown = (bool)typeof(HostWindow).GetField("_mouseDown", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(window)!;
+        var dragging = (bool)typeof(HostWindow).GetField("_draggingWindow", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(window)!;
+
+        Assert.False(mouseDown);
+        Assert.False(dragging);
+    }
+}

--- a/tests/Dock.Avalonia.HeadlessTests/WindowDragHelperTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/WindowDragHelperTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Reflection;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Internal;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class WindowDragHelperTests
+{
+    [AvaloniaFact]
+    public void CaptureLost_Cleans_Up_State()
+    {
+        var owner = new Control();
+        var helper = new WindowDragHelper(owner, () => true, _ => true);
+        var window = new Window();
+        var handler = new EventHandler<PixelPointEventArgs>((_, _) => { });
+        var fieldDragWindow = typeof(WindowDragHelper).GetField("_dragWindow", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var fieldHandler = typeof(WindowDragHelper).GetField("_positionChangedHandler", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        fieldDragWindow.SetValue(helper, window);
+        fieldHandler.SetValue(helper, handler);
+        window.PositionChanged += handler;
+        typeof(WindowDragHelper).GetMethod("Attach")!.Invoke(helper, null);
+
+        var captureArgsCtor = typeof(PointerCaptureLostEventArgs).GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new[] { typeof(object), typeof(IPointer) }, null)!;
+        var args = (PointerCaptureLostEventArgs)captureArgsCtor.Invoke(new object?[] { owner, new global::Avalonia.Input.Pointer(0, PointerType.Mouse, true) });
+        args.RoutedEvent = InputElement.PointerCaptureLostEvent;
+
+        typeof(WindowDragHelper).GetMethod("OnPointerCaptureLost", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(helper, new object?[] { owner, args });
+
+        Assert.Null(fieldDragWindow.GetValue(helper));
+        Assert.Null(fieldHandler.GetValue(helper));
+    }
+
+    [AvaloniaFact]
+    public void Detach_Cleans_Up_Drag_State()
+    {
+        var owner = new Control();
+        var helper = new WindowDragHelper(owner, () => true, _ => true);
+        var window = new Window();
+        var handler = new EventHandler<PixelPointEventArgs>((_, _) => { });
+        var fieldDragWindow = typeof(WindowDragHelper).GetField("_dragWindow", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var fieldHandler = typeof(WindowDragHelper).GetField("_positionChangedHandler", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        fieldDragWindow.SetValue(helper, window);
+        fieldHandler.SetValue(helper, handler);
+        window.PositionChanged += handler;
+
+        helper.Detach();
+
+        Assert.Null(fieldDragWindow.GetValue(helper));
+        Assert.Null(fieldHandler.GetValue(helper));
+    }
+}


### PR DESCRIPTION
## Summary
- clean up HostWindow state when pointer capture is lost
- stop drags in WindowDragHelper when capture is lost or helper detaches
- add tests covering capture lost behaviour

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6882574472c88321844e25a0fa8ec5a0