### PR TITLE
Add Ctrl+Shift hit test shortcut for diagnostics

### DIFF
--- a/docs/dock-root-dock-debug.md
+++ b/docs/dock-root-dock-debug.md
@@ -14,3 +14,5 @@ mainWindow.AttachDockDebug(
 
 Pass a custom `KeyGesture` to use another shortcut. The method returns an `IDisposable` that unregisters the hotkey and closes the window when disposed.
 
+While the window is open you can press **Ctrl+Shift** over any `DockControl` to automatically select the underlying model in the tree view.
+

--- a/src/Dock.Avalonia.Diagnostics/Controls/RootDockDebug.axaml
+++ b/src/Dock.Avalonia.Diagnostics/Controls/RootDockDebug.axaml
@@ -70,7 +70,8 @@
       <diagnostics:RootDockInfoDebugView />
     </DataTemplate>
   </UserControl.DataTemplates>
-  <TabControl>
+  <DockPanel>
+  <TabControl DockPanel.Dock="Top">
     <TabItem Header="{DynamicResource RootDockDebugLayoutTabString}">
       <TreeView x:Name="Visible"
                 ItemsSource="{Binding VisibleDockables}">
@@ -254,4 +255,9 @@
       </ScrollViewer>
     </TabItem>
   </TabControl>
+  <TextBlock Margin="4"
+             HorizontalAlignment="Center"
+             FontSize="{DynamicResource TabItemHeaderFontSize}"
+             Text="{DynamicResource RootDockDebugPickInfoString}" />
+  </DockPanel>
 </UserControl>

--- a/src/Dock.Avalonia.Diagnostics/Controls/RootDockDebug.axaml.cs
+++ b/src/Dock.Avalonia.Diagnostics/Controls/RootDockDebug.axaml.cs
@@ -22,6 +22,11 @@ namespace Dock.Avalonia.Diagnostics.Controls;
 /// </summary>
 public partial class RootDockDebug : UserControl, INotifyPropertyChanged
 {
+    /// <summary>
+    /// Event raised when a dockable should be selected from hit testing.
+    /// </summary>
+    public static event Action<IDockable?>? SelectDockableRequested;
+
     private List<IDisposable>? _subscriptions;
     private string? _filter;
     private SelectionOverlayHelper? _overlayHelper;
@@ -76,6 +81,8 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
         {
             _visibleTree.SelectionChanged += OnVisibleSelectionChanged;
         }
+
+        SelectDockableRequested += OnSelectDockableRequested;
     }
 
     /// <inheritdoc/>
@@ -91,6 +98,8 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
 
         _overlayHelper?.RemoveOverlay();
         _overlayHelper = null;
+
+        SelectDockableRequested -= OnSelectDockableRequested;
     }
 
     private void InitializeComponent()
@@ -232,6 +241,16 @@ public partial class RootDockDebug : UserControl, INotifyPropertyChanged
         {
             _overlayHelper?.Highlight(null);
         }
+    }
+
+    private void OnSelectDockableRequested(IDockable? dockable)
+    {
+        if (dockable is null || _visibleTree is null)
+        {
+            return;
+        }
+
+        _visibleTree.SelectedItem = dockable;
     }
 
     /// <summary>

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ControlStrings.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ControlStrings.axaml
@@ -61,4 +61,5 @@
   <x:String x:Key="RootDockDebugEventsTabString">Events</x:String>
   <x:String x:Key="RootDockDebugFilterString">Filter:</x:String>
   <x:String x:Key="RootDockDebugResetString">Reset</x:String>
+  <x:String x:Key="RootDockDebugPickInfoString">Hold Ctrl+Shift to pick a control</x:String>
 </ResourceDictionary>

--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -14,6 +14,7 @@ using Dock.Avalonia.Internal;
 using Dock.Avalonia.Contract;
 using Dock.Model;
 using Dock.Model.Core;
+using Dock.Avalonia.Diagnostics.Controls;
 
 namespace Dock.Avalonia.Controls;
 
@@ -300,6 +301,24 @@ public class DockControl : TemplatedControl, IDockControl
     {
         if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
+            return;
+        }
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            var pos = e.GetPosition(this);
+            if (this.InputHitTest(pos) is Control control)
+            {
+                IDockable? dockable = null;
+                while (control is { } && dockable is null)
+                {
+                    dockable = control.DataContext as IDockable;
+                    control = control.FindAncestorOfType<Control>();
+                }
+
+                RootDockDebug.SelectDockableRequested?.Invoke(dockable);
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Summary
- allow diagnostics window to pick dockable using Ctrl+Shift
- expose `SelectDockableRequested` event
- update theme resources and docs about the new shortcut

## Testing
- `dotnet format src/Dock.Avalonia.Diagnostics/Dock.Avalonia.Diagnostics.csproj --no-restore >/tmp/format.log && tail -n 20 /tmp/format.log`
- `dotnet format src/Dock.Avalonia/Dock.Avalonia.csproj --no-restore >/tmp/format.log && tail -n 20 /tmp/format.log`
- `dotnet test --no-build` *(fails: "The argument ... is invalid")*

------
https://chatgpt.com/codex/tasks/task_e_68828cebcce88321b516b45ea822fba5