### PR TITLE
Fix debug overlay hotkey

### DIFF
--- a/docs/dock-debug-overlay.md
+++ b/docs/dock-debug-overlay.md
@@ -11,7 +11,7 @@ Hovering over an area fills it with a translucent color and shows the hovered
 control's data context in the bottom-right corner.
 
 Attach the overlay in your application just like Avalonia's dev tools. It can be
-toggled at runtime using <kbd>F10</kbd> by default:
+toggled at runtime using <kbd>F9</kbd> by default:
 
 ```csharp
 #if DEBUG


### PR DESCRIPTION
## Summary
- correct the hotkey in the debug overlay guide

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_68828cad28648321b2967101b642dabd