### PR TITLE
Fix runtime tracking of tool and document controls

### DIFF
--- a/docs/dock-tracking-controls.md
+++ b/docs/dock-tracking-controls.md
@@ -25,6 +25,11 @@ The following properties on `IFactory` keep track of runtime controls.  Each dic
 
 These collections are populated automatically by `FactoryBase` when layouts are initialised.  They can be inspected or modified at runtime if you create custom host controls or windows.
 
+The default Avalonia controls update these dictionaries whenever the `DataContext`
+changes. `ToolContentControl` and `DocumentContentControl` subscribe to the
+`DataContext` property so the `ToolControls` and `DocumentControls` mappings stay
+in sync with the currently visible dockables.
+
 ## Typical usage
 
 Most applications rely on these collections indirectly via the factory helpers.  For example `ShowWindows` iterates `HostWindows` to open any floating tools and documents.  You can also retrieve a specific control:

--- a/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Reactive;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -11,15 +13,17 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class DocumentContentControl : TemplatedControl
 {
+    private IDisposable? _dataContextDisposable;
+    private IDockable? _currentDockable;
     /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
 
-        if (DataContext is IDockable { Factory: { } factory } dockable)
-        {
-            factory.DocumentControls[dockable] = this;
-        }
+        _dataContextDisposable = this.GetObservable(DataContextProperty).Subscribe(
+            new AnonymousObserver<object?>(DataContextTracking));
+
+        DataContextTracking(DataContext);
     }
 
     /// <inheritdoc/>
@@ -27,9 +31,27 @@ public class DocumentContentControl : TemplatedControl
     {
         base.OnDetachedFromVisualTree(e);
 
-        if (DataContext is IDockable { Factory: { } factory } dockable)
+        if (_currentDockable is { Factory: { } factory })
         {
-            factory.DocumentControls.Remove(dockable);
+            factory.DocumentControls.Remove(_currentDockable);
+            _currentDockable = null;
+        }
+
+        _dataContextDisposable?.Dispose();
+    }
+
+    private void DataContextTracking(object? dataContext)
+    {
+        if (_currentDockable is { Factory: { } factory })
+        {
+            factory.DocumentControls.Remove(_currentDockable);
+            _currentDockable = null;
+        }
+
+        if (dataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.DocumentControls[dockable] = this;
+            _currentDockable = dockable;
         }
     }
 }

--- a/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
 using Avalonia;
 using Avalonia.Controls.Primitives;
+using Avalonia.Reactive;
 using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
@@ -11,15 +13,17 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class ToolContentControl : TemplatedControl
 {
+    private IDisposable? _dataContextDisposable;
+    private IDockable? _currentDockable;
     /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
         base.OnAttachedToVisualTree(e);
 
-        if (DataContext is IDockable { Factory: { } factory } dockable)
-        {
-            factory.ToolControls[dockable] = this;
-        }
+        _dataContextDisposable = this.GetObservable(DataContextProperty).Subscribe(
+            new AnonymousObserver<object?>(DataContextTracking));
+
+        DataContextTracking(DataContext);
     }
 
     /// <inheritdoc/>
@@ -27,9 +31,27 @@ public class ToolContentControl : TemplatedControl
     {
         base.OnDetachedFromVisualTree(e);
 
-        if (DataContext is IDockable { Factory: { } factory } dockable)
+        if (_currentDockable is { Factory: { } factory })
         {
-            factory.ToolControls.Remove(dockable);
+            factory.ToolControls.Remove(_currentDockable);
+            _currentDockable = null;
+        }
+
+        _dataContextDisposable?.Dispose();
+    }
+
+    private void DataContextTracking(object? dataContext)
+    {
+        if (_currentDockable is { Factory: { } factory })
+        {
+            factory.ToolControls.Remove(_currentDockable);
+            _currentDockable = null;
+        }
+
+        if (dataContext is IDockable { Factory: { } factory } dockable)
+        {
+            factory.ToolControls[dockable] = this;
+            _currentDockable = dockable;
         }
     }
 }


### PR DESCRIPTION
## Summary
- track controls when `DataContext` changes in `ToolContentControl` and `DocumentContentControl`
- clarify tracking behaviour in documentation

## Testing
- `dotnet format --no-restore --include src/Dock.Avalonia/Controls/DocumentContentControl.axaml.cs src/Dock.Avalonia/Controls/ToolContentControl.axaml.cs --verbosity diagnostic`
- `dotnet test --no-build --nologo` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6882a3f6ef0483219f058f927ff8cf66