### PR TITLE
fix win32 issues with dragging by the document tab strip. 

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -202,17 +202,11 @@ public class DocumentTabStrip : TabStrip
             return;
         }
 
-        if (VisualRoot is Window window &&
-            window is HostWindow hostWindow &&
-            _grip is { } &&
-            (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+        if (VisualRoot is Window win)
         {
-            hostWindow.AttachGrip(_grip, ":documentwindow");
-            _attachedWindow = hostWindow;
+            _windowDragHelper = CreateDragHelper();
+            _windowDragHelper.Attach(win);
         }
-
-        _windowDragHelper = CreateDragHelper();
-        _windowDragHelper.Attach();
     }
 
     private void DetachFromWindow()

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -188,8 +188,11 @@ public class ToolChromeControl : ContentControl
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    _windowDragHelper = CreateDragHelper(Grip);
-                    _windowDragHelper.Attach();
+                    if (VisualRoot is Window win)
+                    {
+                        _windowDragHelper = CreateDragHelper(win);
+                        _windowDragHelper.Attach(win);
+                    }
                 }
             }
 #if false


### PR DESCRIPTION
Ensure we subscribe to the window events and not the control events.

Due to some bug in Avalonia, the event route differs after beginmovedrag is called, meaning controls dont get the pointer released event. Subscribing to the root window events works around this.