### PR TITLE
Dynamic Resource for Menu Button on ToolChromeControl

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
@@ -108,7 +108,7 @@
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                   <Button x:Name="PART_MenuButton"
                           Theme="{StaticResource ChromeButton}"
-                          Flyout="{StaticResource ToolChromeControlContextMenu}">
+                          Flyout="{DynamicResource ToolChromeControlContextMenu}">
                     <Viewbox Margin="2">
                       <Path x:Name="PART_MenuPath" />
                     </Viewbox>


### PR DESCRIPTION
Use Dynamic Resource instead of Static so both right click flyout and the menu button can be replaceable.