### PR TITLE
Set flyouts and context menus using properties on controls instead setting resources in templates

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentTabStripItem.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentTabStripItem.axaml
@@ -180,6 +180,7 @@
     <Setter Property="BorderThickness" Value="0" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="4,0,4,0" />
+    <Setter Property="DocumentContextMenu" Value="{DynamicResource DocumentTabStripItemContextMenu}" />
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -190,7 +191,7 @@
                   TextElement.FontWeight="{TemplateBinding FontWeight}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  ContextMenu="{DynamicResource DocumentTabStripItemContextMenu}"
+                  ContextMenu="{TemplateBinding DocumentContextMenu}"
                   Padding="{TemplateBinding Padding}"
                   DockProperties.IsDragArea="True"
                   DockProperties.IsDropArea="True"

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
@@ -9,7 +9,6 @@
   <ToolChromeControl Width="300" Height="400" />
   </Design.PreviewWith>
 
-
   <MenuFlyout x:Key="ToolChromeControlContextMenu">
     <MenuItem Header="{DynamicResource ToolChromeControlFloatString}"
               Command="{Binding Owner.Factory.FloatDockable}"
@@ -83,6 +82,7 @@
     <Setter Property="Padding" Value="0" />
     <Setter Property="IsPinned" Value="{Binding ActiveDockable.OriginalOwner, FallbackValue=False, Converter={x:Static ObjectConverters.IsNotNull}}" />
     <Setter Property="IsMaximized" Value="{Binding $parent[Window].WindowState, FallbackValue=False, Converter={x:Static IsMaximizedConverter.Instance}}" />
+    <Setter Property="ToolFlyout" Value="{DynamicResource ToolChromeControlContextMenu}" />
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -97,7 +97,7 @@
           <Border x:Name="PART_Border"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   VerticalAlignment="Top"
-                  ContextFlyout="{DynamicResource ToolChromeControlContextMenu}"
+                  ContextFlyout="{TemplateBinding ToolFlyout}"
                   Grid.Row="{Binding GripMode, Converter={x:Static GripModeConverters.GridRowAutoHideConverter}}">
             <Grid x:Name="PART_Grip">
               <DockPanel LastChildFill="True" Margin="8 0">
@@ -108,7 +108,7 @@
                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal">
                   <Button x:Name="PART_MenuButton"
                           Theme="{StaticResource ChromeButton}"
-                          Flyout="{DynamicResource ToolChromeControlContextMenu}">
+                          Flyout="{TemplateBinding ToolFlyout}">
                     <Viewbox Margin="2">
                       <Path x:Name="PART_MenuPath" />
                     </Viewbox>

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ToolPinItemControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ToolPinItemControl.axaml
@@ -55,6 +55,7 @@
     <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
 
     <Setter Property="Background" Value="Transparent" />
+    <Setter Property="PinContextMenu" Value="{DynamicResource ToolPinItemControlContextMenu}" />
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -76,7 +77,7 @@
                 <TextBlock Text="{Binding Title}"
                            VerticalAlignment="Center"
                            HorizontalAlignment="Left"
-                           ContextMenu="{DynamicResource ToolPinItemControlContextMenu}">
+                           ContextMenu="{TemplateBinding PinContextMenu}">
                 </TextBlock>
               </Button>
             </Border>

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ToolTabStripItem.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ToolTabStripItem.axaml
@@ -97,6 +97,7 @@
     <Setter Property="BorderThickness" Value="0 0 0 0" />
     <Setter Property="Margin" Value="0" />
     <Setter Property="Padding" Value="4 1 4 0" />
+    <Setter Property="TabContextMenu" Value="{DynamicResource ToolTabStripItemContextMenu}" />
 
     <Setter Property="Template">
       <ControlTemplate>
@@ -107,7 +108,7 @@
                   TextElement.FontWeight="{TemplateBinding FontWeight}"
                   BorderBrush="{TemplateBinding BorderBrush}"
                   BorderThickness="{TemplateBinding BorderThickness}"
-                  ContextMenu="{DynamicResource ToolTabStripItemContextMenu}"
+                  ContextMenu="{TemplateBinding TabContextMenu}"
                   Padding="{TemplateBinding Padding}"
                   DockProperties.IsDragArea="True"
                   DockProperties.IsDropArea="True"

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -69,6 +69,21 @@ public class DocumentTabStripItem : TabStripItem
         set => SetValue(IsActiveProperty, value);
     }
 
+    /// <summary>
+    /// Define the <see cref="DocumentContextMenu"/> property.
+    /// </summary>
+    public static readonly StyledProperty<ContextMenu?> DocumentContextMenuProperty =
+        AvaloniaProperty.Register<DocumentTabStripItem, ContextMenu?>(nameof(DocumentContextMenu));
+
+    /// <summary>
+    /// Gets or sets the document context menu.
+    /// </summary>
+    public ContextMenu? DocumentContextMenu
+    {
+        get => GetValue(DocumentContextMenuProperty);
+        set => SetValue(DocumentContextMenuProperty, value);
+    }
+
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(DocumentTabStripItem);
 

--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -55,6 +55,12 @@ public class ToolChromeControl : ContentControl
         AvaloniaProperty.Register<ToolChromeControl, bool>(nameof(IsMaximized));
 
     /// <summary>
+    /// Define the <see cref="ToolFlyout"/> property.
+    /// </summary>
+    public static readonly StyledProperty<FlyoutBase?> ToolFlyoutProperty =
+        AvaloniaProperty.Register<ToolChromeControl, FlyoutBase?>(nameof(ToolFlyout));
+
+    /// <summary>
     /// Gets or sets is pinned
     /// </summary>
     public bool IsPinned
@@ -79,6 +85,15 @@ public class ToolChromeControl : ContentControl
     {
         get => GetValue(IsMaximizedProperty);
         set => SetValue(IsMaximizedProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the tool flyout.
+    /// </summary>
+    public FlyoutBase? ToolFlyout
+    {
+        get => GetValue(ToolFlyoutProperty);
+        set => SetValue(ToolFlyoutProperty, value);
     }
 
     /// <summary>

--- a/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolPinItemControl.axaml.cs
@@ -35,6 +35,20 @@ public class ToolPinItemControl : TemplatedControl
         set => SetValue(OrientationProperty, value);
     }
 
+    /// <summary>
+    /// Define the <see cref="PinContextMenu"/> property.
+    /// </summary>
+    public static readonly StyledProperty<ContextMenu?> PinContextMenuProperty =
+        AvaloniaProperty.Register<ToolPinItemControl, ContextMenu?>(nameof(PinContextMenu));
+
+    /// <summary>
+    /// Gets or sets the pin context menu.
+    /// </summary>
+    public ContextMenu? PinContextMenu
+    {
+        get => GetValue(PinContextMenuProperty);
+        set => SetValue(PinContextMenuProperty, value);
+    }
 
 
     private static DragAction ToDragAction(PointerEventArgs e)

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -56,6 +56,21 @@ public class ToolTabStripItem : TabStripItem
     /// <inheritdoc/>
     protected override Type StyleKeyOverride => typeof(ToolTabStripItem);
 
+    /// <summary>
+    /// Define the <see cref="TabContextMenu"/> property.
+    /// </summary>
+    public static readonly StyledProperty<ContextMenu?> TabContextMenuProperty =
+        AvaloniaProperty.Register<ToolTabStripItem, ContextMenu?>(nameof(TabContextMenu));
+
+    /// <summary>
+    /// Gets or sets the tab context menu.
+    /// </summary>
+    public ContextMenu? TabContextMenu
+    {
+        get => GetValue(TabContextMenuProperty);
+        set => SetValue(TabContextMenuProperty, value);
+    }
+
     /// <inheritdoc/>
     protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {


### PR DESCRIPTION
Fixes #841 