### PR TITLE
Fix unexpected content

### DIFF
--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -9,6 +9,8 @@ using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Core;
+using Avalonia.Controls.Templates;
+using Avalonia.Markup.Xaml.Templates;
 
 namespace DockCodeOnlySample;
 
@@ -28,6 +30,7 @@ internal class Program
 
 public class App : Application
 {
+
     public override void OnFrameworkInitializationCompleted()
     {
         Styles.Add(new FluentTheme());
@@ -50,7 +53,14 @@ public class App : Application
             documentDock.DocumentFactory = () =>
             {
                 var index = documentDock.VisibleDockables?.Count ?? 0;
-                return new Document { Id = $"Doc{index + 1}", Title = $"Document {index + 1}" };
+                return new Document {
+                    Id = $"Doc{index + 1}",
+                    Title = $"Document {index + 1}",
+                    Content = new TextBlock()
+                    {
+                        Text = "test"
+                    }
+                };
             };
 
             var document = new Document { Id = "Doc1", Title = "Document 1" };

--- a/src/Dock.Model.Avalonia/Controls/TemplateHelper.cs
+++ b/src/Dock.Model.Avalonia/Controls/TemplateHelper.cs
@@ -26,7 +26,7 @@ internal static class TemplateHelper
                 return control as Control;
             }
 
-            control = TemplateContent.Load(content)?.Result;
+            control = Load(content)?.Result;
             if (control is not null)
             {
                 controlRecycling.Add(content, control);
@@ -35,7 +35,7 @@ internal static class TemplateHelper
             return control as Control;
         }
 
-        return TemplateContent.Load(content)?.Result;
+        return Load(content)?.Result;
     }
 
     internal static TemplateResult<Control>? Load(object? templateContent)
@@ -45,9 +45,19 @@ internal static class TemplateHelper
             return null;
         }
 
-        if (templateContent is Func<IServiceProvider, object> direct)
+        if (templateContent is Func<IServiceProvider, object> directFunc)
         {
-            return (TemplateResult<Control>)direct(null!);
+            return (TemplateResult<Control>)directFunc(null!);
+        }
+
+        if (templateContent is FuncControlTemplate funcControlTemplate)
+        {
+            return funcControlTemplate.Build(null!);
+        }
+
+        if (templateContent is Control control)
+        {
+            return new TemplateResult<Control>(control, null!);
         }
 
         return TemplateContent.Load(templateContent);


### PR DESCRIPTION
The problem with adding content directly is TemplateContent.Load() didn't expect a direct control but a deferred function. Since the Helper is building it on the spot we can directly create a `TemplateResult` and also use `FuncControlTemplate` as well.