### PR TITLE
Fix the proportions applied when splitting

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
@@ -20,6 +20,7 @@
       <ControlTemplate>
         <DockableControl TrackingMode="Visible">
           <ItemsControl ItemsSource="{Binding VisibleDockables}" 
+                        Name="PART_ItemsControl"
                         Classes="ProportionalStackPanel">
             <ItemsControl.Styles>
               <Style Selector="ItemsControl.ProportionalStackPanel > ContentPresenter">

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
@@ -23,8 +23,6 @@
                         Classes="ProportionalStackPanel">
             <ItemsControl.Styles>
               <Style Selector="ItemsControl.ProportionalStackPanel > ContentPresenter">
-                <Setter Property="(ProportionalStackPanel.Proportion)"
-                        Value="{Binding Proportion}" />
                 <Setter Property="(ProportionalStackPanel.CollapsedProportion)"
                         Value="{Binding CollapsedProportion}" />
                 <Setter Property="(ProportionalStackPanel.IsCollapsed)">

--- a/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
+
+using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Dock.Controls.ProportionalStackPanel;
+using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
 
@@ -9,4 +14,33 @@ namespace Dock.Avalonia.Controls;
 /// </summary>
 public class ProportionalDockControl : TemplatedControl
 {
+    private ItemsControl? _itemsControl;
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        // Unsubscribe from the previous ItemsControl if it exists
+        if (_itemsControl != null)
+        {
+            _itemsControl.ContainerPrepared -= ItemsControlOnContainerPrepared;
+            _itemsControl = null;
+        }
+
+        base.OnApplyTemplate(e);
+
+        var itemsControl = e.NameScope.Find<ItemsControl>("PART_ItemsControl");
+
+        if (itemsControl != null)
+        {
+            _itemsControl = itemsControl;
+            _itemsControl.ContainerPrepared += ItemsControlOnContainerPrepared;
+        }
+    }
+
+    private void ItemsControlOnContainerPrepared(object sender, ContainerPreparedEventArgs e)
+    {
+        if (e.Container.DataContext is IDockable)
+        {
+            e.Container[!ProportionalStackPanel.ProportionProperty] = new Binding(nameof(IDockable.Proportion));
+        }
+    }
 }

--- a/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
@@ -18,6 +18,7 @@ public class ProportionalDockControl : TemplatedControl
 {
     private ItemsControl? _itemsControl;
 
+    /// <inheritdoc /> 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         // Unsubscribe from the previous ItemsControl if it exists
@@ -38,7 +39,7 @@ public class ProportionalDockControl : TemplatedControl
         }
     }
 
-    private void ItemsControlOnContainerPrepared(object sender, ContainerPreparedEventArgs e)
+    private void ItemsControlOnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
     {
         if (e.Container.DataContext is IDockable)
         {

--- a/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Dock.Controls.ProportionalStackPanel;
@@ -12,6 +13,7 @@ namespace Dock.Avalonia.Controls;
 /// <summary>
 /// Interaction logic for <see cref="ProportionalDockControl"/> xaml.
 /// </summary>
+[TemplatePart("PART_ItemsControl", typeof(ItemsControl), IsRequired = true)]
 public class ProportionalDockControl : TemplatedControl
 {
     private ItemsControl? _itemsControl;


### PR DESCRIPTION
A bug in avalonia means that binding the properties from a style either doesnt update more than once, or gets a styletrigger priority, causing the properties not to stay in sync with the model.

I have worked around this by setting up the binding in code in OnContainerPrepared.