### PR TITLE
Do drag offset calculation on all controls not just tabstripitems

### DIFF
--- a/src/Dock.Avalonia/Internal/DefaultDragOffsetCalculator.cs
+++ b/src/Dock.Avalonia/Internal/DefaultDragOffsetCalculator.cs
@@ -12,9 +12,9 @@ internal class DefaultDragOffsetCalculator : IDragOffsetCalculator
     {
         var screenPoint = dockControl.PointToScreen(pointerPosition);
 
-        if (dragControl is TabStripItem tabStripItem)
+        if (dragControl is not Control{ Name: "PART_Grip"})
         {
-            var corner = tabStripItem.PointToScreen(new Point());
+            var corner = dragControl.PointToScreen(new Point());
             return corner - screenPoint;
         }
 


### PR DESCRIPTION
It doesnt make sense to restrict this only to tabstripitems.

Iv made it skip doing this for Tool control Grips, however as these tool controls implement the drag offset themselves.