### PR TITLE
only set IsDraggingDock when a drag operation has actually started.

### DIFF
--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -328,7 +328,6 @@ internal class DockControlState : DockManagerState, IDockControlState
 
                     _context.Start(dragControl, point);
                     DropControl = null;
-                    activeDockControl.IsDraggingDock = true;
                 }
                 break;
             }
@@ -387,6 +386,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                             _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset);
                         }
                         _context.DoDragDrop = true;
+                        activeDockControl.IsDraggingDock = true;
                     }
                 }
 


### PR DESCRIPTION
Currently this property is set to true on pointer pressed, but the drag wont actually start unless the minimum drag distance has been reached.

This PR sets the property when we are actually entering a drag operation.