### PR TITLE
Fix: Dont crash if docktarget ApplyTemplate is called multiple times

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTargetBase.cs
+++ b/src/Dock.Avalonia/Controls/DockTargetBase.cs
@@ -102,7 +102,7 @@ public abstract class DockTargetBase : TemplatedControl, IDockTarget
 
         var operation = DockProperties.GetIndicatorDockOperation(indicator);
 
-        IndicatorOperations.Add(operation, indicator);
+        IndicatorOperations[operation] = indicator;
     }
 
     /// <summary>
@@ -120,7 +120,7 @@ public abstract class DockTargetBase : TemplatedControl, IDockTarget
 
         var operation = DockProperties.GetIndicatorDockOperation(selector);
 
-        SelectorsOperations.Add(operation, selector);
+        SelectorsOperations[operation] = selector;
     }
 
     /// <summary>


### PR DESCRIPTION
Templates can be applied more than once in cases like a dock was inside a popup or flyout.

make sure we dont throw duplicate key exceptions in this case.