### PR TITLE
Fix view locator match causing crashes for list data

### DIFF
--- a/docs/dock-custom-model.md
+++ b/docs/dock-custom-model.md
@@ -53,8 +53,18 @@ This package provides `INotifyPropertyChanged` implementations without the addit
 
        public bool Match(object? data)
        {
-           // Match your framework's base types
-           return data is YourFrameworkBaseType || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           var name = data.GetType().FullName!.Replace("ViewModel", "View");
+           return Type.GetType(name) is not null;
        }
    }
    ```

--- a/docs/dock-inpc.md
+++ b/docs/dock-inpc.md
@@ -74,7 +74,13 @@ Follow these instructions to create a minimal INPC-based application using Dock.
 
        public bool Match(object? data)
        {
-           return data is INotifyPropertyChanged || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```
@@ -108,7 +114,18 @@ Follow these instructions to create a minimal INPC-based application using Dock.
 
        public bool Match(object? data)
        {
-           return data is INotifyPropertyChanged || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           var name = data.GetType().FullName?.Replace("ViewModel", "View");
+           return Type.GetType(name) is not null;
        }
    }
    ```

--- a/docs/dock-mvvm.md
+++ b/docs/dock-mvvm.md
@@ -78,7 +78,13 @@ The following steps walk you through creating a very small application that uses
 
        public bool Match(object? data)
        {
-           return data is ObservableObject || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```
@@ -111,7 +117,18 @@ The following steps walk you through creating a very small application that uses
 
        public bool Match(object? data)
        {
-           return data is ViewModelBase || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           var name = data.GetType().FullName?.Replace("ViewModel", "View");
+           return Type.GetType(name) is not null;
        }
    }
    ```

--- a/docs/dock-reactive-property.md
+++ b/docs/dock-reactive-property.md
@@ -78,7 +78,13 @@ Follow these instructions to create a ReactiveProperty-based application using D
 
        public bool Match(object? data)
        {
-           return data is ReactiveBase || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```
@@ -112,7 +118,18 @@ Follow these instructions to create a ReactiveProperty-based application using D
 
        public bool Match(object? data)
        {
-           return data is ReactiveBase || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           var name = data.GetType().FullName?.Replace("ViewModel", "View");
+           return Type.GetType(name) is not null;
        }
    }
    ```

--- a/docs/dock-reactiveui-di.md
+++ b/docs/dock-reactiveui-di.md
@@ -99,10 +99,20 @@ Follow these instructions to create a ReactiveUI application with dependency inj
 
        public bool Match(object? data)
        {
-           return data is ReactiveObject || data is IDockable;
-       }
+           if (data is null)
+           {
+               return false;
+           }
 
-       IViewFor? IViewLocator.ResolveView<T>(T? viewModel, string? contract) where T : default => 
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           return Resolve(data) is not null;
+       }
+       
+       IViewFor? IViewLocator.ResolveView<T>(T? viewModel, string? contract) where T : default =>
            viewModel is null ? null : Resolve(viewModel);
    }
    ```

--- a/docs/dock-reactiveui-routing.md
+++ b/docs/dock-reactiveui-routing.md
@@ -68,7 +68,13 @@ Follow these instructions to create a ReactiveUI application with routing using 
 
        public bool Match(object? data)
        {
-           return data is ReactiveObject || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```

--- a/docs/dock-reactiveui.md
+++ b/docs/dock-reactiveui.md
@@ -80,7 +80,13 @@ Follow these instructions to create a minimal ReactiveUI based application using
 
        public bool Match(object? data)
        {
-           return data is ReactiveObject || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```
@@ -140,16 +146,26 @@ Follow these instructions to create a minimal ReactiveUI based application using
            if (Resolve(data) is IViewFor view && view is Control control)
                return control;
 
-           var viewName = data.GetType().FullName?.Replace("ViewModel", "View");
-           return new TextBlock { Text = $"Not Found: {viewName}" };
-       }
+       var viewName = data.GetType().FullName?.Replace("ViewModel", "View");
+       return new TextBlock { Text = $"Not Found: {viewName}" };
+   }
 
        public bool Match(object? data)
        {
-           return data is ReactiveObject || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           return Resolve(data) is not null;
        }
 
-       IViewFor? IViewLocator.ResolveView<T>(T? viewModel, string? contract) where T : default => 
+       IViewFor? IViewLocator.ResolveView<T>(T? viewModel, string? contract) where T : default =>
            viewModel is null ? null : Resolve(viewModel);
    }
    ```

--- a/docs/dock-views.md
+++ b/docs/dock-views.md
@@ -48,7 +48,13 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ObservableObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -81,7 +81,13 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
 
        public bool Match(object? data)
        {
-           return data is ObservableObject || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return data is IDockable || s_views.ContainsKey(type);
        }
    }
    ```
@@ -114,7 +120,18 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
 
        public bool Match(object? data)
        {
-           return data is ViewModelBase || data is IDockable;
+           if (data is null)
+           {
+               return false;
+           }
+
+           if (data is IDockable)
+           {
+               return true;
+           }
+
+           var name = data.GetType().FullName?.Replace("ViewModel", "View");
+           return Type.GetType(name) is not null;
        }
    }
    ```

--- a/samples/DockInpcSample/ViewLocator.cs
+++ b/samples/DockInpcSample/ViewLocator.cs
@@ -29,6 +29,12 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is INotifyPropertyChanged || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }

--- a/samples/DockMvvmSample/ViewLocator.cs
+++ b/samples/DockMvvmSample/ViewLocator.cs
@@ -29,6 +29,12 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ObservableObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }

--- a/samples/DockReactivePropertySample/ViewLocator.cs
+++ b/samples/DockReactivePropertySample/ViewLocator.cs
@@ -29,6 +29,12 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ObservableObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }

--- a/samples/DockReactiveUIDiSample/ViewLocator.cs
+++ b/samples/DockReactiveUIDiSample/ViewLocator.cs
@@ -55,7 +55,12 @@ public class ViewLocator : IDataTemplate, IViewLocator
 
     public bool Match(object? data)
     {
-        return data is ReactiveObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        return data is IDockable || Resolve(data) is not null;
     }
 
     IViewFor? IViewLocator.ResolveView<T>(T? viewModel, string? contract) where T : default => viewModel is null ? null : Resolve(viewModel);

--- a/samples/DockReactiveUIRoutingSample/ViewLocator.cs
+++ b/samples/DockReactiveUIRoutingSample/ViewLocator.cs
@@ -26,6 +26,17 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ReactiveObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        if (data is IDockable)
+        {
+            return true;
+        }
+
+        var viewLocator = Locator.Current.GetService<IViewLocator>();
+        return viewLocator?.ResolveView(data) is not null;
     }
 }

--- a/samples/DockReactiveUISample/ViewLocator.cs
+++ b/samples/DockReactiveUISample/ViewLocator.cs
@@ -30,6 +30,12 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ReactiveObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }

--- a/samples/Notepad/ViewLocator.cs
+++ b/samples/Notepad/ViewLocator.cs
@@ -29,6 +29,12 @@ public partial class ViewLocator : IDataTemplate
 
     public bool Match(object? data)
     {
-        return data is ObservableObject || data is IDockable;
+        if (data is null)
+        {
+            return false;
+        }
+
+        var type = data.GetType();
+        return data is IDockable || s_views.ContainsKey(type);
     }
 }


### PR DESCRIPTION
## Summary
- ensure sample view locators only match dockables or registered views
- document safer `Match` implementations to avoid unintended view resolution

## Testing
- `dotnet format --include samples/DockMvvmSample/ViewLocator.cs samples/Notepad/ViewLocator.cs samples/DockReactivePropertySample/ViewLocator.cs samples/DockReactiveUISample/ViewLocator.cs samples/DockInpcSample/ViewLocator.cs samples/DockReactiveUIDiSample/ViewLocator.cs samples/DockReactiveUIRoutingSample/ViewLocator.cs`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a83496308c8321b1230f7bc5b1f0ad