### PR TITLE
Call close window when a window is closed by the caption buttons

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -408,6 +408,7 @@ public class HostWindow : Window, IHostWindow
 
         if (Window is { })
         {
+            Window.Factory?.CloseWindow(Window);
             Window.Factory?.OnWindowClosed(Window);
 
             if (IsTracked)


### PR DESCRIPTION
Without this we wont call close the layout / dockables withing the windows layout.