### PR TITLE
Relax rule 2: When using DockGroups you should still be able to do global docking

### DIFF
--- a/src/Dock.Model/DockService.cs
+++ b/src/Dock.Model/DockService.cs
@@ -61,7 +61,7 @@ public class DockService : IDockService
         {
             // For global docking operations (no specific target dockable), use global validation
             // This allows non-grouped dockables to dock anywhere globally
-            if (!DockGroupValidator.ValidateDockingGroups(sourceDockable, targetDock))
+            if (!DockGroupValidator.ValidateGlobalDocking(sourceDockable, targetDock))
             {
                 return false;
             }

--- a/src/Dock.Model/DockService.cs
+++ b/src/Dock.Model/DockService.cs
@@ -61,7 +61,7 @@ public class DockService : IDockService
         {
             // For global docking operations (no specific target dockable), use global validation
             // This allows non-grouped dockables to dock anywhere globally
-            if (!DockGroupValidator.ValidateGlobalDocking(sourceDockable, targetDock))
+            if (!DockGroupValidator.ValidateDockingGroups(sourceDockable, targetDock))
             {
                 return false;
             }


### PR DESCRIPTION
Rule2 was too aggressive, it prevented users from using the Global docking feature entirely when using DockGroups.

This PR changes it so that it can be used as long as the groups match.

null groups can still dock anywhere.