### PR TITLE
TabStripItems double click obeys CanCloseLastDockable

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -139,8 +139,11 @@ public class DocumentTabStripItem : TabStripItem
     {
         if (DataContext is IDockable { Owner: IDock { Factory: { } factory } owner, CanFloat: true } dockable)
         {
-            if(owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+            if (owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+            {
                 factory.FloatDockable(dockable);
+                factory.ActivateWindow(dockable);
+            }
         }
     }
 

--- a/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStripItem.axaml.cs
@@ -137,9 +137,10 @@ public class DocumentTabStripItem : TabStripItem
 
     private void DoubleTappedHandler(object? sender, TappedEventArgs e)
     {
-        if (DataContext is IDockable { Owner: IDock { Factory: { } factory }, CanFloat: true } dockable)
+        if (DataContext is IDockable { Owner: IDock { Factory: { } factory } owner, CanFloat: true } dockable)
         {
-            factory.FloatDockable(dockable);
+            if(owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+                factory.FloatDockable(dockable);
         }
     }
 

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -113,9 +113,10 @@ public class ToolTabStripItem : TabStripItem
 
     private void DoubleTappedHandler(object? sender, TappedEventArgs e)
     {
-        if (DataContext is IDockable { Owner: IDock { Factory: { } factory }, CanFloat: true } dockable)
+        if (DataContext is IDockable { Owner: IDock { Factory: { } factory } owner, CanFloat: true } dockable)
         {
-            factory.FloatDockable(dockable);
+            if(owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+                factory.FloatDockable(dockable);
         }
     }
 }

--- a/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolTabStripItem.axaml.cs
@@ -115,8 +115,11 @@ public class ToolTabStripItem : TabStripItem
     {
         if (DataContext is IDockable { Owner: IDock { Factory: { } factory } owner, CanFloat: true } dockable)
         {
-            if(owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+            if (owner.CanCloseLastDockable || (owner.VisibleDockables?.Count ?? 0) > 1)
+            {
                 factory.FloatDockable(dockable);
+                factory.ActivateWindow(dockable);
+            }
         }
     }
 }


### PR DESCRIPTION
When we double click a tabstrip item we float.

however in docs where CanCloseLastDockable is false, this shouldnt happen.
