### PR TITLE
Restore windows that are minimized when activating

### DIFF
--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -557,6 +557,9 @@ public class HostWindow : Window, IHostWindow
 
     void IHostWindow.SetActive()
     {
-        this.Activate();
+        if(WindowState == WindowState.Minimized)
+            WindowState = WindowState.Normal;
+        
+        Activate();
     }
 }


### PR DESCRIPTION
 (macos already does this implicitly, but other platforms dont)