### PR TITLE
Only show Indicator for the DockOperation that will be used

### DIFF
--- a/src/Dock.Avalonia/Controls/DockTargetBase.cs
+++ b/src/Dock.Avalonia/Controls/DockTargetBase.cs
@@ -306,6 +306,14 @@ public abstract class DockTargetBase : TemplatedControl, IDockTarget
             }
         }
 
+        foreach (var kvp in IndicatorOperations)
+        {
+            if (kvp.Key != result)
+            {
+                kvp.Value.Opacity = 0;
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
Currently in the case of 2 Dock Selectors overlapping the indicators for both may be shown, yet only the DockOperation corresponding to one of these indicators will be used. This pull requests modifies DockTargetBase.cs so that only the indicator of the DockOperation that will be used is shown