### PR TITLE
Fix Toolwindow Grip in Linux

### DIFF
--- a/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ToolChromeControl.axaml.cs
@@ -267,7 +267,7 @@ public class ToolChromeControl : ContentControl
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    _windowDragHelper = CreateDragHelper(hostWindow);
+                    _windowDragHelper = CreateDragHelper(Grip);
                     _windowDragHelper.Attach();
                 }
             }


### PR DESCRIPTION
Fixes #1013 

This will not allow a toolwindow to be dragged anymore just by draggin its contents,  but fixes the Textbox focus issues