### PR TITLE
Add CacheDocumentTabContent option to Browser/Fluent/Simple themes and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A docking layout system.
 **Key Features:**
 - **ItemsSource Support**: Bind document collections directly to DocumentDock for automatic document management
 - **Flexible Content Templates**: Use DocumentTemplate for customizable document content rendering
+- **Optional Document Content Caching**: Keep document views alive across tab switches via theme option (`CacheDocumentTabContent`)
 - **Multiple MVVM Frameworks**: Support for ReactiveUI, Prism, ReactiveProperty, and standard MVVM patterns
 - **Comprehensive Serialization**: Save and restore layouts with multiple format options (JSON, XML, YAML, Protobuf)
 - **Rich Theming**: Fluent and Simple themes with full customization support

--- a/docfx/articles/dock-theme-browser.md
+++ b/docfx/articles/dock-theme-browser.md
@@ -21,7 +21,7 @@ Reference the browser theme project/package and use it in `App.axaml`:
   <Application.Styles>
     <FluentTheme />
     <DockFluentTheme />
-    <browserTheme:BrowserTabTheme />
+    <browserTheme:BrowserTabTheme CacheDocumentTabContent="True" />
   </Application.Styles>
 </Application>
 ```
@@ -37,6 +37,14 @@ Reference the browser theme project/package and use it in `App.axaml`:
 Compact density dictionary:
 
 - `avares://Dock.Avalonia.Themes.Browser/Styles/DensityStyles/Compact.axaml`
+
+## Document tab content caching
+
+`BrowserTabTheme` exposes `CacheDocumentTabContent` to keep document views alive while switching tabs:
+
+```xaml
+<browserTheme:BrowserTabTheme CacheDocumentTabContent="True" />
+```
 
 ## Theme resources
 

--- a/docfx/articles/dock-theme-fluent.md
+++ b/docfx/articles/dock-theme-fluent.md
@@ -54,6 +54,16 @@ Compact density resource dictionary:
 
 Compact mode reduces tab/button/icon metrics by overriding density tokens (for example `DockTabItemMinHeight`, `DockCloseButtonSize`, `DockChromeButtonWidth`).
 
+## Document tab content caching
+
+`DockFluentTheme` can keep document tab content alive instead of recreating it on each tab switch:
+
+```xaml
+<dockFluent:DockFluentTheme CacheDocumentTabContent="True" />
+```
+
+When enabled, document views remain instantiated while hidden tabs are inactive, which can improve tab-switch latency for heavy views.
+
 ## Fluent token customization
 
 Customize Dock Fluent visuals by overriding semantic tokens after `DockFluentTheme`.

--- a/docfx/articles/dock-theme-simple.md
+++ b/docfx/articles/dock-theme-simple.md
@@ -48,6 +48,16 @@ Compact density resource dictionary:
 
 - `avares://Dock.Avalonia.Themes.Simple/DensityStyles/Compact.axaml`
 
+## Document tab content caching
+
+`DockSimpleTheme` can keep document tab content alive instead of recreating it on each tab switch:
+
+```xaml
+<dockSimple:DockSimpleTheme CacheDocumentTabContent="True" />
+```
+
+This uses the shared document control templates and keeps hidden tab views instantiated.
+
 ## Simple token customization
 
 Override semantic tokens after `DockSimpleTheme`:

--- a/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentControl.axaml
@@ -21,6 +21,127 @@
     </Style>
   </ControlTheme>
 
+  <ControlTemplate x:Key="DockDocumentControlSingleContentTemplate" TargetType="DocumentControl">
+    <DockPanel x:Name="PART_DockPanel"
+               DockProperties.IsDropArea="True"
+               DockProperties.IsDockTarget="True"
+               DockProperties.ShowDockIndicatorOnly="{DynamicResource DockDocumentControlShowDockIndicatorOnly}"
+               DockProperties.IndicatorDockOperation="{DynamicResource DockDocumentControlIndicatorDockOperation}"
+               VerticalSpacing="{DynamicResource DockDocumentControlVerticalSpacing}"
+               Background="Transparent"
+               ZIndex="1">
+      <DocumentTabStrip x:Name="PART_TabStrip"
+                        ItemsSource="{Binding VisibleDockables}"
+                        SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
+                        CanCreateItem="{Binding CanCreateDocument}"
+                        IsActive="{TemplateBinding IsActive}"
+                        Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
+                        DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"
+                        DockProperties.IsDropArea="True"
+                        DockProperties.DockAdornerHost="{Binding #PART_DockPanel}">
+        <DocumentTabStrip.Styles>
+          <Style Selector="DocumentTabStripItem">
+            <Setter Property="IsActive" Value="{Binding $parent[DocumentTabStrip].IsActive}" />
+          </Style>
+        </DocumentTabStrip.Styles>
+      </DocumentTabStrip>
+      <Panel x:Name="PART_DocumentSeperatorHost" IsVisible="{DynamicResource DockDocumentTabStripSeparatorVisible}">
+        <Panel x:Name="PART_DocumentSeperator"
+               IsVisible="{Binding #PART_TabStrip.IsVisible}" />
+      </Panel>
+      <Border x:Name="PART_Border">
+        <Grid>
+          <DockableControl DataContext="{Binding ActiveDockable}"
+                           TrackingMode="Visible"
+                           IsVisible="{Binding $parent[DocumentControl].HasVisibleDockables}">
+            <ContentControl x:Name="PART_ContentPresenter"
+                            Content="{Binding}"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch">
+              <ContentControl.ContentTemplate>
+                <ControlRecyclingDataTemplate Parent="{Binding #PART_ContentPresenter}" />
+              </ContentControl.ContentTemplate>
+            </ContentControl>
+          </DockableControl>
+
+          <ContentControl x:Name="PART_EmptyContentHost"
+                          Content="{Binding EmptyContent}"
+                          ContentTemplate="{Binding $parent[DocumentControl].EmptyContentTemplate}"
+                          HorizontalContentAlignment="Center"
+                          VerticalContentAlignment="Center"
+                          IsVisible="{Binding !$parent[DocumentControl].HasVisibleDockables}" />
+        </Grid>
+      </Border>
+    </DockPanel>
+  </ControlTemplate>
+
+  <ControlTemplate x:Key="DockDocumentControlCachedContentTemplate" TargetType="DocumentControl">
+    <DockPanel x:Name="PART_DockPanel"
+               DockProperties.IsDropArea="True"
+               DockProperties.IsDockTarget="True"
+               DockProperties.ShowDockIndicatorOnly="{DynamicResource DockDocumentControlShowDockIndicatorOnly}"
+               DockProperties.IndicatorDockOperation="{DynamicResource DockDocumentControlIndicatorDockOperation}"
+               VerticalSpacing="{DynamicResource DockDocumentControlVerticalSpacing}"
+               Background="Transparent"
+               ZIndex="1">
+      <DocumentTabStrip x:Name="PART_TabStrip"
+                        ItemsSource="{Binding VisibleDockables}"
+                        SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
+                        CanCreateItem="{Binding CanCreateDocument}"
+                        IsActive="{TemplateBinding IsActive}"
+                        Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
+                        DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"
+                        DockProperties.IsDropArea="True"
+                        DockProperties.DockAdornerHost="{Binding #PART_DockPanel}">
+        <DocumentTabStrip.Styles>
+          <Style Selector="DocumentTabStripItem">
+            <Setter Property="IsActive" Value="{Binding $parent[DocumentTabStrip].IsActive}" />
+          </Style>
+        </DocumentTabStrip.Styles>
+      </DocumentTabStrip>
+      <Panel x:Name="PART_DocumentSeperatorHost" IsVisible="{DynamicResource DockDocumentTabStripSeparatorVisible}">
+        <Panel x:Name="PART_DocumentSeperator"
+               IsVisible="{Binding #PART_TabStrip.IsVisible}" />
+      </Panel>
+      <Border x:Name="PART_Border">
+        <Grid>
+          <ItemsControl x:Name="PART_CachedContentHost"
+                        ItemsSource="{Binding VisibleDockables}"
+                        IsVisible="{Binding $parent[DocumentControl].HasVisibleDockables}">
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <Grid />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+              <DataTemplate DataType="core:IDockable">
+                <DockableControl TrackingMode="Visible">
+                  <DockableControl.IsVisible>
+                    <MultiBinding Converter="{x:Static converters:ReferenceEqualsMultiConverter.Instance}">
+                      <Binding />
+                      <Binding Path="((core:IDock)Owner).ActiveDockable" />
+                    </MultiBinding>
+                  </DockableControl.IsVisible>
+                  <ContentControl x:Name="PART_CachedContentPresenter"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
+                                  Content="{Binding}" />
+                </DockableControl>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+
+          <ContentControl x:Name="PART_EmptyContentHost"
+                          Content="{Binding EmptyContent}"
+                          ContentTemplate="{Binding $parent[DocumentControl].EmptyContentTemplate}"
+                          HorizontalContentAlignment="Center"
+                          VerticalContentAlignment="Center"
+                          IsVisible="{Binding !$parent[DocumentControl].HasVisibleDockables}" />
+        </Grid>
+      </Border>
+    </DockPanel>
+  </ControlTemplate>
+
   <ControlTheme x:Key="{x:Type DocumentControl}" TargetType="DocumentControl">
 
     <Setter Property="(DockProperties.IsDragEnabled)">
@@ -108,61 +229,7 @@
       </DataTemplate>
     </Setter>
 
-    <Setter Property="Template">
-      <ControlTemplate>
-        <DockPanel x:Name="PART_DockPanel"
-                   DockProperties.IsDropArea="True"
-                   DockProperties.IsDockTarget="True"
-                   DockProperties.ShowDockIndicatorOnly="{DynamicResource DockDocumentControlShowDockIndicatorOnly}"
-                   DockProperties.IndicatorDockOperation="{DynamicResource DockDocumentControlIndicatorDockOperation}"
-                   VerticalSpacing="{DynamicResource DockDocumentControlVerticalSpacing}"
-                   Background="Transparent"
-                   ZIndex="1">
-          <DocumentTabStrip x:Name="PART_TabStrip"
-                            ItemsSource="{Binding VisibleDockables}"
-                            SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
-                            CanCreateItem="{Binding CanCreateDocument}"
-                            IsActive="{TemplateBinding IsActive}"
-                            Orientation="{Binding TabsLayout, Converter={x:Static DocumentTabOrientationConverter.Instance}}"
-                            DockPanel.Dock="{Binding TabsLayout, Converter={x:Static DocumentTabDockConverter.Instance}}"
-                            DockProperties.IsDropArea="True"
-                            DockProperties.DockAdornerHost="{Binding #PART_DockPanel}">
-            <DocumentTabStrip.Styles>
-              <Style Selector="DocumentTabStripItem">
-                <Setter Property="IsActive" Value="{Binding $parent[DocumentTabStrip].IsActive}" />
-              </Style>
-            </DocumentTabStrip.Styles>
-          </DocumentTabStrip>
-          <Panel x:Name="PART_DocumentSeperatorHost" IsVisible="{DynamicResource DockDocumentTabStripSeparatorVisible}">
-            <Panel x:Name="PART_DocumentSeperator"
-                   IsVisible="{Binding #PART_TabStrip.IsVisible}" />
-          </Panel>
-          <Border x:Name="PART_Border">
-            <Grid>
-              <DockableControl DataContext="{Binding ActiveDockable}"
-                               TrackingMode="Visible"
-                               IsVisible="{Binding $parent[DocumentControl].HasVisibleDockables}">
-                <ContentControl x:Name="PART_ContentPresenter"
-                                Content="{Binding}"
-                                HorizontalAlignment="Stretch"
-                                VerticalAlignment="Stretch">
-                  <ContentControl.ContentTemplate>
-                    <ControlRecyclingDataTemplate Parent="{Binding #PART_ContentPresenter}" />
-                  </ContentControl.ContentTemplate>
-                </ContentControl>
-              </DockableControl>
-
-              <ContentControl x:Name="PART_EmptyContentHost"
-                              Content="{Binding EmptyContent}"
-                              ContentTemplate="{Binding $parent[DocumentControl].EmptyContentTemplate}"
-                              HorizontalContentAlignment="Center"
-                              VerticalContentAlignment="Center"
-                              IsVisible="{Binding !$parent[DocumentControl].HasVisibleDockables}" />
-            </Grid>
-          </Border>
-        </DockPanel>
-      </ControlTemplate>
-    </Setter>
+    <Setter Property="Template" Value="{StaticResource DockDocumentControlSingleContentTemplate}" />
  
     <Style Selector="^[TabsLayout=Top]/template/ Panel#PART_DocumentSeperatorHost">
       <Setter Property="DockPanel.Dock" Value="Top" />

--- a/src/Dock.Avalonia.Themes.Fluent/DockFluentTheme.axaml.cs
+++ b/src/Dock.Avalonia.Themes.Fluent/DockFluentTheme.axaml.cs
@@ -5,8 +5,11 @@ using System;
 using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
+using Dock.Avalonia.Controls;
 using Dock.Avalonia.Themes;
 
 namespace Dock.Avalonia.Themes.Fluent;
@@ -18,6 +21,8 @@ public class DockFluentTheme : Styles, IResourceNode
 {
     private readonly ResourceDictionary _compactStyles;
     private DockDensityStyle _densityStyle;
+    private bool _cacheDocumentTabContent;
+    private Style? _cachedDocumentTemplateOverrideStyle;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockFluentTheme"/> class.
@@ -27,6 +32,7 @@ public class DockFluentTheme : Styles, IResourceNode
     {
         AvaloniaXamlLoader.Load(serviceProvider, this);
         _compactStyles = (ResourceDictionary)GetAndRemove("CompactStyles");
+        UpdateDocumentTemplateOverride();
 
         object GetAndRemove(string key)
         {
@@ -46,12 +52,30 @@ public class DockFluentTheme : Styles, IResourceNode
             (o, v) => o.DensityStyle = v);
 
     /// <summary>
+    /// Identifies the <see cref="CacheDocumentTabContent"/> direct property.
+    /// </summary>
+    public static readonly DirectProperty<DockFluentTheme, bool> CacheDocumentTabContentProperty =
+        AvaloniaProperty.RegisterDirect<DockFluentTheme, bool>(
+            nameof(CacheDocumentTabContent),
+            o => o.CacheDocumentTabContent,
+            (o, v) => o.CacheDocumentTabContent = v);
+
+    /// <summary>
     /// Gets or sets the density style used by this theme.
     /// </summary>
     public DockDensityStyle DensityStyle
     {
         get => _densityStyle;
         set => SetAndRaise(DensityStyleProperty, ref _densityStyle, value);
+    }
+
+    /// <summary>
+    /// Gets or sets whether document tabs should keep content views alive between tab switches.
+    /// </summary>
+    public bool CacheDocumentTabContent
+    {
+        get => _cacheDocumentTabContent;
+        set => SetAndRaise(CacheDocumentTabContentProperty, ref _cacheDocumentTabContent, value);
     }
 
     /// <summary>
@@ -66,6 +90,12 @@ public class DockFluentTheme : Styles, IResourceNode
         {
             Owner?.NotifyHostedResourcesChanged(new ResourcesChangedEventArgs());
         }
+
+        if (change.Property == CacheDocumentTabContentProperty)
+        {
+            UpdateDocumentTemplateOverride();
+            Owner?.NotifyHostedResourcesChanged(new ResourcesChangedEventArgs());
+        }
     }
 
     bool IResourceNode.TryGetResource(object key, ThemeVariant? theme, out object? value)
@@ -76,5 +106,36 @@ public class DockFluentTheme : Styles, IResourceNode
         }
 
         return base.TryGetResource(key, theme, out value);
+    }
+
+    private void UpdateDocumentTemplateOverride()
+    {
+        if (!_cacheDocumentTabContent)
+        {
+            if (_cachedDocumentTemplateOverrideStyle is not null)
+            {
+                Remove(_cachedDocumentTemplateOverrideStyle);
+                _cachedDocumentTemplateOverrideStyle = null;
+            }
+
+            return;
+        }
+
+        if (!base.TryGetResource("DockDocumentControlCachedContentTemplate", null, out var templateObject)
+            || templateObject is not IControlTemplate template)
+        {
+            return;
+        }
+
+        if (_cachedDocumentTemplateOverrideStyle is null)
+        {
+            _cachedDocumentTemplateOverrideStyle = new Style(x => x.OfType<DocumentControl>());
+            _cachedDocumentTemplateOverrideStyle.Setters.Add(new Setter(TemplatedControl.TemplateProperty, template));
+            Add(_cachedDocumentTemplateOverrideStyle);
+            return;
+        }
+
+        _cachedDocumentTemplateOverrideStyle.Setters.Clear();
+        _cachedDocumentTemplateOverrideStyle.Setters.Add(new Setter(TemplatedControl.TemplateProperty, template));
     }
 }

--- a/src/Dock.Avalonia/Converters/ReferenceEqualsMultiConverter.cs
+++ b/src/Dock.Avalonia/Converters/ReferenceEqualsMultiConverter.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Wiesław Šoltés. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace Dock.Avalonia.Converters;
+
+/// <summary>
+/// Returns true when all supplied values are the same object instance.
+/// </summary>
+public sealed class ReferenceEqualsMultiConverter : IMultiValueConverter
+{
+    /// <summary>
+    /// Singleton converter instance.
+    /// </summary>
+    public static ReferenceEqualsMultiConverter Instance { get; } = new();
+
+    /// <inheritdoc />
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count == 0)
+        {
+            return null;
+        }
+
+        if (values[0] is null)
+        {
+            return false;
+        }
+
+        var first = values[0];
+        for (var i = 1; i < values.Count; i++)
+        {
+            if (!ReferenceEquals(first, values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Dock.Controls.Recycling/RecylingDataTemplate.cs
+++ b/src/Dock.Controls.Recycling/RecylingDataTemplate.cs
@@ -13,6 +13,10 @@ namespace Avalonia.Controls.Recycling;
 /// </summary>
 public class ControlRecyclingDataTemplate : AvaloniaObject, IRecyclingDataTemplate
 {
+    public ControlRecyclingDataTemplate()
+    {
+        
+    }
     /// <summary>
     /// Defines the ControlRecycling attached property.
     /// </summary>


### PR DESCRIPTION
## Summary
This PR adds an opt-in `CacheDocumentTabContent` theme option to Dock themes so document tab content can stay alive across tab switches (instead of being recreated each time).

Supported themes:
- `BrowserTabTheme`
- `DockFluentTheme`
- `DockSimpleTheme`

## What changed
- Added `CacheDocumentTabContent` direct property to:
  - `/Volumes/SSD/repos/StackWich/Dock/src/Dock.Avalonia.Themes.Browser/Styles/BrowserTabTheme.axaml.cs`
  - `/Volumes/SSD/repos/StackWich/Dock/src/Dock.Avalonia.Themes.Fluent/DockFluentTheme.axaml.cs`
  - `/Volumes/SSD/repos/StackWich/Dock/src/Dock.Avalonia.Themes.Simple/DockSimpleTheme.axaml.cs`
- Split Fluent `DocumentControl` templates into:
  - `DockDocumentControlSingleContentTemplate` (default behavior, recycling template path)
  - `DockDocumentControlCachedContentTemplate` (cached content host for tabs, no `ControlRecyclingDataTemplate`)
  - File: `/Volumes/SSD/repos/StackWich/Dock/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentControl.axaml`
- Added `ReferenceEqualsMultiConverter` for active-tab visibility checks in cached mode:
  - `/Volumes/SSD/repos/StackWich/Dock/src/Dock.Avalonia/Converters/ReferenceEqualsMultiConverter.cs`
- Updated docs:
  - `/Volumes/SSD/repos/StackWich/Dock/README.md`
  - `/Volumes/SSD/repos/StackWich/Dock/docfx/articles/dock-theme-browser.md`
  - `/Volumes/SSD/repos/StackWich/Dock/docfx/articles/dock-theme-fluent.md`
  - `/Volumes/SSD/repos/StackWich/Dock/docfx/articles/dock-theme-simple.md`

## Why
Tab switching performance regressed when content was recreated on each activation. This adds an explicit startup-time option to keep document views alive and restore fast tab switching behavior.

## Usage
```xml
<browserTheme:BrowserTabTheme CacheDocumentTabContent="True" />
```

```xml
<dockFluent:DockFluentTheme CacheDocumentTabContent="True" />
```

```xml
<dockSimple:DockSimpleTheme CacheDocumentTabContent="True" />
```

## Notes
- `CacheDocumentTabContent` is intended as a configuration-time choice (not a runtime toggle).
- Cached mode avoids `ControlRecyclingDataTemplate` for document tab content to prevent recycling-related behavior when content is intentionally kept alive.

## Validation
- Built successfully with:
  - `dotnet build /Volumes/SSD/repos/StackWich/Startups/Sandwich.Desktop/Sandwich.Desktop.csproj`
