### PR TITLE
Restrict document window drag docking to chrome targets

### DIFF
--- a/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DocumentTabStrip.axaml.cs
@@ -16,6 +16,7 @@ using Avalonia.Reactive;
 using Avalonia.Styling;
 using Dock.Avalonia.Contract;
 using Dock.Avalonia.Automation.Peers;
+using Dock.Settings;
 
 namespace Dock.Avalonia.Controls;
 
@@ -631,7 +632,8 @@ public class DocumentTabStrip : TabStrip, IExternalDockSurface
                     DataContext is Dock.Model.Core.IDock { CanCloseLastDockable: false };
 
                 return baseAllow || overrideAllow;
-            });
+            },
+            getDockScope: _ => DockSettings.DocumentWindowDragScope);
     }
 
     private void AttachToWindow()

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -87,6 +87,8 @@ public class HostWindow : Window, IHostWindow
     /// <inheritdoc/>
     public IHostWindowState HostWindowState => _hostWindowState;
 
+    internal WindowDragDockScope WindowDragDockScope { get; set; } = WindowDragDockScope.FullWindow;
+
     /// <inheritdoc/>
     public bool IsTracked { get; set; }
 

--- a/src/Dock.Avalonia/Internal/DockHelpers.cs
+++ b/src/Dock.Avalonia/Internal/DockHelpers.cs
@@ -210,6 +210,11 @@ internal static class DockHelpers
             return localHit;
         }
 
+        return GetExternalControl(dockControl, point, property);
+    }
+
+    public static Control? GetExternalControl(DockControl dockControl, Point point, StyledProperty<bool> property)
+    {
         if (dockControl.GetVisualRoot() is not Visual visualRoot)
         {
             return null;

--- a/src/Dock.Avalonia/Internal/HostWindowState.cs
+++ b/src/Dock.Avalonia/Internal/HostWindowState.cs
@@ -396,7 +396,9 @@ internal class HostWindowState : DockManagerState, IHostWindowState
                     }
 
                     var dockControlPoint = dockControl.PointToClient(screenPoint);
-                    var dropControl = DockHelpers.GetControlIncludingExternal(dockControl, dockControlPoint, DockProperties.IsDropAreaProperty);
+                    var dropControl = _hostWindow.WindowDragDockScope == WindowDragDockScope.WindowChrome
+                        ? DockHelpers.GetExternalControl(dockControl, dockControlPoint, DockProperties.IsDropAreaProperty)
+                        : DockHelpers.GetControlIncludingExternal(dockControl, dockControlPoint, DockProperties.IsDropAreaProperty);
                     if (dropControl is { })
                     {
                         var isDropEnabled = dropControl.GetValue(DockProperties.IsDropEnabledProperty);

--- a/src/Dock.Avalonia/Internal/WindowDragHelper.cs
+++ b/src/Dock.Avalonia/Internal/WindowDragHelper.cs
@@ -20,23 +20,31 @@ internal class WindowDragHelper
     private readonly Control _owner;
     private readonly Func<bool> _isEnabled;
     private readonly Func<Control?, bool> _canStartDrag;
+    private readonly Func<Control?, WindowDragDockScope> _getDockScope;
     private readonly bool _handlePointerPressed;
     private bool _handledPointerPressed;
     private Point _dragStartPoint;
     private bool _pointerPressed;
     private bool _isDragging;
+    private WindowDragDockScope _dockScope = WindowDragDockScope.FullWindow;
     private PointerPressedEventArgs? _lastPointerPressedArgs;
     private Window? _dragWindow;
     private EventHandler<PixelPointEventArgs>? _positionChangedHandler;
     private IDisposable[]? _disposables;
     private IDisposable? _releasedEventDisposable;
 
-    public WindowDragHelper(Control owner, Func<bool> isEnabled, Func<Control?, bool> canStartDrag, bool handlePointerPressed = true)
+    public WindowDragHelper(
+        Control owner,
+        Func<bool> isEnabled,
+        Func<Control?, bool> canStartDrag,
+        bool handlePointerPressed = true,
+        Func<Control?, WindowDragDockScope>? getDockScope = null)
     {
         _owner = owner;
         _isEnabled = isEnabled;
         _canStartDrag = canStartDrag;
         _handlePointerPressed = handlePointerPressed;
+        _getDockScope = getDockScope ?? (_ => WindowDragDockScope.FullWindow);
     }
 
     public void Attach()
@@ -74,6 +82,7 @@ internal class WindowDragHelper
         _pointerPressed = false;
         _isDragging = false;
         _handledPointerPressed = false;
+        _dockScope = WindowDragDockScope.FullWindow;
         _lastPointerPressedArgs = null;
     }
 
@@ -97,6 +106,7 @@ internal class WindowDragHelper
         {
             _dragStartPoint = e.GetPosition(_owner);
             _pointerPressed = true;
+            _dockScope = _getDockScope(source);
             if (_handlePointerPressed)
             {
                 e.Handled = true;
@@ -135,6 +145,8 @@ internal class WindowDragHelper
 
             if (_dragWindow is HostWindow hostWindow)
             {
+                hostWindow.WindowDragDockScope = WindowDragDockScope.FullWindow;
+
                 if (hostWindow.HostWindowState is HostWindowState state)
                 {
                     var point = hostWindow.PointToScreen(e.GetPosition(hostWindow)) -
@@ -147,6 +159,7 @@ internal class WindowDragHelper
         }
 
         _dragWindow = null;
+        _dockScope = WindowDragDockScope.FullWindow;
 
         if (shouldHandleRelease)
         {
@@ -221,6 +234,7 @@ internal class WindowDragHelper
         }
 
         _dragWindow = hostWindow;
+        hostWindow.WindowDragDockScope = _dockScope;
 
         _positionChangedHandler = (_, _) =>
         {

--- a/src/Dock.Settings/DockSettings.cs
+++ b/src/Dock.Settings/DockSettings.cs
@@ -75,6 +75,12 @@ public static class DockSettings
     public static bool BringWindowsToFrontOnDrag = true;
 
     /// <summary>
+    /// Controls which background-window docking targets are considered when a floating document
+    /// window is dragged by its document tab strip.
+    /// </summary>
+    public static WindowDragDockScope DocumentWindowDragScope = WindowDragDockScope.WindowChrome;
+
+    /// <summary>
     /// Close all floating windows when the main (non-host) window closes.
     /// </summary>
     public static bool CloseFloatingWindowsOnMainWindowClose = false;
@@ -261,4 +267,20 @@ public enum DockCommandBarMergingScope
     /// Merge command bars from the active dockable (documents and tools).
     /// </summary>
     ActiveDockable
+}
+
+/// <summary>
+/// Controls which docking targets are considered during window move-drag operations.
+/// </summary>
+public enum WindowDragDockScope
+{
+    /// <summary>
+    /// Consider all window docking targets, including the main dock area.
+    /// </summary>
+    FullWindow,
+
+    /// <summary>
+    /// Consider only chrome-like targets such as external tab strips and titlebars.
+    /// </summary>
+    WindowChrome
 }


### PR DESCRIPTION
This changes floating document window drag behavior so drags started from DocumentTabStrip no longer dock back into background windows over the full dock surface by default. Instead, they only target window chrome surfaces such as tab strips/titlebars, which restores the expected titlebar-to-titlebar docking behavior.

The drag target scope is now configurable through DockSettings.DocumentWindowDragScope, using the new WindowDragDockScope enum. The default is WindowChrome, while FullWindow preserves the broader docking behavior if needed. The host-window drag pipeline was updated to honor that scope, and existing HostWindowState headless tests still pass.