### PR TITLE
Move document tab strip visibility into a style

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/DocumentControl.axaml
@@ -19,7 +19,6 @@
                Background="Transparent"
                ZIndex="1">
       <DocumentTabStrip x:Name="PART_TabStrip"
-                        IsVisible="{DynamicResource DockDocumentControlTabStripVisible}"
                         ItemsSource="{Binding VisibleDockables}"
                         SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
                         CanCreateItem="{Binding CanCreateDocument}"
@@ -79,7 +78,6 @@
                Background="Transparent"
                ZIndex="1">
       <DocumentTabStrip x:Name="PART_TabStrip"
-                        IsVisible="{DynamicResource DockDocumentControlTabStripVisible}"
                         ItemsSource="{Binding VisibleDockables}"
                         SelectedItem="{Binding ActiveDockable, Mode=TwoWay}"
                         CanCreateItem="{Binding CanCreateDocument}"
@@ -210,6 +208,10 @@
       <Setter Property="DockPanel.Dock" Value="Right" />
       <Setter Property="Width" Value="{DynamicResource DockDocumentTabStripSeparatorSize}" />
       <Setter Property="Height" Value="NaN" />
+    </Style>
+
+    <Style Selector="^/template/ DocumentTabStrip#PART_TabStrip">
+      <Setter Property="IsVisible" Value="{DynamicResource DockDocumentControlTabStripVisible}" />
     </Style>
 
     <Style Selector="^/template/ Panel#PART_DocumentSeperator">


### PR DESCRIPTION
This changes DocumentControl so the PART_TabStrip visibility is no longer set inline in the control template. Instead, it is applied through a template-part style in the Fluent theme.

That makes the tab strip visibility easier to override from downstream themes or app styles without replacing the full DocumentControl template. No behavior change is intended; this is just a theming/customization improvement.

