### PR TITLE
Fixes/browser seperators rendering

### DIFF
--- a/src/Dock.Avalonia/Controls/DelayedUniformTabPanel.cs
+++ b/src/Dock.Avalonia/Controls/DelayedUniformTabPanel.cs
@@ -206,6 +206,9 @@ public class DelayedUniformTabPanel : Panel
             : ResolveTabWidth(visibleCount, finalSize);
         _resolvedInMeasurePass = false;
         var spacing = Math.Max(0d, ItemSpacing);
+        var arrangedExtentWidth = Math.Min(
+            finalSize.Width,
+            RoundToDevicePixels((tabWidth * visibleCount) + (spacing * Math.Max(0, visibleCount - 1))));
         var x = 0d;
         var arrangedIndex = 0;
 
@@ -219,7 +222,7 @@ public class DelayedUniformTabPanel : Panel
 
             var startX = RoundToDevicePixels(x);
             var endX = arrangedIndex == visibleCount - 1
-                ? finalSize.Width
+                ? arrangedExtentWidth
                 : RoundToDevicePixels(x + tabWidth);
             var arrangedWidth = Math.Max(0d, endX - startX);
 

--- a/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
@@ -185,7 +185,7 @@ public class DelayedUniformTabPanelTests
     private static void Layout(DelayedUniformTabPanel panel, double width, double height)
     {
         panel.Measure(new Size(width, height));
-        panel.Arrange(new Rect(0, 0, panel.DesiredSize.Width, height));
+        panel.Arrange(new Rect(0, 0, width, height));
     }
 
     private static void AssertTabWidth(DelayedUniformTabPanel panel, double expectedWidth)


### PR DESCRIPTION
Due to not snapping to pixels the browser tab separators would shimmer and toggle visibility as the layout changes.