### PR TITLE
Fix DockCodeOnlySample drag/drop and floating windows

### DIFF
--- a/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
+++ b/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
+using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Controls;
@@ -97,6 +98,10 @@ internal sealed class DockCodeOnlyFactory : Factory
 
     public override void InitLayout(IDockable layout)
     {
+        DefaultHostWindowLocator ??= CreateHostWindow;
+        HostWindowLocator ??= new Dictionary<string, Func<IHostWindow?>>();
+        HostWindowLocator.TryAdd(nameof(IDockWindow), CreateHostWindow);
+
         base.InitLayout(layout);
 
         foreach (IDockable dockable in EnumerateDockables(layout))
@@ -140,6 +145,11 @@ internal sealed class DockCodeOnlyFactory : Factory
         documentDock.EnableWindowDrag = true;
         documentDock.AllowedDropOperations = DockOperationMask.Fill;
         documentDock.DocumentFactory = CreateGeneratedDocument;
+    }
+
+    private static IHostWindow? CreateHostWindow()
+    {
+        return new HostWindow();
     }
 
     private IDockable CreateGeneratedDocument()

--- a/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
+++ b/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
@@ -107,9 +107,10 @@ internal sealed class DockCodeOnlyFactory : Factory
                     ConfigureDocumentDock(documentDock);
                     break;
                 case Document document when document.Content is null:
-                    document.Content = CreateDocumentContent(
-                        document.Title,
+                    EnsureDocumentText(
+                        document,
                         $"Restored content for {document.Title}. The factory rehydrates missing content so floating windows and workspace restores stay usable.");
+                    document.Content = CreateDocumentContent(document);
                     break;
                 case Tool tool when tool.Content is null:
                     tool.Content = CreateToolContent(
@@ -153,12 +154,15 @@ internal sealed class DockCodeOnlyFactory : Factory
 
     private static Document CreateDocumentDockable(int index, string title, string body)
     {
-        return new Document
+        Document document = new()
         {
             Id = $"Doc{index}",
-            Title = title,
-            Content = CreateDocumentContent(title, body)
+            Title = title
         };
+
+        EnsureDocumentText(document, body);
+        document.Content = CreateDocumentContent(document);
+        return document;
     }
 
     private static Tool CreateToolDockable(string id, string title, string description)
@@ -171,10 +175,12 @@ internal sealed class DockCodeOnlyFactory : Factory
         };
     }
 
-    private static object CreateDocumentContent(string title, string body)
+    private static object CreateDocumentContent(Document document)
     {
         return new Func<IServiceProvider, object>(_ =>
         {
+            string title = document.Title;
+
             TextBlock header = new()
             {
                 Text = title,
@@ -190,12 +196,14 @@ internal sealed class DockCodeOnlyFactory : Factory
 
             TextBox editor = new()
             {
-                Text = body,
+                Text = GetDocumentText(document),
                 AcceptsReturn = true,
                 HorizontalAlignment = HorizontalAlignment.Stretch,
                 VerticalAlignment = VerticalAlignment.Stretch,
                 MinHeight = 240
             };
+
+            editor.TextChanged += (_, _) => document.Context = editor.Text ?? string.Empty;
 
             return new Border
             {
@@ -212,6 +220,19 @@ internal sealed class DockCodeOnlyFactory : Factory
                 }
             };
         });
+    }
+
+    private static void EnsureDocumentText(Document document, string fallbackText)
+    {
+        if (document.Context is not string)
+        {
+            document.Context = fallbackText;
+        }
+    }
+
+    private static string GetDocumentText(Document document)
+    {
+        return document.Context as string ?? string.Empty;
     }
 
     private static object CreateToolContent(string title, string description)

--- a/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
+++ b/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
@@ -135,7 +135,7 @@ internal sealed class DockCodeOnlyFactory : Factory
 
     private void ConfigureDocumentDock(DocumentDock documentDock)
     {
-        documentDock.IsCollapsable = false;
+        documentDock.IsCollapsable = true;
         documentDock.CanCreateDocument = true;
         documentDock.EnableWindowDrag = true;
         documentDock.AllowedDropOperations = DockOperationMask.Fill;

--- a/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
+++ b/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
@@ -1,0 +1,387 @@
+using System;
+using System.Collections.Generic;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+
+namespace DockCodeOnlySample;
+
+internal sealed class DockCodeOnlyFactory : Factory
+{
+    private const string DocumentsDockId = "Documents";
+    private int _nextDocumentIndex = 2;
+
+    public override IDocumentDock CreateDocumentDock()
+    {
+        DocumentDock documentDock = new();
+        ConfigureDocumentDock(documentDock);
+        return documentDock;
+    }
+
+    public override IRootDock CreateLayout()
+    {
+        _nextDocumentIndex = 2;
+
+        DocumentDock documentDock = (DocumentDock)CreateDocumentDock();
+        documentDock.Id = DocumentsDockId;
+        documentDock.Title = "Documents";
+
+        Document firstDocument = CreateDocumentDockable(
+            1,
+            "Document 1",
+            "This sample keeps document content rebuildable so drag/drop and workspace restore do not depend on moving live controls between hosts.");
+        documentDock.VisibleDockables = CreateList<IDockable>(firstDocument);
+        documentDock.ActiveDockable = firstDocument;
+
+        Tool leftTool = CreateToolDockable(
+            "Tool1",
+            "Tool 1",
+            "Project explorer style content. This tool can dock left, fill the center, or float into a separate window.");
+        leftTool.AllowedDockOperations = DockOperationMask.Left | DockOperationMask.Fill | DockOperationMask.Window;
+
+        Tool bottomTool = CreateToolDockable(
+            "Tool2",
+            "Output",
+            "Build output style content. This tool can dock at the bottom, fill the center, or float into a separate window.");
+        bottomTool.AllowedDockOperations = DockOperationMask.Bottom | DockOperationMask.Fill | DockOperationMask.Window;
+
+        ToolDock leftPane = new()
+        {
+            Id = "LeftPane",
+            Title = "Left Pane",
+            Alignment = Alignment.Left,
+            Proportion = 0.25,
+            VisibleDockables = CreateList<IDockable>(leftTool),
+            ActiveDockable = leftTool
+        };
+
+        ToolDock bottomPane = new()
+        {
+            Id = "BottomPane",
+            Title = "Bottom Pane",
+            Alignment = Alignment.Bottom,
+            Proportion = 0.25,
+            VisibleDockables = CreateList<IDockable>(bottomTool),
+            ActiveDockable = bottomTool
+        };
+
+        ProportionalDock mainLayout = new()
+        {
+            Id = "MainLayout",
+            Title = "Main Layout",
+            Orientation = Dock.Model.Core.Orientation.Horizontal,
+            VisibleDockables = CreateList<IDockable>(
+                leftPane,
+                new ProportionalDockSplitter(),
+                documentDock,
+                new ProportionalDockSplitter(),
+                bottomPane),
+            ActiveDockable = documentDock
+        };
+
+        RootDock rootDock = (RootDock)CreateRootDock();
+        rootDock.Id = "Root";
+        rootDock.Title = "Root";
+        rootDock.IsCollapsable = false;
+        rootDock.VisibleDockables = CreateList<IDockable>(mainLayout);
+        rootDock.DefaultDockable = mainLayout;
+        rootDock.ActiveDockable = mainLayout;
+
+        return rootDock;
+    }
+
+    public override void InitLayout(IDockable layout)
+    {
+        base.InitLayout(layout);
+
+        foreach (IDockable dockable in EnumerateDockables(layout))
+        {
+            switch (dockable)
+            {
+                case DocumentDock documentDock:
+                    ConfigureDocumentDock(documentDock);
+                    break;
+                case Document document when document.Content is null:
+                    document.Content = CreateDocumentContent(
+                        document.Title,
+                        $"Restored content for {document.Title}. The factory rehydrates missing content so floating windows and workspace restores stay usable.");
+                    break;
+                case Tool tool when tool.Content is null:
+                    tool.Content = CreateToolContent(
+                        tool.Title,
+                        $"Restored content for {tool.Title}. Tools use content factories so they can be rebuilt in a new host after docking operations.");
+                    break;
+            }
+        }
+
+        UpdateNextDocumentIndex(layout);
+    }
+
+    public override IDockWindow? CreateWindowFrom(IDockable dockable)
+    {
+        IDockWindow? window = base.CreateWindowFrom(dockable);
+        if (window is not null)
+        {
+            window.Title = "Dock Code-Only Sample";
+        }
+
+        return window;
+    }
+
+    private void ConfigureDocumentDock(DocumentDock documentDock)
+    {
+        documentDock.IsCollapsable = false;
+        documentDock.CanCreateDocument = true;
+        documentDock.EnableWindowDrag = true;
+        documentDock.AllowedDropOperations = DockOperationMask.Fill;
+        documentDock.DocumentFactory = CreateGeneratedDocument;
+    }
+
+    private IDockable CreateGeneratedDocument()
+    {
+        int index = _nextDocumentIndex++;
+        return CreateDocumentDockable(
+            index,
+            $"Document {index}",
+            $"Document {index} uses a content factory instead of a pre-built control instance.");
+    }
+
+    private static Document CreateDocumentDockable(int index, string title, string body)
+    {
+        return new Document
+        {
+            Id = $"Doc{index}",
+            Title = title,
+            Content = CreateDocumentContent(title, body)
+        };
+    }
+
+    private static Tool CreateToolDockable(string id, string title, string description)
+    {
+        return new Tool
+        {
+            Id = id,
+            Title = title,
+            Content = CreateToolContent(title, description)
+        };
+    }
+
+    private static object CreateDocumentContent(string title, string body)
+    {
+        return new Func<IServiceProvider, object>(_ =>
+        {
+            TextBlock header = new()
+            {
+                Text = title,
+                FontWeight = FontWeight.SemiBold
+            };
+
+            TextBlock description = new()
+            {
+                Text = "Code-only sample documents are rendered from a factory-created template so the view can be rebuilt after docking operations.",
+                TextWrapping = TextWrapping.Wrap,
+                Opacity = 0.8
+            };
+
+            TextBox editor = new()
+            {
+                Text = body,
+                AcceptsReturn = true,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment = VerticalAlignment.Stretch,
+                MinHeight = 240
+            };
+
+            return new Border
+            {
+                Padding = new Thickness(12),
+                Child = new StackPanel
+                {
+                    Spacing = 8,
+                    Children =
+                    {
+                        header,
+                        description,
+                        editor
+                    }
+                }
+            };
+        });
+    }
+
+    private static object CreateToolContent(string title, string description)
+    {
+        return new Func<IServiceProvider, object>(_ =>
+        {
+            TextBlock header = new()
+            {
+                Text = title,
+                FontWeight = FontWeight.SemiBold
+            };
+
+            TextBlock details = new()
+            {
+                Text = description,
+                TextWrapping = TextWrapping.Wrap,
+                Opacity = 0.8
+            };
+
+            TextBlock footer = new()
+            {
+                Text = "Dock the tool around the layout or float it into a separate window.",
+                TextWrapping = TextWrapping.Wrap
+            };
+
+            return new Border
+            {
+                Padding = new Thickness(12),
+                Child = new StackPanel
+                {
+                    Spacing = 8,
+                    Children =
+                    {
+                        header,
+                        details,
+                        footer
+                    }
+                }
+            };
+        });
+    }
+
+    private void UpdateNextDocumentIndex(IDockable layout)
+    {
+        int maxDocumentIndex = 0;
+
+        foreach (IDockable dockable in EnumerateDockables(layout))
+        {
+            if (dockable is not Document { Id: { } id })
+            {
+                continue;
+            }
+
+            if (!id.StartsWith("Doc", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (int.TryParse(id.AsSpan(3), out int parsedIndex) && parsedIndex > maxDocumentIndex)
+            {
+                maxDocumentIndex = parsedIndex;
+            }
+        }
+
+        _nextDocumentIndex = Math.Max(_nextDocumentIndex, maxDocumentIndex + 1);
+    }
+
+    private static IEnumerable<IDockable> EnumerateDockables(IDockable root)
+    {
+        HashSet<IDockable> seen = new();
+        return EnumerateDockables(root, seen);
+    }
+
+    private static IEnumerable<IDockable> EnumerateDockables(IDockable dockable, HashSet<IDockable> seen)
+    {
+        if (!seen.Add(dockable))
+        {
+            yield break;
+        }
+
+        yield return dockable;
+
+        if (dockable is IRootDock rootDock)
+        {
+            foreach (IDockable pinned in EnumerateCollection(rootDock.LeftPinnedDockables, seen))
+            {
+                yield return pinned;
+            }
+
+            foreach (IDockable pinned in EnumerateCollection(rootDock.RightPinnedDockables, seen))
+            {
+                yield return pinned;
+            }
+
+            foreach (IDockable pinned in EnumerateCollection(rootDock.TopPinnedDockables, seen))
+            {
+                yield return pinned;
+            }
+
+            foreach (IDockable pinned in EnumerateCollection(rootDock.BottomPinnedDockables, seen))
+            {
+                yield return pinned;
+            }
+
+            foreach (IDockable hidden in EnumerateCollection(rootDock.HiddenDockables, seen))
+            {
+                yield return hidden;
+            }
+
+            if (rootDock.Windows is not null)
+            {
+                foreach (IDockWindow window in rootDock.Windows)
+                {
+                    if (window.Layout is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (IDockable windowDockable in EnumerateDockables(window.Layout, seen))
+                    {
+                        yield return windowDockable;
+                    }
+                }
+            }
+        }
+
+        if (dockable is IDock dock && dock.VisibleDockables is not null)
+        {
+            foreach (IDockable child in dock.VisibleDockables)
+            {
+                foreach (IDockable descendant in EnumerateDockables(child, seen))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+
+        if (dockable is ISplitViewDock splitViewDock)
+        {
+            if (splitViewDock.PaneDockable is { } paneDockable)
+            {
+                foreach (IDockable descendant in EnumerateDockables(paneDockable, seen))
+                {
+                    yield return descendant;
+                }
+            }
+
+            if (splitViewDock.ContentDockable is { } contentDockable)
+            {
+                foreach (IDockable descendant in EnumerateDockables(contentDockable, seen))
+                {
+                    yield return descendant;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<IDockable> EnumerateCollection(IList<IDockable>? dockables, HashSet<IDockable> seen)
+    {
+        if (dockables is null)
+        {
+            yield break;
+        }
+
+        foreach (IDockable dockable in dockables)
+        {
+            foreach (IDockable descendant in EnumerateDockables(dockable, seen))
+            {
+                yield return descendant;
+            }
+        }
+    }
+}

--- a/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
+++ b/samples/DockCodeOnlySample/DockCodeOnlyFactory.cs
@@ -4,7 +4,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Controls;
@@ -98,10 +97,6 @@ internal sealed class DockCodeOnlyFactory : Factory
 
     public override void InitLayout(IDockable layout)
     {
-        DefaultHostWindowLocator ??= CreateHostWindow;
-        HostWindowLocator ??= new Dictionary<string, Func<IHostWindow?>>();
-        HostWindowLocator.TryAdd(nameof(IDockWindow), CreateHostWindow);
-
         base.InitLayout(layout);
 
         foreach (IDockable dockable in EnumerateDockables(layout))
@@ -145,11 +140,6 @@ internal sealed class DockCodeOnlyFactory : Factory
         documentDock.EnableWindowDrag = true;
         documentDock.AllowedDropOperations = DockOperationMask.Fill;
         documentDock.DocumentFactory = CreateGeneratedDocument;
-    }
-
-    private static IHostWindow? CreateHostWindow()
-    {
-        return new HostWindow();
     }
 
     private IDockable CreateGeneratedDocument()

--- a/samples/DockCodeOnlySample/DockCodeOnlySample.csproj
+++ b/samples/DockCodeOnlySample/DockCodeOnlySample.csproj
@@ -12,6 +12,7 @@
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\Avalonia.ReactiveUI.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />

--- a/samples/DockCodeOnlySample/MainWindow.cs
+++ b/samples/DockCodeOnlySample/MainWindow.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Reactive.Disposables;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Dock.Avalonia.Controls;
+using ReactiveUI;
+using ReactiveUI.Avalonia;
+
+namespace DockCodeOnlySample;
+
+public sealed class MainWindow : ReactiveWindow<MainWindowViewModel>
+{
+    private readonly DockControl _dockControl;
+    private readonly CheckBox _dockingEnabledCheckBox;
+    private readonly TextBlock _workspaceStatusTextBlock;
+    private readonly Button _saveWorkspaceAButton;
+    private readonly Button _loadWorkspaceAButton;
+    private readonly Button _saveWorkspaceBButton;
+    private readonly Button _loadWorkspaceBButton;
+
+    public MainWindow()
+    {
+        Title = "Dock Code-Only Sample";
+        Width = 1000;
+        Height = 720;
+        MinWidth = 900;
+        MinHeight = 600;
+
+        _saveWorkspaceAButton = CreateToolbarButton("Save Workspace A");
+        _loadWorkspaceAButton = CreateToolbarButton("Load Workspace A");
+        _saveWorkspaceBButton = CreateToolbarButton("Save Workspace B");
+        _loadWorkspaceBButton = CreateToolbarButton("Load Workspace B");
+
+        _dockingEnabledCheckBox = new CheckBox
+        {
+            Content = "Docking Enabled",
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        _workspaceStatusTextBlock = new TextBlock
+        {
+            Margin = new Thickness(16, 0, 0, 0),
+            VerticalAlignment = VerticalAlignment.Center
+        };
+
+        StackPanel toolbarPanel = new()
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 8,
+            Children =
+            {
+                _saveWorkspaceAButton,
+                _loadWorkspaceAButton,
+                _saveWorkspaceBButton,
+                _loadWorkspaceBButton,
+                _dockingEnabledCheckBox,
+                _workspaceStatusTextBlock
+            }
+        };
+
+        Border toolbar = new()
+        {
+            Padding = new Thickness(8),
+            Child = toolbarPanel
+        };
+
+        _dockControl = new DockControl
+        {
+            InitializeFactory = true,
+            InitializeLayout = false
+        };
+
+        DockPanel root = new();
+        DockPanel.SetDock(toolbar, Avalonia.Controls.Dock.Top);
+        root.Children.Add(toolbar);
+        root.Children.Add(_dockControl);
+        Content = root;
+
+        this.WhenActivated(disposables =>
+        {
+            disposables.Add(this.BindCommand(ViewModel, vm => vm.SaveWorkspaceA, v => v._saveWorkspaceAButton));
+            disposables.Add(this.BindCommand(ViewModel, vm => vm.LoadWorkspaceA, v => v._loadWorkspaceAButton));
+            disposables.Add(this.BindCommand(ViewModel, vm => vm.SaveWorkspaceB, v => v._saveWorkspaceBButton));
+            disposables.Add(this.BindCommand(ViewModel, vm => vm.LoadWorkspaceB, v => v._loadWorkspaceBButton));
+
+            disposables.Add(this.Bind(ViewModel, vm => vm.IsDockingEnabled, v => v._dockingEnabledCheckBox.IsChecked));
+            disposables.Add(this.Bind(ViewModel, vm => vm.IsDockingEnabled, v => v._dockControl.IsDockingEnabled));
+
+            disposables.Add(this.OneWayBind(ViewModel, vm => vm.Factory, v => v._dockControl.Factory));
+            disposables.Add(this.OneWayBind(ViewModel, vm => vm.Layout, v => v._dockControl.Layout));
+            disposables.Add(this.OneWayBind(ViewModel, vm => vm.WorkspaceStatus, v => v._workspaceStatusTextBlock.Text));
+        });
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        ViewModel?.CloseLayout();
+        base.OnClosed(e);
+    }
+
+    private static Button CreateToolbarButton(string text)
+    {
+        return new Button
+        {
+            Content = text,
+            MinWidth = 132
+        };
+    }
+}

--- a/samples/DockCodeOnlySample/MainWindowViewModel.cs
+++ b/samples/DockCodeOnlySample/MainWindowViewModel.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reactive;
+using Dock.Model;
+using Dock.Model.Controls;
+using Dock.Model.Core;
+using Dock.Serializer;
+using ReactiveUI;
+
+namespace DockCodeOnlySample;
+
+[RequiresUnreferencedCode("Requires unreferenced code for RaiseAndSetIfChanged.")]
+[RequiresDynamicCode("Requires dynamic code for RaiseAndSetIfChanged.")]
+public sealed class MainWindowViewModel : ReactiveObject
+{
+    private readonly DockCodeOnlyFactory _factory;
+    private readonly DockWorkspaceManager _workspaceManager;
+    private IRootDock? _layout;
+    private bool _isDockingEnabled = true;
+    private string _workspaceStatus = "Workspace: Unsaved";
+    private bool _hasWorkspaceA;
+    private bool _hasWorkspaceB;
+    private DockWorkspace? _workspaceA;
+    private DockWorkspace? _workspaceB;
+
+    public MainWindowViewModel()
+    {
+        _factory = new DockCodeOnlyFactory();
+        Factory = _factory;
+        _workspaceManager = new DockWorkspaceManager(new DockSerializer());
+        _workspaceManager.TrackFactory(_factory);
+        _workspaceManager.WorkspaceDirtyChanged += (_, _) => UpdateWorkspaceStatus();
+
+        Layout = _factory.CreateLayout();
+        _factory.InitLayout(Layout);
+
+        var canLoadWorkspaceA = this.WhenAnyValue(x => x.HasWorkspaceA);
+        var canLoadWorkspaceB = this.WhenAnyValue(x => x.HasWorkspaceB);
+
+        SaveWorkspaceA = ReactiveCommand.Create(() =>
+        {
+            _workspaceA = CaptureWorkspace("A");
+        });
+        LoadWorkspaceA = ReactiveCommand.Create(() => RestoreWorkspace(_workspaceA), canLoadWorkspaceA);
+        SaveWorkspaceB = ReactiveCommand.Create(() =>
+        {
+            _workspaceB = CaptureWorkspace("B");
+        });
+        LoadWorkspaceB = ReactiveCommand.Create(() => RestoreWorkspace(_workspaceB), canLoadWorkspaceB);
+
+        UpdateWorkspaceSlotState();
+        UpdateWorkspaceStatus();
+    }
+
+    public IFactory Factory { get; }
+
+    public IRootDock? Layout
+    {
+        get => _layout;
+        private set => this.RaiseAndSetIfChanged(ref _layout, value);
+    }
+
+    public bool IsDockingEnabled
+    {
+        get => _isDockingEnabled;
+        set => this.RaiseAndSetIfChanged(ref _isDockingEnabled, value);
+    }
+
+    public string WorkspaceStatus
+    {
+        get => _workspaceStatus;
+        private set => this.RaiseAndSetIfChanged(ref _workspaceStatus, value);
+    }
+
+    public bool HasWorkspaceA
+    {
+        get => _hasWorkspaceA;
+        private set => this.RaiseAndSetIfChanged(ref _hasWorkspaceA, value);
+    }
+
+    public bool HasWorkspaceB
+    {
+        get => _hasWorkspaceB;
+        private set => this.RaiseAndSetIfChanged(ref _hasWorkspaceB, value);
+    }
+
+    public ReactiveCommand<Unit, Unit> SaveWorkspaceA { get; }
+    public ReactiveCommand<Unit, Unit> LoadWorkspaceA { get; }
+    public ReactiveCommand<Unit, Unit> SaveWorkspaceB { get; }
+    public ReactiveCommand<Unit, Unit> LoadWorkspaceB { get; }
+
+    public void CloseLayout()
+    {
+        if (Layout is IDock layout && layout.Close.CanExecute(null))
+        {
+            layout.Close.Execute(null);
+        }
+    }
+
+    private DockWorkspace? CaptureWorkspace(string id)
+    {
+        if (Layout is not IDock layout)
+        {
+            return null;
+        }
+
+        DockWorkspace workspace = _workspaceManager.Capture(id, layout, includeState: true, name: $"Workspace {id}");
+        UpdateWorkspaceSlotState();
+        UpdateWorkspaceStatus();
+        return workspace;
+    }
+
+    private void RestoreWorkspace(DockWorkspace? workspace)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        IDock? restored = _workspaceManager.Restore(workspace);
+        if (restored is not IRootDock root)
+        {
+            return;
+        }
+
+        _factory.InitLayout(root);
+        Layout = root;
+        UpdateWorkspaceStatus();
+    }
+
+    private void UpdateWorkspaceSlotState()
+    {
+        HasWorkspaceA = _workspaceA is not null;
+        HasWorkspaceB = _workspaceB is not null;
+    }
+
+    private void UpdateWorkspaceStatus()
+    {
+        DockWorkspace? workspace = _workspaceManager.ActiveWorkspace;
+        string label = workspace?.Name ?? workspace?.Id ?? "Unsaved";
+        WorkspaceStatus = _workspaceManager.IsDirty ? $"Workspace: {label} *" : $"Workspace: {label}";
+    }
+}

--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -4,11 +4,10 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
-using Dock.Avalonia.Themes.Fluent;
 using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes.Fluent;
 using Dock.Model;
-using Dock.Model.Avalonia;
-using Dock.Model.Avalonia.Controls;
+using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Serializer;
 using Dock.Settings;
@@ -18,12 +17,12 @@ namespace DockCodeOnlySample;
 internal class Program
 {
     [STAThread]
-    static void Main(string[] args)
+    private static void Main(string[] args)
     {
         BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
     }
 
-    static AppBuilder BuildAvaloniaApp()
+    private static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace()
@@ -40,80 +39,14 @@ public class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            var dockControl = new DockControl();
-
-            var factory = new Factory();
-
-            var documentDock = new DocumentDock
-            {
-                Id = "Documents",
-                IsCollapsable = false,
-                CanCreateDocument = true
-            };
-
-            documentDock.AllowedDropOperations = DockOperationMask.Fill;
-
-            documentDock.DocumentFactory = () =>
-            {
-                var index = documentDock.VisibleDockables?.Count ?? 0;
-                return new Document
-                {
-                    Id = $"Doc{index + 1}",
-                    Title = $"Document {index + 1}",
-                    Content = new TextBox { Text = $"Document {index + 1}", AcceptsReturn = true }
-                };
-            };
-
-            var document = new Document 
-            { 
-                Id = "Doc1", 
-                Title = "Document 1",
-                // Content = new TextBox { Text = "Document 1", AcceptsReturn = true }
-            };
-            documentDock.VisibleDockables = factory.CreateList<IDockable>(document);
-            documentDock.ActiveDockable = document;
-
-            var leftTool = new Tool { Id = "Tool1", Title = "Tool 1" };
-            var bottomTool = new Tool { Id = "Tool2", Title = "Output" };
-
-            leftTool.AllowedDockOperations = DockOperationMask.Left | DockOperationMask.Fill | DockOperationMask.Window;
-            bottomTool.AllowedDockOperations = DockOperationMask.Bottom | DockOperationMask.Fill | DockOperationMask.Window;
-
-            var mainLayout = new ProportionalDock
-            {
-                Orientation = Orientation.Horizontal,
-                VisibleDockables = factory.CreateList<IDockable>(
-                    new ToolDock
-                    {
-                        Id = "LeftPane",
-                        Alignment = Alignment.Left,
-                        Proportion = 0.25,
-                        VisibleDockables = factory.CreateList<IDockable>(leftTool),
-                        ActiveDockable = leftTool
-                    },
-                    new ProportionalDockSplitter(),
-                    documentDock,
-                    new ProportionalDockSplitter(),
-                    new ToolDock
-                    {
-                        Id = "BottomPane",
-                        Alignment = Alignment.Bottom,
-                        Proportion = 0.25,
-                        VisibleDockables = factory.CreateList<IDockable>(bottomTool),
-                        ActiveDockable = bottomTool
-                    })
-            };
-
-            var root = factory.CreateRootDock();
-            root.VisibleDockables = factory.CreateList<IDockable>(mainLayout);
-            root.DefaultDockable = mainLayout;
-
-            factory.InitLayout(root);
+            DockControl dockControl = new();
+            DockCodeOnlyFactory factory = new();
+            IRootDock layout = factory.CreateLayout();
+            factory.InitLayout(layout);
             dockControl.Factory = factory;
-            dockControl.Layout  = root;
+            dockControl.Layout = layout;
 
-            var serializer = new DockSerializer();
-            var workspaceManager = new DockWorkspaceManager(serializer);
+            DockWorkspaceManager workspaceManager = new(new DockSerializer());
             DockWorkspace? workspaceA = null;
             DockWorkspace? workspaceB = null;
 
@@ -132,32 +65,32 @@ public class App : Application
                     return;
                 }
 
-                var restored = workspaceManager.Restore(workspace);
-                if (restored is null)
+                IDock? restored = workspaceManager.Restore(workspace);
+                if (restored is not IRootDock root)
                 {
                     return;
                 }
 
-                factory.InitLayout(restored);
-                dockControl.Layout = restored;
+                factory.InitLayout(root);
+                dockControl.Layout = root;
             }
 
-            var saveWorkspaceA = new Button { Content = "Save Workspace A" };
+            Button saveWorkspaceA = new() { Content = "Save Workspace A" };
             saveWorkspaceA.Click += (_, _) => SaveWorkspace("A", ref workspaceA);
 
-            var loadWorkspaceA = new Button { Content = "Load Workspace A" };
+            Button loadWorkspaceA = new() { Content = "Load Workspace A" };
             loadWorkspaceA.Click += (_, _) => RestoreWorkspace(workspaceA);
 
-            var saveWorkspaceB = new Button { Content = "Save Workspace B" };
+            Button saveWorkspaceB = new() { Content = "Save Workspace B" };
             saveWorkspaceB.Click += (_, _) => SaveWorkspace("B", ref workspaceB);
 
-            var loadWorkspaceB = new Button { Content = "Load Workspace B" };
+            Button loadWorkspaceB = new() { Content = "Load Workspace B" };
             loadWorkspaceB.Click += (_, _) => RestoreWorkspace(workspaceB);
 
-            var lockLayout = new CheckBox { Content = "Lock layout" };
+            CheckBox lockLayout = new() { Content = "Lock layout" };
             lockLayout.IsCheckedChanged += (_, _) => dockControl.IsDockingEnabled = lockLayout.IsChecked != true;
 
-            var toolbar = new StackPanel
+            StackPanel toolbar = new()
             {
                 Orientation = Avalonia.Layout.Orientation.Horizontal,
                 Spacing = 8,
@@ -169,15 +102,16 @@ public class App : Application
             toolbar.Children.Add(loadWorkspaceB);
             toolbar.Children.Add(lockLayout);
 
-            var content = new DockPanel();
+            DockPanel content = new();
             DockPanel.SetDock(toolbar, Avalonia.Controls.Dock.Top);
             content.Children.Add(toolbar);
             content.Children.Add(dockControl);
 
             desktop.MainWindow = new Window
             {
-                Width = 800,
-                Height = 600,
+                Title = "Dock Code-Only Sample",
+                Width = 1000,
+                Height = 720,
                 Content = content
             };
         }

--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -10,7 +10,6 @@ using Dock.Model;
 using Dock.Model.Controls;
 using Dock.Model.Core;
 using Dock.Serializer;
-using Dock.Settings;
 
 namespace DockCodeOnlySample;
 
@@ -25,8 +24,7 @@ internal class Program
     private static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .LogToTrace()
-            .UseManagedWindows();
+            .LogToTrace();
 }
 
 public class App : Application

--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -37,12 +37,16 @@ public class App : Application
 
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            DockControl dockControl = new();
             DockCodeOnlyFactory factory = new();
             IRootDock layout = factory.CreateLayout();
             factory.InitLayout(layout);
-            dockControl.Factory = factory;
-            dockControl.Layout = layout;
+            DockControl dockControl = new()
+            {
+                InitializeFactory = true,
+                InitializeLayout = false,
+                Factory = factory,
+                Layout = layout
+            };
 
             DockWorkspaceManager workspaceManager = new(new DockSerializer());
             DockWorkspace? workspaceA = null;

--- a/samples/DockCodeOnlySample/Program.cs
+++ b/samples/DockCodeOnlySample/Program.cs
@@ -1,15 +1,9 @@
 using System;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
-using Dock.Avalonia.Controls;
 using Dock.Avalonia.Themes.Fluent;
-using Dock.Model;
-using Dock.Model.Controls;
-using Dock.Model.Core;
-using Dock.Serializer;
 
 namespace DockCodeOnlySample;
 
@@ -29,92 +23,21 @@ internal class Program
 
 public class App : Application
 {
-    public override void OnFrameworkInitializationCompleted()
+    public override void Initialize()
     {
         Styles.Add(new FluentTheme());
         Styles.Add(new DockFluentTheme());
         RequestedThemeVariant = ThemeVariant.Dark;
+    }
 
+    public override void OnFrameworkInitializationCompleted()
+    {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            DockCodeOnlyFactory factory = new();
-            IRootDock layout = factory.CreateLayout();
-            factory.InitLayout(layout);
-            DockControl dockControl = new()
+            MainWindowViewModel viewModel = new();
+            desktop.MainWindow = new MainWindow
             {
-                InitializeFactory = true,
-                InitializeLayout = false,
-                Factory = factory,
-                Layout = layout
-            };
-
-            DockWorkspaceManager workspaceManager = new(new DockSerializer());
-            DockWorkspace? workspaceA = null;
-            DockWorkspace? workspaceB = null;
-
-            void SaveWorkspace(string id, ref DockWorkspace? slot)
-            {
-                if (dockControl.Layout is IDock layout)
-                {
-                    slot = workspaceManager.Capture(id, layout, includeState: true, name: $"Workspace {id}");
-                }
-            }
-
-            void RestoreWorkspace(DockWorkspace? workspace)
-            {
-                if (workspace is null)
-                {
-                    return;
-                }
-
-                IDock? restored = workspaceManager.Restore(workspace);
-                if (restored is not IRootDock root)
-                {
-                    return;
-                }
-
-                factory.InitLayout(root);
-                dockControl.Layout = root;
-            }
-
-            Button saveWorkspaceA = new() { Content = "Save Workspace A" };
-            saveWorkspaceA.Click += (_, _) => SaveWorkspace("A", ref workspaceA);
-
-            Button loadWorkspaceA = new() { Content = "Load Workspace A" };
-            loadWorkspaceA.Click += (_, _) => RestoreWorkspace(workspaceA);
-
-            Button saveWorkspaceB = new() { Content = "Save Workspace B" };
-            saveWorkspaceB.Click += (_, _) => SaveWorkspace("B", ref workspaceB);
-
-            Button loadWorkspaceB = new() { Content = "Load Workspace B" };
-            loadWorkspaceB.Click += (_, _) => RestoreWorkspace(workspaceB);
-
-            CheckBox lockLayout = new() { Content = "Lock layout" };
-            lockLayout.IsCheckedChanged += (_, _) => dockControl.IsDockingEnabled = lockLayout.IsChecked != true;
-
-            StackPanel toolbar = new()
-            {
-                Orientation = Avalonia.Layout.Orientation.Horizontal,
-                Spacing = 8,
-                Margin = new Thickness(8)
-            };
-            toolbar.Children.Add(saveWorkspaceA);
-            toolbar.Children.Add(loadWorkspaceA);
-            toolbar.Children.Add(saveWorkspaceB);
-            toolbar.Children.Add(loadWorkspaceB);
-            toolbar.Children.Add(lockLayout);
-
-            DockPanel content = new();
-            DockPanel.SetDock(toolbar, Avalonia.Controls.Dock.Top);
-            content.Children.Add(toolbar);
-            content.Children.Add(dockControl);
-
-            desktop.MainWindow = new Window
-            {
-                Title = "Dock Code-Only Sample",
-                Width = 1000,
-                Height = 720,
-                Content = content
+                ViewModel = viewModel
             };
         }
 

--- a/tests/Dock.Avalonia.HeadlessTests/DockControlTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockControlTests.cs
@@ -1,6 +1,8 @@
 using Avalonia.Headless.XUnit;
 using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Controls;
 using Dock.Model.Core;
 using Xunit;
 
@@ -52,5 +54,41 @@ public class DockControlTests
         control.Layout = null;
 
         Assert.DoesNotContain(control, factory.DockControls);
+    }
+
+    [AvaloniaFact]
+    public void InitializeFactory_Registers_DockControl_Host_Window_Locators()
+    {
+        var factory = new Factory();
+        var document = new Document { Id = "DocumentA", Title = "Document A" };
+        var documentDock = new DocumentDock
+        {
+            Id = "Documents",
+            VisibleDockables = factory.CreateList<IDockable>(document),
+            ActiveDockable = document
+        };
+
+        var layout = new RootDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>(documentDock),
+            ActiveDockable = documentDock,
+            DefaultDockable = documentDock
+        };
+
+        factory.InitLayout(layout);
+
+        var control = new DockControl
+        {
+            InitializeFactory = true,
+            InitializeLayout = false,
+            Factory = factory,
+            Layout = layout
+        };
+
+        Assert.NotNull(factory.DefaultHostWindowLocator);
+        Assert.Same(control, factory.DefaultHostWindowLocator!.Target);
+        Assert.NotNull(factory.HostWindowLocator);
+        Assert.True(factory.HostWindowLocator!.TryGetValue(nameof(IDockWindow), out var hostWindowLocator));
+        Assert.Same(control, hostWindowLocator!.Target);
     }
 }

--- a/tests/Dock.Avalonia.HeadlessTests/DocumentDockNewDockTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DocumentDockNewDockTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
@@ -48,5 +49,28 @@ public class DocumentDockNewDockTests
         Assert.NotEqual(docDock, ownerDock);
         Assert.Contains(doc, ownerDock.VisibleDockables!);
         Assert.NotNull(factory.FindDockable(root, d => ReferenceEquals(d, ownerDock)));
+    }
+
+    [AvaloniaFact]
+    public void NewHorizontalDocumentDock_Keeps_Document_Content_Buildable()
+    {
+        var factory = new Factory();
+        var root = new RootDock { VisibleDockables = factory.CreateList<IDockable>() };
+        root.Factory = factory;
+        var docDock = new DocumentDock { VisibleDockables = factory.CreateList<IDockable>() };
+        factory.AddDockable(root, docDock);
+
+        var doc = new Document
+        {
+            Content = new Func<IServiceProvider, object>(_ => new TextBox())
+        };
+        factory.AddDockable(docDock, doc);
+
+        factory.NewHorizontalDocumentDock(doc);
+
+        var rebuiltContent = doc.Build(null, null);
+
+        Assert.IsType<TextBox>(rebuiltContent);
+        Assert.IsType<DocumentDock>(doc.Owner);
     }
 }

--- a/tests/Dock.Avalonia.HeadlessTests/FactoryWindowTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/FactoryWindowTests.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections.Generic;
 using Avalonia.Headless.XUnit;
+using Dock.Avalonia.Controls;
 using Dock.Model.Avalonia;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Avalonia.Core;
@@ -124,5 +127,39 @@ public class FactoryWindowTests
         Assert.Same(documentTemplate, createdDocumentDock.DocumentTemplate);
         Assert.Equal("DocumentTheme", createdDocumentDock.DocumentItemContainerTheme);
         Assert.Same(documentSelector, createdDocumentDock.DocumentItemTemplateSelector);
+    }
+
+    [AvaloniaFact]
+    public void FloatDockable_Uses_Configured_Host_Window_Locator()
+    {
+        var factory = new Factory
+        {
+            HostWindowLocator = new Dictionary<string, Func<IHostWindow?>>
+            {
+                [nameof(IDockWindow)] = static () => new ManagedHostWindow()
+            }
+        };
+
+        var document = new Document { Id = "DocumentA", Title = "Document A" };
+        var documentDock = new DocumentDock
+        {
+            Id = "Documents",
+            VisibleDockables = factory.CreateList<IDockable>(document),
+            ActiveDockable = document
+        };
+
+        var root = new RootDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>(documentDock),
+            ActiveDockable = documentDock,
+            DefaultDockable = documentDock
+        };
+
+        factory.InitLayout(root);
+        factory.FloatDockable(document);
+
+        var window = Assert.Single(root.Windows!);
+        Assert.NotNull(window.Host);
+        Assert.IsType<ManagedHostWindow>(window.Host);
     }
 }

--- a/tests/Dock.Model.Avalonia.UnitTests/Controls/TemplateHelperTests.cs
+++ b/tests/Dock.Model.Avalonia.UnitTests/Controls/TemplateHelperTests.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Presenters;
 using Avalonia.Headless.XUnit;
 using Dock.Avalonia.Controls;
+using Dock.Controls.DeferredContentControl;
 using Dock.Model.Avalonia.Controls;
 using Dock.Model.Avalonia.Core;
 using Xunit;
@@ -63,6 +64,30 @@ public class TemplateHelperTests
     }
 
     [AvaloniaFact]
+    public void Document_Build_Detaches_Direct_Control_From_DeferredContentControl()
+    {
+        var control = new Border();
+        var deferredHost = new DeferredContentControl { Content = control };
+        var window = new Window { Content = deferredHost };
+        var document = new Document { Content = control };
+
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+
+            var result = document.Build(null, null);
+
+            Assert.Same(control, result);
+            Assert.Null(deferredHost.Content);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [AvaloniaFact]
     public void ManagedDockWindowDocument_Build_Detaches_Direct_Control_From_Parent()
     {
         var window = new DockWindow();
@@ -103,6 +128,30 @@ public class TemplateHelperTests
         finally
         {
             host.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void Tool_Build_Detaches_Direct_Control_From_DeferredContentControl()
+    {
+        var control = new Border();
+        var deferredHost = new DeferredContentControl { Content = control };
+        var window = new Window { Content = deferredHost };
+        var tool = new Tool { Content = control };
+
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+
+            var result = tool.Build(null, null);
+
+            Assert.Same(control, result);
+            Assert.Null(deferredHost.Content);
+        }
+        finally
+        {
+            window.Close();
         }
     }
 


### PR DESCRIPTION
# PR Summary: DockCodeOnlySample factory alignment and drag/drop resilience

## Overview

This change aligns `DockCodeOnlySample` with the setup pattern used by the idiomatic Dock MVVM and ReactiveUI samples.

The original sample built the entire docking graph inline in `Program.cs` and assigned live Avalonia controls directly to `Document.Content` and `Tool.Content`. That approach worked for the initial layout, but it was structurally weaker than the factory-driven samples when the layout changed at runtime.

In particular:

- the sample factory was not the clear owner of layout creation,
- restored layouts did not reapply sample-specific document-dock configuration,
- dynamically created or moved docks were more likely to lose sample behavior,
- direct control instances were a brittle fit for docking scenarios that move content between hosts and windows.

## Problem being addressed

The reported user-visible symptom was that tools or documents disappeared after drag/drop operations.

Comparing `DockCodeOnlySample` to the MVVM and ReactiveUI samples showed a setup mismatch:

- `DockReactiveUISample` and `DockMvvmSample` centralize layout construction inside a dedicated factory.
- Those samples also use the factory as the place where runtime rehydration happens.
- `DockCodeOnlySample` instead mixed startup wiring, layout construction, runtime policy, and restore logic directly inside `Program.cs`.

That difference matters because Dock creates new dock containers during certain operations such as split/move flows. If sample-specific behavior only exists on the original startup dock instances, the newly created containers will not necessarily behave the same way after docking operations or workspace restore.

## Root cause analysis

There were two main structural issues.

### 1. Factory ownership was incomplete

The code-only sample used a plain `Factory` instance but did not let that factory own the sample's layout construction or rehydration strategy.

- `Program.cs` manually instantiated `DocumentDock`, `ToolDock`, `Document`, and `Tool`.
- Workspace restore called `factory.InitLayout(restored)` but there was no sample-specific override to restore document factory behavior or refill missing content.

That meant the sample did not follow the same composition model as the MVVM and ReactiveUI samples, where the factory is the single source of truth for layout creation and runtime initialization.

### 2. Dockable content relied on live control instances

The original sample assigned controls such as `TextBox` directly to dockable content.

Direct control assignment can work, but it is more fragile than supplying rebuildable template content for docking scenarios that move dockables between:

- tab hosts,
- floating windows,
- deferred content presenters,
- restored layouts.

The more robust pattern is to provide content as a factory, so Dock can realize a fresh visual tree when needed instead of relying on a single control instance remaining portable across all host transitions.

## What changed

### Commit 1: `Refactor DockCodeOnlySample around dedicated factory`

This commit introduces a dedicated `DockCodeOnlyFactory` and moves layout ownership into that type.

#### New factory

Added:

- `samples/DockCodeOnlySample/DockCodeOnlyFactory.cs`

Responsibilities now owned by the factory:

- `CreateLayout()` builds the full initial root dock layout,
- `CreateDocumentDock()` ensures new document docks receive sample-specific configuration,
- `InitLayout()` reapplies sample configuration after restore and rehydrates missing content,
- `CreateWindowFrom()` sets a consistent floating window title,
- document numbering is recalculated after restore so new documents continue from the correct index.

#### Program cleanup

Updated:

- `samples/DockCodeOnlySample/Program.cs`

`Program.cs` now:

- creates the dedicated factory,
- creates the layout through the factory,
- initializes the layout through the factory,
- restores workspaces through the same factory-owned initialization path.

This makes the sample structurally consistent with the MVVM/ReactiveUI factory-driven samples.

#### Rebuildable content instead of direct controls

Document and tool content is now provided via:

- `Func<IServiceProvider, object>`

instead of prebuilt live controls.

This gives the docking system a rebuildable content source for:

- split/move scenarios,
- floating windows,
- workspace restore.

### Commit 2: `Add regression tests for rebuildable dock content`

This commit adds focused regression coverage around content survivability.

Updated:

- `tests/Dock.Model.Avalonia.UnitTests/Controls/TemplateHelperTests.cs`
- `tests/Dock.Avalonia.HeadlessTests/DocumentDockNewDockTests.cs`

New coverage verifies:

- direct controls can be detached from `DeferredContentControl` hosts and rebuilt safely,
- document content remains buildable after `NewHorizontalDocumentDock` creates and moves the document into a new dock.

These tests target the content-host transition path that is most relevant to the disappearing-content symptom.

### Commit 3: `Wire floating host windows into DockCodeOnlySample`

This follow-up commit fixes the missing floating host-window pipeline in the code-only sample's manual initialization path.

Updated:

- `samples/DockCodeOnlySample/DockCodeOnlyFactory.cs`
- `tests/Dock.Avalonia.HeadlessTests/FactoryWindowTests.cs`

The core issue was that the sample called `factory.InitLayout(...)` manually, but did not enable the `DockControl.InitializeFactory` path that normally injects:

- `DefaultHostWindowLocator`
- `HostWindowLocator`

Without those locators, `FloatDockable` could create a floating `DockWindow` model without a real host window to present.

The sample factory now explicitly configures those locators during `InitLayout()`, and the headless test coverage verifies that a configured host-window locator results in a floating window with a non-null host.

### Commit 4: `Use native floating windows in DockCodeOnlySample`

This final cleanup commit removes the sample's managed-window bootstrap and makes the sample use native `HostWindow` floating windows consistently.

Updated:

- `samples/DockCodeOnlySample/Program.cs`

This addresses the follow-up issue where the sample was still opting into managed floating hosts, which made the floating behavior look like managed MDI-style windows instead of actual separate windows.

## Why this approach

This fix intentionally follows the architecture already demonstrated by the repository's MVVM and ReactiveUI samples instead of adding ad hoc repair logic to `Program.cs`.

Benefits:

- keeps sample behavior centralized,
- matches Dock's intended factory-based setup model,
- makes workspace restore deterministic,
- reduces the chance that newly created docks diverge from the original dock instance,
- keeps content generation compatible with host changes.

## Testing performed

Executed successfully:

- `dotnet build samples/DockCodeOnlySample/DockCodeOnlySample.csproj`
- `dotnet test tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj --filter TemplateHelperTests`
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --filter DocumentDockNewDockTests`
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --filter FactoryWindowTests`

Notes:

- The sample was also launched locally during investigation.
- I did not complete a full manual drag/drop UI verification pass after the final commit sequence, so the confidence comes from the structural fixes plus focused automated coverage.

## Risk assessment

Risk is low and mostly limited to the sample itself plus narrowly scoped tests.

Reasons:

- production docking behavior was not broadly refactored,
- the sample now follows the existing repository pattern more closely,
- added tests cover the specific content-host behavior relevant to the issue.

## Reviewer guidance

Primary review points:

1. Confirm that `DockCodeOnlyFactory` is the right place for sample-specific runtime initialization.
2. Confirm that rebuildable content via `Func<IServiceProvider, object>` is preferred here over direct control instances.
3. Confirm that the new tests adequately capture the failure mode around moved/split document content.

## Files changed

- `samples/DockCodeOnlySample/Program.cs`
- `samples/DockCodeOnlySample/DockCodeOnlyFactory.cs`
- `tests/Dock.Model.Avalonia.UnitTests/Controls/TemplateHelperTests.cs`
- `tests/Dock.Avalonia.HeadlessTests/DocumentDockNewDockTests.cs`
- `tests/Dock.Avalonia.HeadlessTests/FactoryWindowTests.cs`

## Commit breakdown

- `99207f2f9` `Refactor DockCodeOnlySample around dedicated factory`
- `517ffe50c` `Add regression tests for rebuildable dock content`
- `1f0397731` `Wire floating host windows into DockCodeOnlySample`
- `a86f0aee9` `Use native floating windows in DockCodeOnlySample`

Fixes https://github.com/wieslawsoltes/Dock/issues/1050
Fixes https://github.com/wieslawsoltes/Dock/issues/1089