### PR TITLE
Fix proportional dock save and restore

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
@@ -24,8 +24,10 @@
                         Classes="ProportionalStackPanel">
             <ItemsControl.Styles>
               <Style Selector="ItemsControl.ProportionalStackPanel > ContentPresenter">
+                <Setter Property="(ProportionalStackPanel.Proportion)"
+                  Value="{Binding Proportion, Mode=TwoWay}" />
                 <Setter Property="(ProportionalStackPanel.CollapsedProportion)"
-                        Value="{Binding CollapsedProportion}" />
+                  Value="{Binding CollapsedProportion, Mode=TwoWay}" />
                 <Setter Property="(ProportionalStackPanel.IsCollapsed)">
                   <Setter.Value>
                     <MultiBinding Converter="{x:Static BoolConverters.And}">

--- a/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs
@@ -4,9 +4,6 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Data;
-using Dock.Controls.ProportionalStackPanel;
-using Dock.Model.Core;
 
 namespace Dock.Avalonia.Controls;
 
@@ -16,34 +13,4 @@ namespace Dock.Avalonia.Controls;
 [TemplatePart("PART_ItemsControl", typeof(ItemsControl), IsRequired = true)]
 public class ProportionalDockControl : TemplatedControl
 {
-    private ItemsControl? _itemsControl;
-
-    /// <inheritdoc /> 
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        // Unsubscribe from the previous ItemsControl if it exists
-        if (_itemsControl != null)
-        {
-            _itemsControl.ContainerPrepared -= ItemsControlOnContainerPrepared;
-            _itemsControl = null;
-        }
-
-        base.OnApplyTemplate(e);
-
-        var itemsControl = e.NameScope.Find<ItemsControl>("PART_ItemsControl");
-
-        if (itemsControl != null)
-        {
-            _itemsControl = itemsControl;
-            _itemsControl.ContainerPrepared += ItemsControlOnContainerPrepared;
-        }
-    }
-
-    private void ItemsControlOnContainerPrepared(object? sender, ContainerPreparedEventArgs e)
-    {
-        if (e.Container.DataContext is IDockable)
-        {
-            e.Container[!ProportionalStackPanel.ProportionProperty] = new Binding(nameof(IDockable.Proportion));
-        }
-    }
 }


### PR DESCRIPTION
Summary
This change fixes proportional dock layout persistence so splitter-driven size changes are saved back into the dock model and restored correctly when the layout is reopened.

What changed
updated the proportional dock presenter binding so proportion values round-trip correctly between the UI container and the underlying dock model
removed the old code-behind hookup used to manage proportional bindings
simplified the implementation by relying on the XAML binding path instead of imperative container preparation logic
Why
When users resized proportional dock regions with the splitter, the updated proportions were not being restored reliably after reopening a tab or restarting the app. The UI sizing state was not consistently flowing back into the serialized layout model.

Result
splitter changes to proportional dock sizes are persisted
saved layouts restore the expected proportions on reopen/startup
the proportional dock implementation is smaller and easier to reason about
Testing
verified the proportional dock save/restore fix on the current branch
confirmed the relevant Dock-side change is limited to:
src/Dock.Avalonia.Themes.Fluent/Controls/ProportionalDockControl.axaml
src/Dock.Avalonia/Controls/ProportionalDockControl.axaml.cs