### PR TITLE
Add ReactiveUI agent bridge services (command registry, scripting, evidence capture)

### DIFF
--- a/src/Dock.Model.ReactiveUI.Services.Avalonia/Agent/AvaloniaScreenshotService.cs
+++ b/src/Dock.Model.ReactiveUI.Services.Avalonia/Agent/AvaloniaScreenshotService.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using Dock.Model.ReactiveUI.Services.Agent;
+
+namespace Dock.Model.ReactiveUI.Services.Avalonia.Agent;
+
+/// <summary>
+/// Captures Avalonia main window screenshots as PNG artifacts for agent execution evidence.
+/// </summary>
+public sealed class AvaloniaScreenshotService : IAgentScreenshotService
+{
+    private readonly Func<Window?> _getMainWindow;
+    private readonly string _artifactRoot;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvaloniaScreenshotService"/> class.
+    /// </summary>
+    /// <param name="getMainWindow">A function that returns the current main window.</param>
+    /// <param name="artifactRoot">The root directory for captured artifacts.</param>
+    public AvaloniaScreenshotService(Func<Window?> getMainWindow, string artifactRoot)
+    {
+        _getMainWindow = getMainWindow ?? throw new ArgumentNullException(nameof(getMainWindow));
+        _artifactRoot = string.IsNullOrWhiteSpace(artifactRoot)
+            ? throw new ArgumentException("Artifact root is required.", nameof(artifactRoot))
+            : artifactRoot;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> CaptureMainWindowAsync(string executionId, string name, CancellationToken cancellationToken = default)
+    {
+        return await Dispatcher.UIThread.InvokeAsync(
+            () => CaptureMainWindow(executionId, name, cancellationToken),
+            DispatcherPriority.Render,
+            cancellationToken);
+    }
+
+    private string CaptureMainWindow(string executionId, string name, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var window = _getMainWindow() ?? throw new InvalidOperationException("Main window is not available.");
+        var width = Math.Max(1, (int)Math.Ceiling(window.Bounds.Width));
+        var height = Math.Max(1, (int)Math.Ceiling(window.Bounds.Height));
+        var pixelSize = new PixelSize(width, height);
+        var dpi = new Vector(96, 96);
+
+        using var bitmap = new RenderTargetBitmap(pixelSize, dpi);
+        bitmap.Render(window);
+
+        var safeName = SanitizeFileName(name);
+        var directory = Path.Combine(_artifactRoot, executionId, "screenshots");
+        Directory.CreateDirectory(directory);
+
+        var path = Path.Combine(directory, $"{DateTimeOffset.UtcNow:yyyyMMdd_HHmmss_fff}_{safeName}.png");
+        bitmap.Save(path);
+        return path;
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return "screenshot";
+        }
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var chars = name.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+        {
+            for (var j = 0; j < invalid.Length; j++)
+            {
+                if (chars[i] == invalid[j])
+                {
+                    chars[i] = '_';
+                    break;
+                }
+            }
+        }
+
+        return new string(chars);
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentAttributes.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentAttributes.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Marks a view model command as available through an agent command registry.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Method)]
+public sealed class AgentCommandAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentCommandAttribute"/> class.
+    /// </summary>
+    /// <param name="description">A planner-friendly command description.</param>
+    public AgentCommandAttribute(string description)
+    {
+        Description = description ?? throw new ArgumentNullException(nameof(description));
+    }
+
+    /// <summary>
+    /// Gets the stable command identifier. When omitted, generated registries should derive one from the view model and member name.
+    /// </summary>
+    public string? Id { get; init; }
+
+    /// <summary>
+    /// Gets the display name exposed to agent clients.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets the command description exposed to agent clients.
+    /// </summary>
+    public string Description { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether invoking the command may mutate or delete user data.
+    /// </summary>
+    public bool Destructive { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether clients should ask for confirmation before invocation.
+    /// </summary>
+    public bool RequiresConfirmation { get; init; }
+}
+
+/// <summary>
+/// Marks a view model property as part of an agent-readable state snapshot.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public sealed class AgentStateAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the exported state name. When omitted, generated snapshots should use the property name.
+    /// </summary>
+    public string? Name { get; init; }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentCommandModels.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentCommandModels.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Describes a command that can be discovered and invoked by agent clients.
+/// </summary>
+/// <param name="Id">The stable command identifier.</param>
+/// <param name="Name">The display name.</param>
+/// <param name="ViewModel">The view model type name that owns the command.</param>
+/// <param name="Description">A planner-friendly command description.</param>
+/// <param name="InputType">The CLR input type name.</param>
+/// <param name="OutputType">The CLR output type name.</param>
+/// <param name="InputSchema">The JSON schema for command input.</param>
+/// <param name="OutputSchema">The JSON schema for command output.</param>
+/// <param name="CanExecute">A value indicating whether the command can execute now.</param>
+/// <param name="IsExecuting">A value indicating whether the command is currently executing.</param>
+/// <param name="Destructive">A value indicating whether the command may mutate or delete user data.</param>
+/// <param name="RequiresConfirmation">A value indicating whether clients should confirm before invoking.</param>
+/// <param name="RequiresIdleAfterInvoke">A value indicating whether clients should wait for UI idle after invoking.</param>
+public sealed record AgentCommandDescriptor(
+    string Id,
+    string Name,
+    string ViewModel,
+    string Description,
+    string InputType,
+    string OutputType,
+    JsonElement InputSchema,
+    JsonElement OutputSchema,
+    bool CanExecute,
+    bool IsExecuting,
+    bool Destructive,
+    bool RequiresConfirmation,
+    bool RequiresIdleAfterInvoke);
+
+/// <summary>
+/// Represents an agent command invocation request.
+/// </summary>
+/// <param name="Input">The optional JSON input payload.</param>
+public sealed record AgentInvokeRequest(JsonElement? Input);
+
+/// <summary>
+/// Represents an agent command invocation response.
+/// </summary>
+/// <param name="Success">A value indicating whether invocation completed successfully.</param>
+/// <param name="Result">The command result.</param>
+/// <param name="Error">The invocation error, when any.</param>
+public sealed record AgentInvokeResponse(bool Success, object? Result, string? Error)
+{
+    /// <summary>
+    /// Creates a successful response.
+    /// </summary>
+    /// <param name="result">The command result.</param>
+    /// <returns>A successful response.</returns>
+    public static AgentInvokeResponse Ok(object? result) => new(true, result, null);
+
+    /// <summary>
+    /// Creates a failed response.
+    /// </summary>
+    /// <param name="error">The error message.</param>
+    /// <returns>A failed response.</returns>
+    public static AgentInvokeResponse Fail(string error) => new(false, null, error);
+}
+
+/// <summary>
+/// Provides access to the current view model exposed by the host application.
+/// </summary>
+public interface ICurrentViewModelProvider
+{
+    /// <summary>
+    /// Gets the current view model, or <see langword="null"/> when no route is active.
+    /// </summary>
+    object? CurrentViewModel { get; }
+}
+
+/// <summary>
+/// Defines a registry of strongly typed agent commands.
+/// </summary>
+public interface IAgentCommandRegistry
+{
+    /// <summary>
+    /// Gets command descriptors that are valid for the supplied current view model.
+    /// </summary>
+    /// <param name="currentViewModel">The current view model.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The available command descriptors.</returns>
+    Task<IReadOnlyList<AgentCommandDescriptor>> GetAvailableCommandsAsync(object? currentViewModel, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Invokes a registered command on the supplied current view model.
+    /// </summary>
+    /// <param name="id">The command identifier.</param>
+    /// <param name="currentViewModel">The current view model.</param>
+    /// <param name="input">The optional JSON input payload.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<object?> InvokeAsync(string id, object? currentViewModel, JsonElement? input, CancellationToken cancellationToken = default);
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentCommandRegistry.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentCommandRegistry.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveUI;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Stores source-generated or manually registered ReactiveUI commands for deterministic agent invocation.
+/// </summary>
+public sealed class AgentCommandRegistry : IAgentCommandRegistry
+{
+    private static readonly JsonSerializerOptions DefaultJsonOptions = new(JsonSerializerDefaults.Web);
+    private readonly Dictionary<string, IAgentCommandBinding> _bindings = new(StringComparer.Ordinal);
+    private readonly JsonSerializerOptions _jsonOptions;
+    private readonly UiActivityTracker? _activityTracker;
+    private readonly TimeSpan _idleTimeout;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentCommandRegistry"/> class.
+    /// </summary>
+    /// <param name="activityTracker">The optional activity tracker used to wait for idle after invocations.</param>
+    /// <param name="jsonOptions">The JSON options used for input conversion.</param>
+    /// <param name="idleTimeout">The idle timeout used after commands that require idle.</param>
+    public AgentCommandRegistry(
+        UiActivityTracker? activityTracker = null,
+        JsonSerializerOptions? jsonOptions = null,
+        TimeSpan? idleTimeout = null)
+    {
+        _activityTracker = activityTracker;
+        _jsonOptions = jsonOptions ?? DefaultJsonOptions;
+        _idleTimeout = idleTimeout ?? TimeSpan.FromSeconds(30);
+    }
+
+    /// <summary>
+    /// Registers a strongly typed ReactiveUI command binding.
+    /// </summary>
+    /// <typeparam name="TViewModel">The owning view model type.</typeparam>
+    /// <typeparam name="TInput">The command input type.</typeparam>
+    /// <typeparam name="TOutput">The command output type.</typeparam>
+    /// <param name="id">The stable command identifier.</param>
+    /// <param name="name">The display name.</param>
+    /// <param name="description">The planner-friendly description.</param>
+    /// <param name="getCommand">A function that returns the command from the view model.</param>
+    /// <param name="inputSchema">The optional input schema.</param>
+    /// <param name="outputSchema">The optional output schema.</param>
+    /// <param name="destructive">A value indicating whether the command may mutate or delete data.</param>
+    /// <param name="requiresConfirmation">A value indicating whether invocation should be confirmed first.</param>
+    /// <param name="requiresIdleAfterInvoke">A value indicating whether invocation waits for idle.</param>
+    public void Register<TViewModel, TInput, TOutput>(
+        string id,
+        string name,
+        string description,
+        Func<TViewModel, ReactiveCommand<TInput, TOutput>> getCommand,
+        JsonElement? inputSchema = null,
+        JsonElement? outputSchema = null,
+        bool destructive = false,
+        bool requiresConfirmation = false,
+        bool requiresIdleAfterInvoke = true)
+        where TViewModel : class
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            throw new ArgumentException("Command id is required.", nameof(id));
+        }
+
+        ArgumentNullException.ThrowIfNull(getCommand);
+
+        _bindings.Add(
+            id,
+            new AgentCommandBinding<TViewModel, TInput, TOutput>(
+                id,
+                name,
+                description,
+                getCommand,
+                inputSchema ?? AgentJsonSchemas.CreateFor<TInput>(),
+                outputSchema ?? AgentJsonSchemas.CreateFor<TOutput>(),
+                destructive,
+                requiresConfirmation,
+                requiresIdleAfterInvoke));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<AgentCommandDescriptor>> GetAvailableCommandsAsync(
+        object? currentViewModel,
+        CancellationToken cancellationToken = default)
+    {
+        var descriptors = new List<AgentCommandDescriptor>(_bindings.Count);
+
+        foreach (var binding in _bindings.Values)
+        {
+            if (!binding.CanBind(currentViewModel))
+            {
+                continue;
+            }
+
+            descriptors.Add(await binding.CreateDescriptorAsync(currentViewModel!, cancellationToken).ConfigureAwait(false));
+        }
+
+        return descriptors;
+    }
+
+    /// <inheritdoc />
+    public async Task<object?> InvokeAsync(
+        string id,
+        object? currentViewModel,
+        JsonElement? input,
+        CancellationToken cancellationToken = default)
+    {
+        if (!_bindings.TryGetValue(id, out var binding))
+        {
+            throw new InvalidOperationException($"Agent command '{id}' is not registered.");
+        }
+
+        if (!binding.CanBind(currentViewModel))
+        {
+            var actual = currentViewModel?.GetType().FullName ?? "<none>";
+            throw new InvalidOperationException($"Agent command '{id}' is not available for current view model '{actual}'.");
+        }
+
+        using var activity = _activityTracker?.Begin(id);
+        var result = await binding.InvokeAsync(currentViewModel!, input, _jsonOptions, cancellationToken).ConfigureAwait(false);
+
+        if (binding.RequiresIdleAfterInvoke && _activityTracker is not null)
+        {
+            await _activityTracker.WaitForIdleAsync(_idleTimeout, cancellationToken).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+
+    private interface IAgentCommandBinding
+    {
+        bool RequiresIdleAfterInvoke { get; }
+
+        bool CanBind(object? viewModel);
+
+        Task<AgentCommandDescriptor> CreateDescriptorAsync(object viewModel, CancellationToken cancellationToken);
+
+        Task<object?> InvokeAsync(object viewModel, JsonElement? input, JsonSerializerOptions options, CancellationToken cancellationToken);
+    }
+
+    private sealed class AgentCommandBinding<TViewModel, TInput, TOutput> : IAgentCommandBinding
+        where TViewModel : class
+    {
+        private readonly string _id;
+        private readonly string _name;
+        private readonly string _description;
+        private readonly Func<TViewModel, ReactiveCommand<TInput, TOutput>> _getCommand;
+        private readonly JsonElement _inputSchema;
+        private readonly JsonElement _outputSchema;
+        private readonly bool _destructive;
+        private readonly bool _requiresConfirmation;
+
+        public AgentCommandBinding(
+            string id,
+            string name,
+            string description,
+            Func<TViewModel, ReactiveCommand<TInput, TOutput>> getCommand,
+            JsonElement inputSchema,
+            JsonElement outputSchema,
+            bool destructive,
+            bool requiresConfirmation,
+            bool requiresIdleAfterInvoke)
+        {
+            _id = id;
+            _name = string.IsNullOrWhiteSpace(name) ? id : name;
+            _description = description;
+            _getCommand = getCommand;
+            _inputSchema = inputSchema;
+            _outputSchema = outputSchema;
+            _destructive = destructive;
+            _requiresConfirmation = requiresConfirmation;
+            RequiresIdleAfterInvoke = requiresIdleAfterInvoke;
+        }
+
+        public bool RequiresIdleAfterInvoke { get; }
+
+        public bool CanBind(object? viewModel) => viewModel is TViewModel;
+
+        public async Task<AgentCommandDescriptor> CreateDescriptorAsync(object viewModel, CancellationToken cancellationToken)
+        {
+            var command = _getCommand((TViewModel)viewModel);
+            var canExecute = await command.CanExecute.Take(1).ToTask(cancellationToken).ConfigureAwait(false);
+            var isExecuting = await command.IsExecuting.Take(1).ToTask(cancellationToken).ConfigureAwait(false);
+
+            return new AgentCommandDescriptor(
+                _id,
+                _name,
+                typeof(TViewModel).Name,
+                _description,
+                typeof(TInput).FullName ?? typeof(TInput).Name,
+                typeof(TOutput).FullName ?? typeof(TOutput).Name,
+                _inputSchema,
+                _outputSchema,
+                canExecute,
+                isExecuting,
+                _destructive,
+                _requiresConfirmation,
+                RequiresIdleAfterInvoke);
+        }
+
+        public async Task<object?> InvokeAsync(
+            object viewModel,
+            JsonElement? input,
+            JsonSerializerOptions options,
+            CancellationToken cancellationToken)
+        {
+            var command = _getCommand((TViewModel)viewModel);
+            var typedInput = AgentJsonInput.Deserialize<TInput>(input, options);
+            var result = await command.Execute(typedInput).Take(1).ToTask(cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+    }
+}
+
+/// <summary>
+/// Provides small built-in JSON schema documents for common command payloads.
+/// </summary>
+public static class AgentJsonSchemas
+{
+    /// <summary>
+    /// Creates a JSON schema for the supplied type parameter.
+    /// </summary>
+    /// <typeparam name="T">The CLR type.</typeparam>
+    /// <returns>A JSON schema element.</returns>
+    public static JsonElement CreateFor<T>() => CreateFor(typeof(T));
+
+    /// <summary>
+    /// Creates a JSON schema for the supplied type.
+    /// </summary>
+    /// <param name="type">The CLR type.</param>
+    /// <returns>A JSON schema element.</returns>
+    public static JsonElement CreateFor(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        JsonObject schema = type == typeof(Unit)
+            ? new JsonObject { ["type"] = "null" }
+            : type == typeof(string)
+                ? new JsonObject { ["type"] = "string" }
+                : type == typeof(bool)
+                    ? new JsonObject { ["type"] = "boolean" }
+                    : IsNumber(type)
+                        ? new JsonObject { ["type"] = "number" }
+                        : new JsonObject { ["type"] = "object", ["dotnetType"] = type.FullName ?? type.Name };
+
+        return JsonSerializer.SerializeToElement(schema);
+    }
+
+    private static bool IsNumber(Type type)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+        return underlyingType == typeof(byte)
+            || underlyingType == typeof(short)
+            || underlyingType == typeof(int)
+            || underlyingType == typeof(long)
+            || underlyingType == typeof(float)
+            || underlyingType == typeof(double)
+            || underlyingType == typeof(decimal);
+    }
+}
+
+internal static class AgentJsonInput
+{
+    public static T Deserialize<T>(JsonElement? input, JsonSerializerOptions options)
+    {
+        if (typeof(T) == typeof(Unit))
+        {
+            return (T)(object)Unit.Default;
+        }
+
+        if (input is null)
+        {
+            throw new InvalidOperationException($"Agent command requires input of type '{typeof(T).FullName}'.");
+        }
+
+        var value = input.Value.Deserialize<T>(options);
+        if (value is null && Nullable.GetUnderlyingType(typeof(T)) is null && typeof(T).IsValueType)
+        {
+            throw new InvalidOperationException($"Agent command input could not be converted to '{typeof(T).FullName}'.");
+        }
+
+        return value!;
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentExecutionRecorder.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentExecutionRecorder.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Represents an execution recording with events and artifact references.
+/// </summary>
+/// <param name="Id">The execution id.</param>
+/// <param name="Name">The execution name.</param>
+/// <param name="StartedAt">The start timestamp.</param>
+/// <param name="FinishedAt">The optional finish timestamp.</param>
+/// <param name="Events">The timeline events.</param>
+/// <param name="Artifacts">The artifact references.</param>
+public sealed record AgentExecution(
+    string Id,
+    string Name,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? FinishedAt,
+    IReadOnlyList<AgentExecutionEvent> Events,
+    IReadOnlyList<AgentArtifact> Artifacts);
+
+/// <summary>
+/// Represents one timeline event in an execution recording.
+/// </summary>
+/// <param name="Timestamp">The event timestamp.</param>
+/// <param name="Kind">The event kind.</param>
+/// <param name="Message">The event message.</param>
+/// <param name="Data">The optional structured event data.</param>
+public sealed record AgentExecutionEvent(DateTimeOffset Timestamp, string Kind, string Message, JsonElement? Data = null);
+
+/// <summary>
+/// Represents an artifact captured during execution.
+/// </summary>
+/// <param name="Id">The artifact id.</param>
+/// <param name="Kind">The artifact kind.</param>
+/// <param name="Path">The artifact path.</param>
+/// <param name="Description">The optional artifact description.</param>
+public sealed record AgentArtifact(string Id, string Kind, string Path, string? Description);
+
+/// <summary>
+/// Captures execution events, command logs, snapshots, screenshots, and other artifacts for later debugging.
+/// </summary>
+public sealed class AgentExecutionRecorder
+{
+    private readonly ConcurrentDictionary<string, MutableExecution> _executions = new();
+
+    /// <summary>
+    /// Starts recording a new execution.
+    /// </summary>
+    /// <param name="name">The execution name.</param>
+    /// <returns>The execution snapshot.</returns>
+    public AgentExecution Start(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Execution name is required.", nameof(name));
+        }
+
+        var mutable = new MutableExecution($"exec_{Guid.NewGuid():N}", name, DateTimeOffset.UtcNow);
+        _executions[mutable.Id] = mutable;
+        RecordEvent(mutable.Id, "execution.started", name);
+        return Snapshot(mutable);
+    }
+
+    /// <summary>
+    /// Stops recording an execution.
+    /// </summary>
+    /// <param name="executionId">The execution id.</param>
+    /// <returns>The final execution snapshot.</returns>
+    public AgentExecution Stop(string executionId)
+    {
+        var execution = GetMutable(executionId);
+        lock (execution)
+        {
+            execution.Events.Add(new AgentExecutionEvent(DateTimeOffset.UtcNow, "execution.finished", "Execution finished"));
+            execution.FinishedAt = DateTimeOffset.UtcNow;
+            return Snapshot(execution);
+        }
+    }
+
+    /// <summary>
+    /// Gets an execution snapshot.
+    /// </summary>
+    /// <param name="executionId">The execution id.</param>
+    /// <returns>The execution snapshot.</returns>
+    public AgentExecution Get(string executionId) => Snapshot(GetMutable(executionId));
+
+    /// <summary>
+    /// Lists execution snapshots.
+    /// </summary>
+    /// <returns>The known executions.</returns>
+    public IReadOnlyList<AgentExecution> List()
+    {
+        return _executions.Values.Select(Snapshot).ToArray();
+    }
+
+    /// <summary>
+    /// Records an execution event.
+    /// </summary>
+    /// <param name="executionId">The execution id.</param>
+    /// <param name="kind">The event kind.</param>
+    /// <param name="message">The event message.</param>
+    /// <param name="data">The optional structured event data.</param>
+    public void RecordEvent(string executionId, string kind, string message, JsonElement? data = null)
+    {
+        var execution = GetMutable(executionId);
+        lock (execution)
+        {
+            execution.Events.Add(new AgentExecutionEvent(DateTimeOffset.UtcNow, kind, message, data));
+        }
+    }
+
+    /// <summary>
+    /// Records an artifact reference.
+    /// </summary>
+    /// <param name="executionId">The execution id.</param>
+    /// <param name="kind">The artifact kind.</param>
+    /// <param name="path">The artifact path.</param>
+    /// <param name="description">The optional artifact description.</param>
+    /// <returns>The artifact reference.</returns>
+    public AgentArtifact RecordArtifact(string executionId, string kind, string path, string? description = null)
+    {
+        var artifact = new AgentArtifact($"artifact_{Guid.NewGuid():N}", kind, path, description);
+        var execution = GetMutable(executionId);
+        lock (execution)
+        {
+            execution.Artifacts.Add(artifact);
+        }
+
+        return artifact;
+    }
+
+    private MutableExecution GetMutable(string executionId)
+    {
+        if (!_executions.TryGetValue(executionId, out var execution))
+        {
+            throw new InvalidOperationException($"Execution '{executionId}' was not found.");
+        }
+
+        return execution;
+    }
+
+    private static AgentExecution Snapshot(MutableExecution execution)
+    {
+        lock (execution)
+        {
+            return new AgentExecution(
+                execution.Id,
+                execution.Name,
+                execution.StartedAt,
+                execution.FinishedAt,
+                execution.Events.ToArray(),
+                execution.Artifacts.ToArray());
+        }
+    }
+
+    private sealed class MutableExecution
+    {
+        public MutableExecution(string id, string name, DateTimeOffset startedAt)
+        {
+            Id = id;
+            Name = name;
+            StartedAt = startedAt;
+        }
+
+        public string Id { get; }
+
+        public string Name { get; }
+
+        public DateTimeOffset StartedAt { get; }
+
+        public DateTimeOffset? FinishedAt { get; set; }
+
+        public List<AgentExecutionEvent> Events { get; } = new();
+
+        public List<AgentArtifact> Artifacts { get; } = new();
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentOperations.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentOperations.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Represents the lifecycle status of an agent operation.
+/// </summary>
+public enum AgentOperationStatus
+{
+    /// <summary>The operation has been created but has not started.</summary>
+    Queued,
+    /// <summary>The operation is running.</summary>
+    Running,
+    /// <summary>The operation completed successfully.</summary>
+    Completed,
+    /// <summary>The operation failed.</summary>
+    Failed,
+    /// <summary>The operation was cancelled.</summary>
+    Cancelled
+}
+
+/// <summary>
+/// Represents progress reported by an agent command or scenario step.
+/// </summary>
+/// <param name="Phase">The current phase.</param>
+/// <param name="Percent">The optional percent complete.</param>
+public sealed record AgentProgress(string Phase, double? Percent = null);
+
+/// <summary>
+/// Represents a point-in-time operation snapshot.
+/// </summary>
+/// <param name="Id">The operation identifier.</param>
+/// <param name="Instruction">The original instruction.</param>
+/// <param name="Status">The operation status.</param>
+/// <param name="Phase">The current phase.</param>
+/// <param name="Progress">The optional progress.</param>
+/// <param name="Result">The operation result.</param>
+/// <param name="Error">The operation error.</param>
+/// <param name="ActiveOperations">The active UI operation names.</param>
+public sealed record AgentOperationSnapshot(
+    string Id,
+    string Instruction,
+    AgentOperationStatus Status,
+    string? Phase,
+    double? Progress,
+    object? Result,
+    string? Error,
+    IReadOnlyList<string> ActiveOperations);
+
+/// <summary>
+/// Plans natural-language instructions into deterministic operation steps.
+/// </summary>
+public interface IAgentInstructionPlanner
+{
+    /// <summary>
+    /// Creates a plan for an instruction.
+    /// </summary>
+    /// <param name="instruction">The natural-language instruction.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The operation plan.</returns>
+    Task<AgentOperationPlan> PlanAsync(string instruction, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Represents a deterministic plan created from an instruction.
+/// </summary>
+/// <param name="Steps">The ordered plan steps.</param>
+public sealed record AgentOperationPlan(IReadOnlyList<IAgentOperationStep> Steps);
+
+/// <summary>
+/// Represents one executable operation step.
+/// </summary>
+public interface IAgentOperationStep
+{
+    /// <summary>
+    /// Gets a human-readable step description.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Executes the step.
+    /// </summary>
+    /// <param name="progress">The progress sink.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes when the step finishes.</returns>
+    Task ExecuteAsync(IProgress<AgentProgress> progress, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Runs natural-language operations asynchronously and exposes pollable snapshots.
+/// </summary>
+public sealed class AgentOperationRunner
+{
+    private readonly ConcurrentDictionary<string, MutableOperation> _operations = new();
+    private readonly ConcurrentDictionary<string, CancellationTokenSource> _cancellations = new();
+    private readonly UiActivityTracker _activityTracker;
+    private readonly IAgentInstructionPlanner _planner;
+    private readonly TimeSpan _idleTimeout;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentOperationRunner"/> class.
+    /// </summary>
+    /// <param name="activityTracker">The activity tracker.</param>
+    /// <param name="planner">The instruction planner.</param>
+    /// <param name="idleTimeout">The idle timeout after each step.</param>
+    public AgentOperationRunner(UiActivityTracker activityTracker, IAgentInstructionPlanner planner, TimeSpan? idleTimeout = null)
+    {
+        _activityTracker = activityTracker ?? throw new ArgumentNullException(nameof(activityTracker));
+        _planner = planner ?? throw new ArgumentNullException(nameof(planner));
+        _idleTimeout = idleTimeout ?? TimeSpan.FromSeconds(20);
+    }
+
+    /// <summary>
+    /// Starts an operation in the background.
+    /// </summary>
+    /// <param name="instruction">The instruction to execute.</param>
+    /// <returns>The initial operation snapshot.</returns>
+    public AgentOperationSnapshot Start(string instruction)
+    {
+        if (string.IsNullOrWhiteSpace(instruction))
+        {
+            throw new ArgumentException("Instruction is required.", nameof(instruction));
+        }
+
+        var id = $"op_{Guid.NewGuid():N}";
+        var operation = new MutableOperation(id, instruction)
+        {
+            Status = AgentOperationStatus.Queued,
+            Phase = "Queued",
+            Progress = 0
+        };
+
+        _operations[id] = operation;
+        var cts = new CancellationTokenSource();
+        _cancellations[id] = cts;
+        _ = Task.Run(() => RunAsync(operation, cts.Token));
+        return Snapshot(operation);
+    }
+
+    /// <summary>
+    /// Gets a snapshot by operation id.
+    /// </summary>
+    /// <param name="id">The operation id.</param>
+    /// <returns>The operation snapshot, or <see langword="null"/>.</returns>
+    public AgentOperationSnapshot? Get(string id)
+    {
+        return _operations.TryGetValue(id, out var operation) ? Snapshot(operation) : null;
+    }
+
+    /// <summary>
+    /// Requests cancellation of a running operation.
+    /// </summary>
+    /// <param name="id">The operation id.</param>
+    /// <returns><see langword="true"/> when a cancellation source was found.</returns>
+    public bool Cancel(string id)
+    {
+        if (!_cancellations.TryGetValue(id, out var cts))
+        {
+            return false;
+        }
+
+        cts.Cancel();
+        return true;
+    }
+
+    private async Task RunAsync(MutableOperation operation, CancellationToken cancellationToken)
+    {
+        using var activity = _activityTracker.Begin($"AgentInstruction:{operation.Instruction}");
+
+        try
+        {
+            Update(operation, AgentOperationStatus.Running, "Planning", 5, null, null);
+            var plan = await _planner.PlanAsync(operation.Instruction, cancellationToken).ConfigureAwait(false);
+            Update(operation, AgentOperationStatus.Running, "Executing", 15, null, null);
+
+            foreach (var step in plan.Steps)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Update(operation, AgentOperationStatus.Running, step.Description, null, null, null);
+
+                await step.ExecuteAsync(
+                    new Progress<AgentProgress>(progress => Update(operation, AgentOperationStatus.Running, progress.Phase, progress.Percent, null, null)),
+                    cancellationToken).ConfigureAwait(false);
+
+                await _activityTracker.WaitForIdleAsync(_idleTimeout, cancellationToken).ConfigureAwait(false);
+            }
+
+            await _activityTracker.WaitForIdleAsync(_idleTimeout, cancellationToken).ConfigureAwait(false);
+            Update(operation, AgentOperationStatus.Completed, "Completed", 100, operation.Result, null);
+        }
+        catch (OperationCanceledException)
+        {
+            Update(operation, AgentOperationStatus.Cancelled, "Cancelled", null, null, "Operation cancelled.");
+        }
+        catch (Exception ex)
+        {
+            Update(operation, AgentOperationStatus.Failed, "Failed", null, null, ex.Message);
+        }
+        finally
+        {
+            if (_cancellations.TryRemove(operation.Id, out var cts))
+            {
+                cts.Dispose();
+            }
+        }
+    }
+
+    private AgentOperationSnapshot Snapshot(MutableOperation operation)
+    {
+        lock (operation)
+        {
+            return new AgentOperationSnapshot(
+                operation.Id,
+                operation.Instruction,
+                operation.Status,
+                operation.Phase,
+                operation.Progress,
+                operation.Result,
+                operation.Error,
+                _activityTracker.ActiveOperations);
+        }
+    }
+
+    private static void Update(
+        MutableOperation operation,
+        AgentOperationStatus status,
+        string? phase,
+        double? progress,
+        object? result,
+        string? error)
+    {
+        lock (operation)
+        {
+            operation.Status = status;
+            operation.Phase = phase;
+            operation.Progress = progress;
+            operation.Result = result ?? operation.Result;
+            operation.Error = error;
+        }
+    }
+
+    private sealed class MutableOperation
+    {
+        public MutableOperation(string id, string instruction)
+        {
+            Id = id;
+            Instruction = instruction;
+        }
+
+        public string Id { get; }
+
+        public string Instruction { get; }
+
+        public AgentOperationStatus Status { get; set; }
+
+        public string? Phase { get; set; }
+
+        public double? Progress { get; set; }
+
+        public object? Result { get; set; }
+
+        public string? Error { get; set; }
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentScenarioRecorder.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentScenarioRecorder.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Represents a scenario recorded from semantic commands or automation identifiers.
+/// </summary>
+/// <param name="Name">The scenario name.</param>
+/// <param name="CreatedAt">The creation timestamp.</param>
+/// <param name="Steps">The recorded steps.</param>
+public sealed record RecordedScenario(string Name, DateTimeOffset CreatedAt, IReadOnlyList<RecordedStep> Steps);
+
+/// <summary>
+/// Base type for recorded scenario steps.
+/// </summary>
+public abstract record RecordedStep;
+
+/// <summary>
+/// Represents a recorded command invocation.
+/// </summary>
+/// <param name="CommandId">The command id.</param>
+/// <param name="Input">The optional serialized input.</param>
+public sealed record RecordedCommandStep(string CommandId, JsonElement? Input = null) : RecordedStep;
+
+/// <summary>
+/// Represents recorded text entry by automation id.
+/// </summary>
+/// <param name="AutomationId">The automation id.</param>
+/// <param name="Value">The text value.</param>
+public sealed record RecordedSetTextStep(string AutomationId, string Value) : RecordedStep;
+
+/// <summary>
+/// Represents a recorded click by automation id.
+/// </summary>
+/// <param name="AutomationId">The automation id.</param>
+public sealed record RecordedClickStep(string AutomationId) : RecordedStep;
+
+/// <summary>
+/// Represents a recorded idle wait.
+/// </summary>
+/// <param name="Timeout">The idle timeout.</param>
+public sealed record RecordedWaitIdleStep(TimeSpan Timeout) : RecordedStep;
+
+/// <summary>
+/// Represents a recorded route assertion.
+/// </summary>
+/// <param name="Route">The expected route.</param>
+public sealed record RecordedAssertRouteStep(string Route) : RecordedStep;
+
+/// <summary>
+/// Represents a recorded state snapshot.
+/// </summary>
+/// <param name="Name">The snapshot name.</param>
+/// <param name="Snapshot">The snapshot payload.</param>
+public sealed record RecordedSnapshotStep(string Name, JsonElement Snapshot) : RecordedStep;
+
+/// <summary>
+/// Records semantic scenarios for later replay or agent guidance.
+/// </summary>
+public sealed class AgentScenarioRecorder
+{
+    private readonly object _gate = new();
+    private readonly List<RecordedStep> _steps = new();
+    private readonly TimeSpan _defaultWait;
+    private bool _isRecording;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentScenarioRecorder"/> class.
+    /// </summary>
+    /// <param name="defaultWait">The wait inserted after user-visible actions.</param>
+    public AgentScenarioRecorder(TimeSpan? defaultWait = null)
+    {
+        _defaultWait = defaultWait ?? TimeSpan.FromSeconds(10);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether recording is active.
+    /// </summary>
+    public bool IsRecording
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _isRecording;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Starts recording and clears previously recorded steps.
+    /// </summary>
+    public void Start()
+    {
+        lock (_gate)
+        {
+            _steps.Clear();
+            _isRecording = true;
+        }
+    }
+
+    /// <summary>
+    /// Stops recording and returns the scenario.
+    /// </summary>
+    /// <param name="name">The scenario name.</param>
+    /// <returns>The recorded scenario.</returns>
+    public RecordedScenario Stop(string name)
+    {
+        lock (_gate)
+        {
+            _isRecording = false;
+            return new RecordedScenario(name, DateTimeOffset.UtcNow, _steps.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Gets the current in-progress scenario snapshot.
+    /// </summary>
+    /// <param name="name">The scenario name to use in the snapshot.</param>
+    /// <returns>The scenario snapshot.</returns>
+    public RecordedScenario Current(string name = "current")
+    {
+        lock (_gate)
+        {
+            return new RecordedScenario(name, DateTimeOffset.UtcNow, _steps.ToArray());
+        }
+    }
+
+    /// <summary>
+    /// Records a step when recording is active.
+    /// </summary>
+    /// <param name="step">The step to record.</param>
+    public void Record(RecordedStep step)
+    {
+        ArgumentNullException.ThrowIfNull(step);
+
+        lock (_gate)
+        {
+            if (!_isRecording)
+            {
+                return;
+            }
+
+            _steps.Add(step);
+        }
+    }
+
+    /// <summary>
+    /// Records a command invocation and inserts an idle wait.
+    /// </summary>
+    /// <param name="commandId">The command id.</param>
+    /// <param name="input">The optional input.</param>
+    public void RecordCommand(string commandId, JsonElement? input = null)
+    {
+        Record(new RecordedCommandStep(commandId, input));
+        Record(new RecordedWaitIdleStep(_defaultWait));
+    }
+
+    /// <summary>
+    /// Records a click and inserts an idle wait.
+    /// </summary>
+    /// <param name="automationId">The automation id.</param>
+    public void RecordClick(string automationId)
+    {
+        Record(new RecordedClickStep(automationId));
+        Record(new RecordedWaitIdleStep(_defaultWait));
+    }
+
+    /// <summary>
+    /// Records a text edit and inserts an idle wait.
+    /// </summary>
+    /// <param name="automationId">The automation id.</param>
+    /// <param name="value">The text value.</param>
+    public void RecordSetText(string automationId, string value)
+    {
+        Record(new RecordedSetTextStep(automationId, value));
+        Record(new RecordedWaitIdleStep(_defaultWait));
+    }
+}
+
+/// <summary>
+/// Invokes UI controls by automation id for scenario replay.
+/// </summary>
+public interface IAutomationControlInvoker
+{
+    /// <summary>Clicks a control.</summary>
+    /// <param name="automationId">The automation id.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes after the click.</returns>
+    Task ClickAsync(string automationId, CancellationToken cancellationToken = default);
+
+    /// <summary>Sets text on a control.</summary>
+    /// <param name="automationId">The automation id.</param>
+    /// <param name="value">The text value.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes after the text change.</returns>
+    Task SetTextAsync(string automationId, string value, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Replays recorded scenarios using semantic commands first and UI automation identifiers as fallback.
+/// </summary>
+public sealed class AgentScenarioReplayer
+{
+    private readonly IAgentCommandRegistry _commands;
+    private readonly ICurrentViewModelProvider _currentViewModelProvider;
+    private readonly IAutomationControlInvoker _automation;
+    private readonly UiActivityTracker _activityTracker;
+    private readonly IAgentStateProvider _stateProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentScenarioReplayer"/> class.
+    /// </summary>
+    /// <param name="commands">The command registry.</param>
+    /// <param name="currentViewModelProvider">The current view model provider.</param>
+    /// <param name="automation">The automation invoker.</param>
+    /// <param name="activityTracker">The activity tracker.</param>
+    /// <param name="stateProvider">The state provider.</param>
+    public AgentScenarioReplayer(
+        IAgentCommandRegistry commands,
+        ICurrentViewModelProvider currentViewModelProvider,
+        IAutomationControlInvoker automation,
+        UiActivityTracker activityTracker,
+        IAgentStateProvider stateProvider)
+    {
+        _commands = commands ?? throw new ArgumentNullException(nameof(commands));
+        _currentViewModelProvider = currentViewModelProvider ?? throw new ArgumentNullException(nameof(currentViewModelProvider));
+        _automation = automation ?? throw new ArgumentNullException(nameof(automation));
+        _activityTracker = activityTracker ?? throw new ArgumentNullException(nameof(activityTracker));
+        _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
+    }
+
+    /// <summary>
+    /// Replays a recorded scenario.
+    /// </summary>
+    /// <param name="scenario">The scenario.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes after replay.</returns>
+    public async Task ReplayAsync(RecordedScenario scenario, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+
+        foreach (var step in scenario.Steps)
+        {
+            switch (step)
+            {
+                case RecordedCommandStep command:
+                    await _commands.InvokeAsync(command.CommandId, _currentViewModelProvider.CurrentViewModel, command.Input, cancellationToken).ConfigureAwait(false);
+                    break;
+                case RecordedClickStep click:
+                    await _automation.ClickAsync(click.AutomationId, cancellationToken).ConfigureAwait(false);
+                    break;
+                case RecordedSetTextStep text:
+                    await _automation.SetTextAsync(text.AutomationId, text.Value, cancellationToken).ConfigureAwait(false);
+                    break;
+                case RecordedWaitIdleStep wait:
+                    await _activityTracker.WaitForIdleAsync(wait.Timeout, cancellationToken).ConfigureAwait(false);
+                    break;
+                case RecordedAssertRouteStep route:
+                    await AssertRouteAsync(route.Route, cancellationToken).ConfigureAwait(false);
+                    break;
+                case RecordedSnapshotStep:
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported recorded step '{step.GetType().Name}'.");
+            }
+        }
+    }
+
+    private async Task AssertRouteAsync(string route, CancellationToken cancellationToken)
+    {
+        var snapshot = await _stateProvider.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+        if (!StringComparer.Ordinal.Equals(snapshot.Route, route))
+        {
+            throw new InvalidOperationException($"Expected route '{route}', got '{snapshot.Route}'.");
+        }
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentScreenshots.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentScreenshots.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Captures screenshots for execution evidence.
+/// </summary>
+public interface IAgentScreenshotService
+{
+    /// <summary>
+    /// Captures the main window and returns the artifact path.
+    /// </summary>
+    /// <param name="executionId">The execution id.</param>
+    /// <param name="name">The screenshot name.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The artifact path.</returns>
+    Task<string> CaptureMainWindowAsync(string executionId, string name, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Controls automatic screenshot capture around scenario steps.
+/// </summary>
+/// <param name="BeforeEachStep">Capture before every step.</param>
+/// <param name="AfterEachStep">Capture after every step.</param>
+/// <param name="OnFailure">Capture on failures.</param>
+/// <param name="OnNavigation">Capture after navigation assertions.</param>
+/// <param name="OnDialogOpened">Capture when a host maps dialog events to this policy.</param>
+public sealed record ScreenshotPolicy(
+    bool BeforeEachStep = false,
+    bool AfterEachStep = true,
+    bool OnFailure = true,
+    bool OnNavigation = false,
+    bool OnDialogOpened = false);

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentScripts.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentScripts.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Represents a deterministic scenario script.
+/// </summary>
+/// <param name="Name">The script name.</param>
+/// <param name="Timeout">The total timeout.</param>
+/// <param name="Steps">The ordered script steps.</param>
+public sealed record AgentScript(string Name, TimeSpan Timeout, IReadOnlyList<AgentScriptStep> Steps);
+
+/// <summary>
+/// Base type for script steps.
+/// </summary>
+public abstract record AgentScriptStep;
+
+/// <summary>
+/// Invokes an agent command.
+/// </summary>
+/// <param name="Command">The command id.</param>
+/// <param name="Input">The optional input payload.</param>
+public sealed record InvokeCommandStep(string Command, JsonElement? Input = null) : AgentScriptStep;
+
+/// <summary>
+/// Waits for the UI to become idle.
+/// </summary>
+/// <param name="Timeout">The idle timeout.</param>
+public sealed record WaitIdleStep(TimeSpan Timeout) : AgentScriptStep;
+
+/// <summary>
+/// Asserts current route and state values.
+/// </summary>
+/// <param name="Route">The optional expected route.</param>
+/// <param name="State">The optional expected state values.</param>
+public sealed record AssertStateStep(string? Route, IReadOnlyDictionary<string, JsonElement>? State = null) : AgentScriptStep;
+
+/// <summary>
+/// Captures a screenshot artifact.
+/// </summary>
+/// <param name="Name">The screenshot name.</param>
+public sealed record ScreenshotStep(string Name) : AgentScriptStep;
+
+/// <summary>
+/// Delays script execution.
+/// </summary>
+/// <param name="Duration">The delay duration.</param>
+public sealed record DelayStep(TimeSpan Duration) : AgentScriptStep;
+
+/// <summary>
+/// Represents a script run result.
+/// </summary>
+/// <param name="Success">A value indicating whether all steps passed.</param>
+/// <param name="ExecutionId">The optional evidence execution id.</param>
+/// <param name="Steps">The per-step results.</param>
+public sealed record AgentScriptResult(bool Success, string? ExecutionId, IReadOnlyList<AgentScriptStepResult> Steps);
+
+/// <summary>
+/// Represents one script step result.
+/// </summary>
+/// <param name="Index">The zero-based step index.</param>
+/// <param name="Step">The step type.</param>
+/// <param name="Success">A value indicating whether the step passed.</param>
+/// <param name="Error">The error message, when any.</param>
+/// <param name="Duration">The elapsed step duration.</param>
+public sealed record AgentScriptStepResult(int Index, string Step, bool Success, string? Error, TimeSpan Duration);
+
+/// <summary>
+/// Runs deterministic scripts with command invocation, idle waits, assertions, and evidence capture.
+/// </summary>
+public sealed class AgentScriptRunner
+{
+    private readonly IAgentCommandRegistry _commands;
+    private readonly ICurrentViewModelProvider _currentViewModelProvider;
+    private readonly UiActivityTracker _activityTracker;
+    private readonly IAgentStateProvider _stateProvider;
+    private readonly IAgentScreenshotService? _screenshotService;
+    private readonly AgentExecutionRecorder? _executionRecorder;
+    private readonly ScreenshotPolicy _screenshotPolicy;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AgentScriptRunner"/> class.
+    /// </summary>
+    /// <param name="commands">The command registry.</param>
+    /// <param name="currentViewModelProvider">The current view model provider.</param>
+    /// <param name="activityTracker">The activity tracker.</param>
+    /// <param name="stateProvider">The state provider.</param>
+    /// <param name="screenshotService">The optional screenshot service.</param>
+    /// <param name="executionRecorder">The optional execution recorder.</param>
+    /// <param name="screenshotPolicy">The screenshot policy.</param>
+    public AgentScriptRunner(
+        IAgentCommandRegistry commands,
+        ICurrentViewModelProvider currentViewModelProvider,
+        UiActivityTracker activityTracker,
+        IAgentStateProvider stateProvider,
+        IAgentScreenshotService? screenshotService = null,
+        AgentExecutionRecorder? executionRecorder = null,
+        ScreenshotPolicy? screenshotPolicy = null)
+    {
+        _commands = commands ?? throw new ArgumentNullException(nameof(commands));
+        _currentViewModelProvider = currentViewModelProvider ?? throw new ArgumentNullException(nameof(currentViewModelProvider));
+        _activityTracker = activityTracker ?? throw new ArgumentNullException(nameof(activityTracker));
+        _stateProvider = stateProvider ?? throw new ArgumentNullException(nameof(stateProvider));
+        _screenshotService = screenshotService;
+        _executionRecorder = executionRecorder;
+        _screenshotPolicy = screenshotPolicy ?? new ScreenshotPolicy();
+    }
+
+    /// <summary>
+    /// Runs a script.
+    /// </summary>
+    /// <param name="script">The script.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The script result.</returns>
+    public async Task<AgentScriptResult> RunAsync(AgentScript script, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(script);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(script.Timeout);
+
+        AgentExecution? execution = _executionRecorder?.Start(script.Name);
+        var results = new List<AgentScriptStepResult>(script.Steps.Count);
+
+        for (var i = 0; i < script.Steps.Count; i++)
+        {
+            var step = script.Steps[i];
+            var startedAt = DateTimeOffset.UtcNow;
+
+            try
+            {
+                if (_screenshotPolicy.BeforeEachStep)
+                {
+                    await CaptureScreenshotAsync(execution?.Id, $"before-step-{i}", timeout.Token).ConfigureAwait(false);
+                }
+
+                await ExecuteStepAsync(step, execution?.Id, timeout.Token).ConfigureAwait(false);
+
+                if (_screenshotPolicy.AfterEachStep)
+                {
+                    await CaptureScreenshotAsync(execution?.Id, $"after-step-{i}", timeout.Token).ConfigureAwait(false);
+                }
+
+                _executionRecorder?.RecordEvent(execution!.Id, "step.completed", step.GetType().Name);
+                results.Add(new AgentScriptStepResult(i, step.GetType().Name, true, null, DateTimeOffset.UtcNow - startedAt));
+            }
+            catch (Exception ex)
+            {
+                if (_screenshotPolicy.OnFailure)
+                {
+                    await CaptureScreenshotAsync(execution?.Id, $"failure-step-{i}", CancellationToken.None).ConfigureAwait(false);
+                }
+
+                if (execution is not null)
+                {
+                    _executionRecorder?.RecordEvent(execution.Id, "step.failed", ex.Message);
+                    _executionRecorder?.Stop(execution.Id);
+                }
+
+                results.Add(new AgentScriptStepResult(i, step.GetType().Name, false, ex.Message, DateTimeOffset.UtcNow - startedAt));
+                return new AgentScriptResult(false, execution?.Id, results);
+            }
+        }
+
+        if (execution is not null)
+        {
+            _executionRecorder?.Stop(execution.Id);
+        }
+
+        return new AgentScriptResult(true, execution?.Id, results);
+    }
+
+    private async Task ExecuteStepAsync(AgentScriptStep step, string? executionId, CancellationToken cancellationToken)
+    {
+        switch (step)
+        {
+            case InvokeCommandStep invoke:
+                await _commands.InvokeAsync(invoke.Command, _currentViewModelProvider.CurrentViewModel, invoke.Input, cancellationToken).ConfigureAwait(false);
+                await _activityTracker.WaitForIdleAsync(TimeSpan.FromSeconds(30), cancellationToken).ConfigureAwait(false);
+                break;
+            case WaitIdleStep wait:
+                await _activityTracker.WaitForIdleAsync(wait.Timeout, cancellationToken).ConfigureAwait(false);
+                break;
+            case AssertStateStep assert:
+                await AssertStateAsync(assert, cancellationToken).ConfigureAwait(false);
+                if (_screenshotPolicy.OnNavigation && assert.Route is not null)
+                {
+                    await CaptureScreenshotAsync(executionId, $"navigation-{assert.Route}", cancellationToken).ConfigureAwait(false);
+                }
+
+                break;
+            case ScreenshotStep screenshot:
+                await CaptureScreenshotAsync(executionId, screenshot.Name, cancellationToken).ConfigureAwait(false);
+                break;
+            case DelayStep delay:
+                await Task.Delay(delay.Duration, cancellationToken).ConfigureAwait(false);
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported script step '{step.GetType().Name}'.");
+        }
+    }
+
+    private async Task AssertStateAsync(AssertStateStep assert, CancellationToken cancellationToken)
+    {
+        var snapshot = await _stateProvider.GetSnapshotAsync(cancellationToken).ConfigureAwait(false);
+
+        if (assert.Route is not null && !StringComparer.Ordinal.Equals(snapshot.Route, assert.Route))
+        {
+            throw new InvalidOperationException($"Expected route '{assert.Route}', got '{snapshot.Route}'.");
+        }
+
+        if (assert.State is null)
+        {
+            return;
+        }
+
+        foreach (var expected in assert.State)
+        {
+            if (!snapshot.State.TryGetValue(expected.Key, out var actual))
+            {
+                throw new InvalidOperationException($"Missing state key '{expected.Key}'.");
+            }
+
+            if (actual.GetRawText() != expected.Value.GetRawText())
+            {
+                throw new InvalidOperationException($"State mismatch for '{expected.Key}'. Expected {expected.Value.GetRawText()}, got {actual.GetRawText()}.");
+            }
+        }
+    }
+
+    private async Task CaptureScreenshotAsync(string? executionId, string name, CancellationToken cancellationToken)
+    {
+        if (_screenshotService is null || executionId is null)
+        {
+            return;
+        }
+
+        var path = await _screenshotService.CaptureMainWindowAsync(executionId, name, cancellationToken).ConfigureAwait(false);
+        _executionRecorder?.RecordArtifact(executionId, "screenshot", path, name);
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentServiceCollectionExtensions.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Registers agent bridge services for ReactiveUI applications.
+/// </summary>
+public static class AgentServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds the core agent bridge services: command registry, activity tracker, execution recorder, and scenario recorder.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configureRegistry">An optional registry configuration callback.</param>
+    /// <returns>The service collection.</returns>
+    public static IServiceCollection AddDockAgentBridge(
+        this IServiceCollection services,
+        Action<IServiceProvider, AgentCommandRegistry>? configureRegistry = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddSingleton<UiActivityTracker>();
+        services.AddSingleton<AgentExecutionRecorder>();
+        services.AddSingleton<AgentScenarioRecorder>();
+        services.AddSingleton<AgentCommandRegistry>(provider =>
+        {
+            var registry = new AgentCommandRegistry(provider.GetRequiredService<UiActivityTracker>());
+            configureRegistry?.Invoke(provider, registry);
+            return registry;
+        });
+        services.AddSingleton<IAgentCommandRegistry>(provider => provider.GetRequiredService<AgentCommandRegistry>());
+
+        return services;
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/AgentState.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/AgentState.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Represents a deterministic snapshot of the agent-visible application state.
+/// </summary>
+/// <param name="Route">The current route or view model name.</param>
+/// <param name="State">The exported state values.</param>
+/// <param name="ActiveOperations">The active operation names.</param>
+public sealed record AgentStateSnapshot(
+    string? Route,
+    IReadOnlyDictionary<string, JsonElement> State,
+    IReadOnlyList<string> ActiveOperations);
+
+/// <summary>
+/// Produces current state snapshots for agent assertions and reports.
+/// </summary>
+public interface IAgentStateProvider
+{
+    /// <summary>
+    /// Gets a state snapshot.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The state snapshot.</returns>
+    Task<AgentStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Creates state snapshots from supplied delegates without reflection.
+/// </summary>
+public sealed class DelegateAgentStateProvider : IAgentStateProvider
+{
+    private readonly Func<string?> _getRoute;
+    private readonly Func<IReadOnlyDictionary<string, JsonElement>> _getState;
+    private readonly UiActivityTracker? _activityTracker;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegateAgentStateProvider"/> class.
+    /// </summary>
+    /// <param name="getRoute">The route provider.</param>
+    /// <param name="getState">The state provider.</param>
+    /// <param name="activityTracker">The optional activity tracker.</param>
+    public DelegateAgentStateProvider(
+        Func<string?> getRoute,
+        Func<IReadOnlyDictionary<string, JsonElement>> getState,
+        UiActivityTracker? activityTracker = null)
+    {
+        _getRoute = getRoute ?? throw new ArgumentNullException(nameof(getRoute));
+        _getState = getState ?? throw new ArgumentNullException(nameof(getState));
+        _activityTracker = activityTracker;
+    }
+
+    /// <inheritdoc />
+    public Task<AgentStateSnapshot> GetSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<string> activeOperations = _activityTracker?.ActiveOperations ?? Array.Empty<string>();
+        var snapshot = new AgentStateSnapshot(_getRoute(), _getState(), activeOperations);
+        return Task.FromResult(snapshot);
+    }
+}

--- a/src/Dock.Model.ReactiveUI.Services/Agent/UiActivityTracker.cs
+++ b/src/Dock.Model.ReactiveUI.Services/Agent/UiActivityTracker.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dock.Model.ReactiveUI.Services.Agent;
+
+/// <summary>
+/// Tracks asynchronous UI work so agents can wait for deterministic quiescence before reading state.
+/// </summary>
+public sealed class UiActivityTracker
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<Guid, string> _operations = new();
+    private readonly Func<CancellationToken, ValueTask>? _drainUiAsync;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UiActivityTracker"/> class.
+    /// </summary>
+    /// <param name="drainUiAsync">An optional host callback that drains the UI dispatcher/render queue.</param>
+    public UiActivityTracker(Func<CancellationToken, ValueTask>? drainUiAsync = null)
+    {
+        _drainUiAsync = drainUiAsync;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether tracked work is active.
+    /// </summary>
+    public bool IsBusy
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _operations.Count > 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets names of currently active operations.
+    /// </summary>
+    public string[] ActiveOperations
+    {
+        get
+        {
+            lock (_gate)
+            {
+                var names = new string[_operations.Count];
+                _operations.Values.CopyTo(names, 0);
+                return names;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Begins tracking a named operation.
+    /// </summary>
+    /// <param name="name">The operation name.</param>
+    /// <returns>A disposable that ends tracking.</returns>
+    public IDisposable Begin(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Operation name is required.", nameof(name));
+        }
+
+        var id = Guid.NewGuid();
+        lock (_gate)
+        {
+            _operations.Add(id, name);
+        }
+
+        return new ActivityScope(this, id);
+    }
+
+    /// <summary>
+    /// Waits until no tracked operations are active and the optional UI drain callback completes.
+    /// </summary>
+    /// <param name="timeout">The maximum wait duration.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A task that completes when the UI is idle.</returns>
+    public async Task WaitForIdleAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsBusy)
+            {
+                if (_drainUiAsync is not null)
+                {
+                    await _drainUiAsync(cancellationToken).ConfigureAwait(false);
+                }
+
+                if (!IsBusy)
+                {
+                    return;
+                }
+            }
+
+            if (stopwatch.Elapsed > timeout)
+            {
+                throw new TimeoutException($"UI did not become idle. Active: {string.Join(", ", ActiveOperations)}");
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(25), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private void End(Guid id)
+    {
+        lock (_gate)
+        {
+            _operations.Remove(id);
+        }
+    }
+
+    private sealed class ActivityScope : IDisposable
+    {
+        private readonly UiActivityTracker _owner;
+        private readonly Guid _id;
+        private bool _disposed;
+
+        public ActivityScope(UiActivityTracker owner, Guid id)
+        {
+            _owner = owner;
+            _id = id;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _owner.End(_id);
+        }
+    }
+}

--- a/tests/Dock.Model.ReactiveUI.UnitTests/Agent/AgentBridgeTests.cs
+++ b/tests/Dock.Model.ReactiveUI.UnitTests/Agent/AgentBridgeTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Dock.Model.ReactiveUI.Services.Agent;
+using ReactiveUI;
+using System.Reactive;
+using Xunit;
+
+namespace Dock.Model.ReactiveUI.UnitTests.Agent;
+
+public sealed class AgentBridgeTests
+{
+    [Fact]
+    public async Task Registry_lists_and_invokes_registered_reactive_command()
+    {
+        var viewModel = new TestViewModel();
+        var tracker = new UiActivityTracker();
+        var registry = new AgentCommandRegistry(tracker);
+        registry.Register<TestViewModel, string, string>(
+            "test.echo",
+            "Echo",
+            "Echoes input for an agent.",
+            vm => vm.Echo,
+            requiresIdleAfterInvoke: true);
+
+        var commands = await registry.GetAvailableCommandsAsync(viewModel);
+        var input = JsonSerializer.SerializeToElement("hello");
+        var result = await registry.InvokeAsync("test.echo", viewModel, input);
+
+        Assert.Single(commands);
+        Assert.Equal("test.echo", commands[0].Id);
+        Assert.True(commands[0].CanExecute);
+        Assert.False(commands[0].IsExecuting);
+        Assert.Equal("hello", result);
+        Assert.Equal("hello", viewModel.LastEcho);
+    }
+
+    [Fact]
+    public async Task Script_runner_records_evidence_and_stops_on_assertion_failure()
+    {
+        var viewModel = new TestViewModel();
+        var current = new TestCurrentViewModelProvider(viewModel);
+        var tracker = new UiActivityTracker();
+        var registry = new AgentCommandRegistry(tracker);
+        registry.Register<TestViewModel, Unit, Unit>(
+            "test.mark",
+            "Mark",
+            "Marks the view model.",
+            vm => vm.Mark);
+
+        var state = new DelegateAgentStateProvider(
+            () => "TestViewModel",
+            () => new Dictionary<string, JsonElement>
+            {
+                ["marked"] = JsonSerializer.SerializeToElement(viewModel.Marked)
+            },
+            tracker);
+        var recorder = new AgentExecutionRecorder();
+        var screenshots = new TestScreenshotService();
+        var runner = new AgentScriptRunner(
+            registry,
+            current,
+            tracker,
+            state,
+            screenshots,
+            recorder,
+            new ScreenshotPolicy(AfterEachStep: false, OnFailure: true));
+        var expected = new Dictionary<string, JsonElement>
+        {
+            ["marked"] = JsonSerializer.SerializeToElement(false)
+        };
+        var script = new AgentScript(
+            "failing-script",
+            TimeSpan.FromSeconds(10),
+            new AgentScriptStep[]
+            {
+                new InvokeCommandStep("test.mark"),
+                new AssertStateStep("TestViewModel", expected)
+            });
+
+        var result = await runner.RunAsync(script);
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.ExecutionId);
+        Assert.Equal(2, result.Steps.Count);
+        Assert.False(result.Steps[1].Success);
+        Assert.Single(screenshots.Captured);
+        Assert.Contains("failure-step-1", screenshots.Captured[0], StringComparison.Ordinal);
+        Assert.Contains(recorder.Get(result.ExecutionId!).Artifacts, artifact => artifact.Kind == "screenshot");
+    }
+
+    [Fact]
+    public async Task Scenario_recorder_and_replayer_use_semantic_steps_and_automation_ids()
+    {
+        var viewModel = new TestViewModel();
+        var current = new TestCurrentViewModelProvider(viewModel);
+        var tracker = new UiActivityTracker();
+        var registry = new AgentCommandRegistry(tracker);
+        registry.Register<TestViewModel, string, string>(
+            "test.echo",
+            "Echo",
+            "Echoes input for an agent.",
+            vm => vm.Echo);
+        var state = new DelegateAgentStateProvider(
+            () => viewModel.Route,
+            () => new Dictionary<string, JsonElement>(),
+            tracker);
+        var automation = new TestAutomationInvoker();
+        var recorder = new AgentScenarioRecorder(TimeSpan.FromMilliseconds(1));
+        recorder.Start();
+        recorder.RecordSetText("SearchTextBox", "abc");
+        recorder.RecordCommand("test.echo", JsonSerializer.SerializeToElement("from-command"));
+        recorder.Record(new RecordedAssertRouteStep("Ready"));
+        var scenario = recorder.Stop("recorded");
+        var replayer = new AgentScenarioReplayer(registry, current, automation, tracker, state);
+
+        await replayer.ReplayAsync(scenario);
+
+        Assert.Equal("abc", automation.TextValues["SearchTextBox"]);
+        Assert.Equal("from-command", viewModel.LastEcho);
+        Assert.False(recorder.IsRecording);
+    }
+
+    private sealed class TestViewModel
+    {
+        public TestViewModel()
+        {
+            Echo = ReactiveCommand.Create<string, string>(value =>
+            {
+                LastEcho = value;
+                return value;
+            });
+            Mark = ReactiveCommand.Create(() =>
+            {
+                Marked = true;
+                return Unit.Default;
+            });
+        }
+
+        public ReactiveCommand<string, string> Echo { get; }
+
+        public ReactiveCommand<Unit, Unit> Mark { get; }
+
+        public string Route { get; } = "Ready";
+
+        public string? LastEcho { get; private set; }
+
+        public bool Marked { get; private set; }
+    }
+
+    private sealed class TestCurrentViewModelProvider : ICurrentViewModelProvider
+    {
+        public TestCurrentViewModelProvider(object? currentViewModel)
+        {
+            CurrentViewModel = currentViewModel;
+        }
+
+        public object? CurrentViewModel { get; }
+    }
+
+    private sealed class TestScreenshotService : IAgentScreenshotService
+    {
+        public List<string> Captured { get; } = new();
+
+        public Task<string> CaptureMainWindowAsync(string executionId, string name, CancellationToken cancellationToken = default)
+        {
+            var path = $"/{executionId}/{name}.png";
+            Captured.Add(path);
+            return Task.FromResult(path);
+        }
+    }
+
+    private sealed class TestAutomationInvoker : IAutomationControlInvoker
+    {
+        public Dictionary<string, string> TextValues { get; } = new(StringComparer.Ordinal);
+
+        public Task ClickAsync(string automationId, CancellationToken cancellationToken = default)
+        {
+            TextValues[automationId] = "clicked";
+            return Task.CompletedTask;
+        }
+
+        public Task SetTextAsync(string automationId, string value, CancellationToken cancellationToken = default)
+        {
+            TextValues[automationId] = value;
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose ReactiveUI `ReactiveCommand` semantics as a deterministic agent surface so tools/agents can discover and invoke ViewModel commands reliably.
- Provide a robust async/operation model and quiescence tracking so long-running UI work can be awaited and verified before assertions or screenshots.
- Capture execution evidence (screenshots, artifacts, timeline events) to make agent runs auditable and debuggable. 
- Record and replay semantic scenarios (commands + AutomationId interactions) for deterministic regression flows and agent guidance.

### Description
- Added an agent bridge surface under `Dock.Model.ReactiveUI.Services.Agent` including `AgentCommandRegistry`, `AgentCommandDescriptor`, `AgentJsonSchemas`, and `IAgentCommandRegistry` for registering/discovering/invoking strongly-typed `ReactiveCommand<TIn,TOut>` bindings. 
- Implemented `UiActivityTracker`, `AgentOperationRunner`, `IAgentInstructionPlanner` and related types to run natural-language/planned operations with pollable `AgentOperationSnapshot`s and idle waits. 
- Added deterministic scenario scripting and runner (`AgentScript`, `AgentScriptRunner`, `InvokeCommandStep`, `WaitIdleStep`, `AssertStateStep`, `ScreenshotStep`, etc.) with screenshot/evidence hooks and a `ScreenshotPolicy`. 
- Implemented execution evidence types and recorder (`AgentExecutionRecorder`) plus a screenshot service interface `IAgentScreenshotService` and an Avalonia implementation `AvaloniaScreenshotService` that renders the main window to timestamped PNG artifacts. 
- Added a scenario recorder and replayer (`AgentScenarioRecorder`, `AgentScenarioReplayer`) that capture semantic command invocations, `AutomationId` clicks/text edits, idle waits, and route assertions for later replay and normalization. 
- Provided DI helper `AddDockAgentBridge` and state provider `DelegateAgentStateProvider` for easy hosting, plus JSON input helpers and schema defaults. 
- Added unit tests `tests/Dock.Model.ReactiveUI.UnitTests/Agent/AgentBridgeTests.cs` covering command discovery/invocation, script evidence capture on failure, and scenario record/replay semantics. 

### Testing
- Ran a repository static check with `git diff --check` on the new agent and Avalonia agent files which reported no issues. 
- Attempted to run unit tests with `dotnet test tests/Dock.Model.ReactiveUI.UnitTests/Dock.Model.ReactiveUI.UnitTests.csproj --no-restore` but the environment lacks the `dotnet` CLI so tests could not be executed here. 
- Added xUnit tests that exercise `AgentCommandRegistry`, `AgentScriptRunner` evidence capture, and `AgentScenarioRecorder`/`AgentScenarioReplayer`, which are expected to pass when run in a full .NET SDK environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ae576147c8321a41101ab7e648c69)