### PR TITLE
Fix quick-start Dock documentation

### DIFF
--- a/docfx/articles/dock-advanced.md
+++ b/docfx/articles/dock-advanced.md
@@ -122,7 +122,9 @@ With XAML binding:
 <DocumentDock ItemsSource="{Binding OpenFiles}">
     <DocumentDock.DocumentTemplate>
         <DocumentTemplate>
-            <TextEditor Text="{Binding Context.Content}" x:DataType="Document"/>
+            <ContentControl x:DataType="Document" DataContext="{Binding Context}">
+                <TextEditor x:DataType="models:FileModel" Text="{Binding Content}"/>
+            </ContentControl>
         </DocumentTemplate>
     </DocumentDock.DocumentTemplate>
 </DocumentDock>

--- a/docfx/articles/dock-content-guide.md
+++ b/docfx/articles/dock-content-guide.md
@@ -187,8 +187,12 @@ public class MainViewModel : INotifyPropertyChanged
               <StackPanel Margin="10" x:DataType="Document">
                 <TextBlock Text="Document Title:" FontWeight="Bold"/>
                 <TextBox Text="{Binding Title}" Margin="0,0,0,10"/>
-                <TextBlock Text="Content:" FontWeight="Bold"/>
-                <TextBox Text="{Binding Context.Content}" AcceptsReturn="True" Height="200" TextWrapping="Wrap"/>
+                <StackPanel DataContext="{Binding Context}">
+                  <StackPanel x:DataType="local:MyDocumentModel">
+                    <TextBlock Text="Content:" FontWeight="Bold"/>
+                    <TextBox Text="{Binding Content}" AcceptsReturn="True" Height="200" TextWrapping="Wrap"/>
+                  </StackPanel>
+                </StackPanel>
               </StackPanel>
             </DocumentTemplate>
           </DocumentDock.DocumentTemplate>
@@ -229,7 +233,7 @@ public class MainViewModel : INotifyPropertyChanged
    - `Name` → Alternative for title
    - `DisplayName` → Alternative for title  
    - `CanClose` → Whether the document can be closed
-6. **Data Context**: Your model object becomes the `Context` of the created `Document`/`Tool` and is accessible via `{Binding Context.PropertyName}`
+6. **Data Context**: Your model object becomes the `Context` of the created `Document`/`Tool`; for compiled bindings, rebind a subtree to `Context` and set `x:DataType` to the model type.
 
 ### Advanced Examples
 
@@ -253,14 +257,16 @@ public class FileModel
 <DocumentDock ItemsSource="{Binding OpenFiles}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
-      <Grid RowDefinitions="Auto,*,Auto" x:DataType="Document">
-        <TextBlock Grid.Row="0" Text="{Binding Context.Path}" FontSize="12" Opacity="0.7"/>
-        <TextBox Grid.Row="1" Text="{Binding Context.Content}" AcceptsReturn="True"/>
-        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-          <Button Content="Save" Command="{Binding Context.SaveCommand}" Margin="5"/>
-          <Button Content="Revert" Command="{Binding Context.RevertCommand}" Margin="5"/>
-        </StackPanel>
-      </Grid>
+      <ContentControl x:DataType="Document" DataContext="{Binding Context}">
+        <Grid RowDefinitions="Auto,*,Auto" x:DataType="local:FileModel">
+          <TextBlock Grid.Row="0" Text="{Binding Path}" FontSize="12" Opacity="0.7"/>
+          <TextBox Grid.Row="1" Text="{Binding Content}" AcceptsReturn="True"/>
+          <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="Save" Command="{Binding SaveCommand}" Margin="5"/>
+            <Button Content="Revert" Command="{Binding RevertCommand}" Margin="5"/>
+          </StackPanel>
+        </Grid>
+      </ContentControl>
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
 </DocumentDock>
@@ -532,7 +538,7 @@ var document = new Document
 
 **Solutions**:
 1. Ensure `DocumentTemplate` has proper `x:DataType="Document"` on the root element
-2. Access your model properties via `{Binding Context.PropertyName}` not `{Binding PropertyName}`
+2. For compiled bindings, rebind a subtree to `{Binding Context}` and set `x:DataType` to your model type
 3. Verify your model implements `INotifyPropertyChanged`
 4. Check that your collection items have the expected property names (Title, Name, etc.)
 
@@ -547,7 +553,9 @@ var document = new Document
 <DocumentTemplate>
   <StackPanel x:DataType="Document">
     <TextBlock Text="{Binding Title}"/>
-    <TextBlock Text="{Binding Context.Content}"/>
+    <StackPanel DataContext="{Binding Context}">
+      <TextBlock x:DataType="vm:MyDocumentModel" Text="{Binding Content}"/>
+    </StackPanel>
   </StackPanel>
 </DocumentTemplate>
 ```
@@ -750,25 +758,27 @@ public class FileManagerViewModel : INotifyPropertyChanged
     <DocumentDock ItemsSource="{Binding OpenFiles}">
       <DocumentDock.DocumentTemplate>
         <DocumentTemplate>
-          <Grid RowDefinitions="Auto,*,Auto" x:DataType="Document">
-            <!-- File path header -->
-            <TextBlock Grid.Row="0" Text="{Binding Context.FilePath}" 
-                       FontSize="10" Opacity="0.7" Margin="5"/>
-            
-            <!-- Main content editor -->
-            <TextBox Grid.Row="1" Text="{Binding Context.Content}" 
-                     AcceptsReturn="True" AcceptsTab="True"
-                     FontFamily="Consolas" Margin="5"/>
-            
-            <!-- Action buttons -->
-            <StackPanel Grid.Row="2" Orientation="Horizontal" 
-                        HorizontalAlignment="Right" Margin="5">
-              <Button Content="Save" Command="{Binding Context.SaveCommand}"
-                      IsEnabled="{Binding Context.IsModified}"/>
-              <Button Content="Save As" Command="{Binding Context.SaveAsCommand}"
-                      Margin="5,0,0,0"/>
-            </StackPanel>
-          </Grid>
+          <ContentControl x:DataType="Document" DataContext="{Binding Context}">
+            <Grid RowDefinitions="Auto,*,Auto" x:DataType="local:FileDocument">
+              <!-- File path header -->
+              <TextBlock Grid.Row="0" Text="{Binding FilePath}"
+                         FontSize="10" Opacity="0.7" Margin="5"/>
+
+              <!-- Main content editor -->
+              <TextBox Grid.Row="1" Text="{Binding Content}"
+                       AcceptsReturn="True" AcceptsTab="True"
+                       FontFamily="Consolas" Margin="5"/>
+
+              <!-- Action buttons -->
+              <StackPanel Grid.Row="2" Orientation="Horizontal"
+                          HorizontalAlignment="Right" Margin="5">
+                <Button Content="Save" Command="{Binding SaveCommand}"
+                        IsEnabled="{Binding IsModified}"/>
+                <Button Content="Save As" Command="{Binding SaveAsCommand}"
+                        Margin="5,0,0,0"/>
+              </StackPanel>
+            </Grid>
+          </ContentControl>
         </DocumentTemplate>
       </DocumentDock.DocumentTemplate>
     </DocumentDock>

--- a/docfx/articles/dock-faq.md
+++ b/docfx/articles/dock-faq.md
@@ -14,7 +14,9 @@ Use `ItemsSource` on `DocumentDock` and `ToolDock` for automatic source-backed d
     <DocumentTemplate>
       <StackPanel x:DataType="Document">
         <TextBlock Text="{Binding Title}"/>
-        <TextBox Text="{Binding Context.Content}"/>
+        <StackPanel DataContext="{Binding Context}">
+          <TextBox x:DataType="models:FileModel" Text="{Binding Content}"/>
+        </StackPanel>
       </StackPanel>
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
@@ -60,7 +62,7 @@ Use the `ItemsSource` property to bind your existing domain models directly:
 public class FileModel : INotifyPropertyChanged
 {
     public string Title { get; set; }      // Used for tab title
-    public string Content { get; set; }    // Accessible via Context.Content
+    public string Content { get; set; }    // Accessible through Document.Context
     public bool CanClose { get; set; }     // Controls if tab can be closed
 }
 
@@ -73,7 +75,9 @@ Then bind in XAML:
 <DocumentDock ItemsSource="{Binding OpenFiles}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
-      <TextBox x:DataType="Document" Text="{Binding Context.Content}"/>
+      <ContentControl x:DataType="Document" DataContext="{Binding Context}">
+        <TextBox x:DataType="models:FileModel" Text="{Binding Content}"/>
+      </ContentControl>
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
 </DocumentDock>

--- a/docfx/articles/dock-itemssource.md
+++ b/docfx/articles/dock-itemssource.md
@@ -103,7 +103,7 @@ Template selectors return template content for an item. They can return:
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <!-- fallback template for items not handled by selector -->
-      <TextBlock Text="{Binding Context.Title}" />
+      <TextBlock x:DataType="Document" Text="{Binding Title}" />
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
 </DocumentDock>
@@ -222,13 +222,17 @@ Bind the collection to `DocumentDock.ItemsSource` and define a `DocumentTemplate
         <TextBlock Text="Document Properties" FontWeight="Bold" Margin="0,0,0,10"/>
         
         <TextBlock Text="Title:" FontWeight="SemiBold"/>
-        <TextBox Text="{Binding Context.Title}" Margin="0,0,0,10"/>
+        <TextBox Text="{Binding Title}" Margin="0,0,0,10"/>
         
-        <TextBlock Text="Content:" FontWeight="SemiBold"/>
-        <TextBox Text="{Binding Context.Content}" 
-                 AcceptsReturn="True" 
-                 TextWrapping="Wrap"
-                 Height="200"/>
+        <StackPanel DataContext="{Binding Context}">
+          <StackPanel x:DataType="models:FileDocument">
+            <TextBlock Text="Content:" FontWeight="SemiBold"/>
+            <TextBox Text="{Binding Content}"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     Height="200"/>
+          </StackPanel>
+        </StackPanel>
       </StackPanel>
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
@@ -268,12 +272,15 @@ public class DocumentModel
 ```xaml
 <DocumentTemplate>
   <Grid x:DataType="Document">
-    <!-- Access your model properties via Context -->
-    <TextBlock Text="{Binding Context.Title}"/>
-    <TextBox Text="{Binding Context.Content}"/>
-    
-    <!-- You can also access Document properties directly -->
+    <!-- Access generated Document properties directly -->
     <TextBlock Text="{Binding Title}"/>
+
+    <!-- Rebind to the source model before using its properties -->
+    <StackPanel DataContext="{Binding Context}">
+      <StackPanel x:DataType="models:FileDocument">
+        <TextBox Text="{Binding Content}"/>
+      </StackPanel>
+    </StackPanel>
   </Grid>
 </DocumentTemplate>
 ```
@@ -398,14 +405,18 @@ public enum DocumentType
 <DocumentDock ItemsSource="{Binding Documents}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
-      <ContentControl x:DataType="Document">
-        <ContentControl.Content>
-          <MultiBinding Converter="{StaticResource DocumentTypeConverter}">
-            <Binding Path="Context.Type"/>
-            <Binding Path="Context.Data"/>
-          </MultiBinding>
-        </ContentControl.Content>
-      </ContentControl>
+      <StackPanel x:DataType="Document">
+        <StackPanel DataContext="{Binding Context}">
+          <ContentControl x:DataType="models:DocumentModel">
+            <ContentControl.Content>
+              <MultiBinding Converter="{StaticResource DocumentTypeConverter}">
+                <Binding Path="Type"/>
+                <Binding Path="Data"/>
+              </MultiBinding>
+            </ContentControl.Content>
+          </ContentControl>
+        </StackPanel>
+      </StackPanel>
     </DocumentTemplate>
   </DocumentDock.DocumentTemplate>
 </DocumentDock>

--- a/docfx/articles/dock-mvvm.md
+++ b/docfx/articles/dock-mvvm.md
@@ -56,7 +56,6 @@ The following steps walk you through creating a very small application that uses
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
    using CommunityToolkit.Mvvm.ComponentModel;
-   using Dock.Model.Core;
    using StaticViewLocator;
 
    namespace MyDockApp;
@@ -84,7 +83,7 @@ The following steps walk you through creating a very small application that uses
            }
 
            var type = data.GetType();
-           return data is IDockable || s_views.ContainsKey(type);
+           return s_views.ContainsKey(type);
        }
    }
    ```
@@ -95,7 +94,6 @@ The following steps walk you through creating a very small application that uses
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
 
    namespace MyDockApp;
 
@@ -106,13 +104,12 @@ The following steps walk you through creating a very small application that uses
            if (data is null)
                return null;
 
-           var name = data.GetType().FullName!.Replace("ViewModel", "View");
-           var type = Type.GetType(name);
+           var type = ResolveViewType(data.GetType());
 
            if (type != null)
                return (Control)Activator.CreateInstance(type)!;
 
-           return new TextBlock { Text = "Not Found: " + name };
+           return new TextBlock { Text = "Not Found: " + data.GetType().FullName };
        }
 
        public bool Match(object? data)
@@ -122,13 +119,22 @@ The following steps walk you through creating a very small application that uses
                return false;
            }
 
-           if (data is IDockable)
+           return ResolveViewType(data.GetType()) is not null;
+       }
+
+       private static Type? ResolveViewType(Type viewModelType)
+       {
+           var fullName = viewModelType.FullName;
+           if (fullName is null || !fullName.EndsWith("ViewModel", StringComparison.Ordinal))
            {
-               return true;
+               return null;
            }
 
-           var name = data.GetType().FullName?.Replace("ViewModel", "View");
-           return Type.GetType(name) is not null;
+           var viewName = fullName[..^"ViewModel".Length] + "View";
+           var assemblyQualifiedName = $"{viewName}, {viewModelType.Assembly.FullName}";
+           var type = Type.GetType(assemblyQualifiedName);
+
+           return type is not null && typeof(Control).IsAssignableFrom(type) ? type : null;
        }
    }
    ```
@@ -223,8 +229,12 @@ The following steps walk you through creating a very small application that uses
            <DocumentDock.DocumentTemplate>
                <DocumentTemplate>
                    <StackPanel Margin="10" x:DataType="Document">
-                       <TextBox Text="{Binding Context.Title}" Margin="0,0,0,10"/>
-                       <TextBox Text="{Binding Context.Content}" AcceptsReturn="True" Height="300"/>
+                       <TextBox Text="{Binding Title}" Margin="0,0,0,10"/>
+                       <StackPanel DataContext="{Binding Context}">
+                           <StackPanel x:DataType="models:FileDocumentModel">
+                               <TextBox Text="{Binding Content}" AcceptsReturn="True" Height="300"/>
+                           </StackPanel>
+                       </StackPanel>
                    </StackPanel>
                </DocumentTemplate>
            </DocumentDock.DocumentTemplate>

--- a/docfx/articles/dock-reactiveui.md
+++ b/docfx/articles/dock-reactiveui.md
@@ -60,7 +60,6 @@ Follow these instructions to create a minimal ReactiveUI based application using
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
    using ReactiveUI;
    using StaticViewLocator;
 
@@ -89,7 +88,7 @@ Follow these instructions to create a minimal ReactiveUI based application using
            }
 
            var type = data.GetType();
-           return data is IDockable || s_views.ContainsKey(type);
+           return s_views.ContainsKey(type);
        }
    }
    ```
@@ -101,7 +100,6 @@ Follow these instructions to create a minimal ReactiveUI based application using
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
    using ReactiveUI;
    using Microsoft.Extensions.DependencyInjection;
 
@@ -158,11 +156,6 @@ Follow these instructions to create a minimal ReactiveUI based application using
            if (data is null)
            {
                return false;
-           }
-
-           if (data is IDockable)
-           {
-               return true;
            }
 
            return Resolve(data) is not null;

--- a/docfx/articles/dock-xaml.md
+++ b/docfx/articles/dock-xaml.md
@@ -49,7 +49,6 @@ These steps outline how to set up a small Dock application that defines its layo
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
    using StaticViewLocator;
 
    namespace MyDockApp;
@@ -66,16 +65,18 @@ These steps outline how to set up a small Dock application that defines its layo
            if (s_views.TryGetValue(type, out var func))
                return func.Invoke();
 
-           // Fallback for simple content
-           if (data is string text)
-               return new TextBox { Text = text, AcceptsReturn = true };
-
-           return new TextBlock { Text = data.ToString() };
+           throw new Exception($"Unable to create view for type: {type}");
        }
 
        public bool Match(object? data)
        {
-           return data is IDockable || data != null;
+           if (data is null)
+           {
+               return false;
+           }
+
+           var type = data.GetType();
+           return s_views.ContainsKey(type);
        }
    }
    ```
@@ -160,8 +161,12 @@ These steps outline how to set up a small Dock application that defines its layo
                        <StackPanel Margin="10" x:DataType="Document">
                            <TextBlock Text="Title:" FontWeight="Bold"/>
                            <TextBox Text="{Binding Title}" Margin="0,0,0,10"/>
-                           <TextBlock Text="Content:" FontWeight="Bold"/>
-                           <TextBox Text="{Binding Context.Content}" AcceptsReturn="True" Height="200"/>
+                           <StackPanel DataContext="{Binding Context}">
+                               <StackPanel x:DataType="local:FileDocument">
+                                   <TextBlock Text="Content:" FontWeight="Bold"/>
+                                   <TextBox Text="{Binding Content}" AcceptsReturn="True" Height="200"/>
+                               </StackPanel>
+                           </StackPanel>
                        </StackPanel>
                    </DocumentTemplate>
                </DocumentDock.DocumentTemplate>

--- a/docfx/articles/quick-start.md
+++ b/docfx/articles/quick-start.md
@@ -49,7 +49,7 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
 
 3. **Set up View Templates (Optional)**
 
-   If you rely on view models via `Context`, register a view locator or data templates for your document and tool views. If you define `Document.Content` or use `DocumentTemplate` in XAML, you can skip this step.
+   If you rely on view models via `Context`, register a view locator or data templates for your document and tool views. If you define `Document.Content` or use `DocumentTemplate` in XAML, skip this step; the template supplies the document content directly.
 
    **Option A: Static View Locator with Source Generators (Recommended)**
 
@@ -63,7 +63,6 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
    using StaticViewLocator;
 
    namespace DockQuickStart;
@@ -91,7 +90,7 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
            }
 
            var type = data.GetType();
-           return data is IDockable || s_views.ContainsKey(type);
+           return s_views.ContainsKey(type);
        }
    }
    ```
@@ -102,7 +101,6 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    using System;
    using Avalonia.Controls;
    using Avalonia.Controls.Templates;
-   using Dock.Model.Core;
 
    namespace DockQuickStart;
 
@@ -113,13 +111,12 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
            if (data is null)
                return null;
 
-           var name = data.GetType().FullName!.Replace("ViewModel", "View");
-           var type = Type.GetType(name);
+           var type = ResolveViewType(data.GetType());
 
            if (type != null)
                return (Control)Activator.CreateInstance(type)!;
 
-           return new TextBlock { Text = "Not Found: " + name };
+           return new TextBlock { Text = "Not Found: " + data.GetType().FullName };
        }
 
        public bool Match(object? data)
@@ -129,20 +126,29 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
                return false;
            }
 
-           if (data is IDockable)
+           return ResolveViewType(data.GetType()) is not null;
+       }
+
+       private static Type? ResolveViewType(Type viewModelType)
+       {
+           var fullName = viewModelType.FullName;
+           if (fullName is null || !fullName.EndsWith("ViewModel", StringComparison.Ordinal))
            {
-               return true;
+               return null;
            }
 
-           var name = data.GetType().FullName?.Replace("ViewModel", "View");
-           return Type.GetType(name) is not null;
+           var viewName = fullName[..^"ViewModel".Length] + "View";
+           var assemblyQualifiedName = $"{viewName}, {viewModelType.Assembly.FullName}";
+           var type = Type.GetType(assemblyQualifiedName);
+
+           return type is not null && typeof(Control).IsAssignableFrom(type) ? type : null;
        }
    }
    ```
 
 4. **Add Dock styles (and View Locator if used)**
 
-   Reference the theme and register the view locator in `App.axaml` if you use one:
+   Reference the theme in `App.axaml`. Register the view locator only if you use one; omit `Application.DataTemplates` for the `ItemsSource` + `DocumentTemplate` example below.
 
    ```xaml
    <Application xmlns="https://github.com/avaloniaui"
@@ -150,6 +156,7 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
                 xmlns:local="using:DockQuickStart"
                 x:Class="DockQuickStart.App">
 
+     <!-- Include only if you created a ViewLocator in step 3. -->
      <Application.DataTemplates>
        <local:ViewLocator />
      </Application.DataTemplates>
@@ -256,21 +263,35 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    <Window x:Class="DockQuickStart.MainWindow"
            xmlns="https://github.com/avaloniaui"
            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-           xmlns:dock="https://github.com/avaloniaui">
-   <DockControl InitializeLayout="True" InitializeFactory="True">
-       <DockControl.Factory>
-           <Factory />
-       </DockControl.Factory>
-       <RootDock>
-           <DocumentDock ItemsSource="{Binding Documents}">
-               <DocumentDock.DocumentTemplate>
-                   <DocumentTemplate>
-                       <TextBox Text="{Binding Context.Content}" AcceptsReturn="True" />
-                   </DocumentTemplate>
-               </DocumentDock.DocumentTemplate>
-           </DocumentDock>
-       </RootDock>
-   </DockControl>
+           xmlns:dock="using:Dock.Avalonia.Controls"
+           xmlns:dockFactory="using:Dock.Model.Avalonia"
+           xmlns:dockModel="using:Dock.Model.Avalonia.Controls"
+           xmlns:models="using:DockQuickStart"
+           xmlns:vm="using:DockQuickStart"
+           x:DataType="vm:MainWindowViewModel">
+   <dock:DockControl InitializeLayout="True" InitializeFactory="True">
+       <dock:DockControl.Factory>
+           <dockFactory:Factory />
+       </dock:DockControl.Factory>
+       <dockModel:RootDock>
+           <dockModel:DocumentDock ItemsSource="{Binding Documents}">
+               <dockModel:DocumentDock.DocumentTemplate>
+                   <dockModel:DocumentTemplate>
+                       <StackPanel x:DataType="dockModel:Document" Margin="10">
+                           <TextBlock Text="{Binding Title}" />
+                           <StackPanel DataContext="{Binding Context}">
+                               <StackPanel x:DataType="models:FileDocument">
+                                   <TextBox Text="{Binding Content}"
+                                            AcceptsReturn="True"
+                                            TextWrapping="Wrap" />
+                               </StackPanel>
+                           </StackPanel>
+                       </StackPanel>
+                   </dockModel:DocumentTemplate>
+               </dockModel:DocumentDock.DocumentTemplate>
+           </dockModel:DocumentDock>
+       </dockModel:RootDock>
+   </dock:DockControl>
    </Window>
    ```
 


### PR DESCRIPTION
## Summary

- Update the quick-start `ItemsSource` / `DocumentTemplate` example to use `Dock.Model.Avalonia`, explicit Dock namespaces, and compiled-binding-safe source model rebinding.
- Clarify that the optional app-level `ViewLocator` should be skipped for `DocumentTemplate` content and tighten locator examples so they do not match arbitrary `IDockable` instances without a matching view.
- Align related ItemsSource examples in the XAML, MVVM, ReactiveUI, content, FAQ, and advanced docs to avoid direct `Context.*` compiled bindings.

## Root Cause

The previous quick-start combined an `ItemsSource` generated `Document` with a direct `{Binding Context.Content}` expression inside a compiled-binding scope. `Document.Context` is typed as `object?`, so the model property is not available to compiled bindings unless the template rebinds to the source model with a concrete `x:DataType`.

The optional convention `ViewLocator` examples also matched `IDockable` broadly. In the reported project that allowed non-view-model values, including `System.String`, to be routed through the locator and instantiated as controls.

Fixes #1098.

## Validation

- `git diff --check -- docfx/articles/quick-start.md docfx/articles/dock-itemssource.md docfx/articles/dock-xaml.md docfx/articles/dock-mvvm.md docfx/articles/dock-reactiveui.md docfx/articles/dock-content-guide.md docfx/articles/dock-faq.md docfx/articles/dock-advanced.md`
- Markdown fence balance check over the touched docs.
- `./check-docs.sh` could not run because `global.json` pins SDK `10.0.200` with roll-forward disabled, while this machine has SDK `10.0.201`.