### PR TITLE
Fix ItemsSource docs and add quick start sample

### DIFF
--- a/Dock.slnx
+++ b/Dock.slnx
@@ -55,6 +55,7 @@
     <Project Path="samples/DockFigmaSample/DockFigmaSample.csproj" />
     <Project Path="samples/DockFluentCodeOnlySample/DockFluentCodeOnlySample.csproj" />
     <Project Path="samples/DockInpcSample/DockInpcSample.csproj" />
+    <Project Path="samples/DockQuickStartSample/DockQuickStartSample.csproj" />
     <Project Path="samples/DockMvvmSample/DockMvvmSample.csproj" />
     <Project Path="samples/DockPrismSample/DockPrismSample.csproj" />
     <Project Path="samples/DockReactivePropertySample/DockReactivePropertySample.csproj" />

--- a/docfx/articles/dock-advanced.md
+++ b/docfx/articles/dock-advanced.md
@@ -118,8 +118,11 @@ OpenFiles.Remove(fileToClose);
 ```
 
 With XAML binding:
+
+The examples below assume the containing window is named `RootWindow` and the view model namespace is imported as `vm`.
+
 ```xaml
-<DocumentDock ItemsSource="{Binding OpenFiles}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).OpenFiles}">
     <DocumentDock.DocumentTemplate>
         <DocumentTemplate>
             <ContentControl x:DataType="Document" DataContext="{Binding Context}">
@@ -133,7 +136,7 @@ With XAML binding:
 Tool panes can be generated the same way:
 
 ```xaml
-<ToolDock ItemsSource="{Binding OpenTools}" Alignment="Left">
+<ToolDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).OpenTools}" Alignment="Left">
     <ToolDock.ToolTemplate>
         <ToolTemplate>
             <TextBlock Text="{Binding Context.Description}" x:DataType="Tool"/>

--- a/docfx/articles/dock-content-guide.md
+++ b/docfx/articles/dock-content-guide.md
@@ -157,7 +157,9 @@ public class MainViewModel : INotifyPropertyChanged
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="using:YourApp"
-             x:Class="YourApp.ItemsSourceExample">
+             x:Class="YourApp.ItemsSourceExample"
+             x:Name="RootView"
+             x:DataType="local:MainViewModel">
 
   <UserControl.DataContext>
     <local:MainViewModel />
@@ -179,7 +181,7 @@ public class MainViewModel : INotifyPropertyChanged
       <RootDock Id="Root" IsCollapsable="False">
         <DocumentDock Id="DocumentsPane" 
                       CanCreateDocument="True"
-                      ItemsSource="{Binding Documents}">
+                      ItemsSource="{Binding #RootView.((local:MainViewModel)DataContext).Documents}">
           
           <!-- Define how each document should be displayed -->
           <DocumentDock.DocumentTemplate>
@@ -207,7 +209,9 @@ public class MainViewModel : INotifyPropertyChanged
 ### Step 4: Bind to ToolDock in XAML
 
 ```xaml
-<ToolDock Id="ToolsPane" Alignment="Left" ItemsSource="{Binding Tools}">
+<ToolDock Id="ToolsPane"
+          Alignment="Left"
+          ItemsSource="{Binding #RootView.((local:MainViewModel)DataContext).Tools}">
   <ToolDock.ToolTemplate>
     <ToolTemplate>
       <StackPanel Margin="10" x:DataType="Tool">
@@ -254,7 +258,7 @@ public class FileModel
 #### With Commands and Interactions
 
 ```xaml
-<DocumentDock ItemsSource="{Binding OpenFiles}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).OpenFiles}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <ContentControl x:DataType="Document" DataContext="{Binding Context}">
@@ -755,7 +759,7 @@ public class FileManagerViewModel : INotifyPropertyChanged
   </DockControl.Factory>
   
   <RootDock>
-    <DocumentDock ItemsSource="{Binding OpenFiles}">
+    <DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).OpenFiles}">
       <DocumentDock.DocumentTemplate>
         <DocumentTemplate>
           <ContentControl x:DataType="Document" DataContext="{Binding Context}">

--- a/docfx/articles/dock-content-guide.md
+++ b/docfx/articles/dock-content-guide.md
@@ -180,7 +180,7 @@ public class MainViewModel : INotifyPropertyChanged
 
       <RootDock Id="Root" IsCollapsable="False">
         <DocumentDock Id="DocumentsPane" 
-                      CanCreateDocument="True"
+                      CanCreateDocument="False"
                       ItemsSource="{Binding #RootView.((local:MainViewModel)DataContext).Documents}">
           
           <!-- Define how each document should be displayed -->

--- a/docfx/articles/dock-content-wrapper-pattern.md
+++ b/docfx/articles/dock-content-wrapper-pattern.md
@@ -10,9 +10,11 @@ This guide covers an advanced pattern for wrapping your own domain models with D
 
 Before implementing the wrapper pattern below, consider using `ItemsSource` which provides automatic domain model binding:
 
+Name the root window `RootWindow` and import the view model namespace as `vm` when using this fragment in compiled-binding XAML.
+
 ```xaml
 <!-- Modern approach with ItemsSource -->
-<DocumentDock ItemsSource="{Binding SceneDocuments}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).SceneDocuments}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <views:SceneView DataContext="{Binding Context}" />

--- a/docfx/articles/dock-faq.md
+++ b/docfx/articles/dock-faq.md
@@ -8,8 +8,10 @@ This page answers common questions that come up when using Dock.
 
 Use `ItemsSource` on `DocumentDock` and `ToolDock` for automatic source-backed dockable management:
 
+If the dock is declared under `RootDock`, bind `ItemsSource` through a named root such as `RootWindow` so compiled bindings read the window view model instead of the Dock model object.
+
 ```xaml
-<DocumentDock ItemsSource="{Binding Documents}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <StackPanel x:DataType="Document">
@@ -72,7 +74,7 @@ public ObservableCollection<FileModel> OpenFiles { get; } = new();
 
 Then bind in XAML:
 ```xaml
-<DocumentDock ItemsSource="{Binding OpenFiles}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).OpenFiles}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <ContentControl x:DataType="Document" DataContext="{Binding Context}">

--- a/docfx/articles/dock-itemssource.md
+++ b/docfx/articles/dock-itemssource.md
@@ -56,11 +56,11 @@ Control whether closing a generated container removes the source item:
 - Per-tool dock override: `ToolDock.CanUpdateItemsSourceOnUnregister` (`bool?`, `null` = global)
 
 ```xaml
-<DocumentDock ItemsSource="{Binding Documents}"
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}"
               CanUpdateItemsSourceOnUnregister="False" />
 
-<ToolDock ItemsSource="{Binding Tools}"
-          CanUpdateItemsSourceOnUnregister="{Binding ToolUnregisterPolicy}" />
+<ToolDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Tools}"
+          CanUpdateItemsSourceOnUnregister="{Binding #RootWindow.((vm:MainViewModel)DataContext).ToolUnregisterPolicy}" />
 ```
 
 ## Per-Dock Theme and Template Selector APIs
@@ -97,7 +97,7 @@ Template selectors return template content for an item. They can return:
   </ControlTheme>
 </Window.Resources>
 
-<DocumentDock ItemsSource="{Binding Documents}"
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}"
               DocumentItemContainerTheme="GeneratedDocumentTheme"
               DocumentItemTemplateSelector="{StaticResource DocumentSelector}">
   <DocumentDock.DocumentTemplate>
@@ -215,7 +215,7 @@ public class MainViewModel : INotifyPropertyChanged
 Bind the collection to `DocumentDock.ItemsSource` and define a `DocumentTemplate`:
 
 ```xaml
-<DocumentDock ItemsSource="{Binding Documents}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <StackPanel Margin="10" x:DataType="Document">
@@ -238,6 +238,8 @@ Bind the collection to `DocumentDock.ItemsSource` and define a `DocumentTemplate
   </DocumentDock.DocumentTemplate>
 </DocumentDock>
 ```
+
+When `DocumentDock` is declared under `RootDock`, bind `ItemsSource` through an explicit named owner (`RootWindow` in this example). The Dock model tree has its own binding context at runtime, so a shorthand `ItemsSource="{Binding Documents}"` can make compiled bindings try to cast `RootDock` to your view model.
 
 ## Property Mapping
 
@@ -354,7 +356,8 @@ public class DataView : INotifyPropertyChanged
 Bind a tools collection to `ToolDock.ItemsSource` and define a `ToolTemplate`:
 
 ```xaml
-<ToolDock Alignment="Left" ItemsSource="{Binding Tools}">
+<ToolDock Alignment="Left"
+          ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Tools}">
   <ToolDock.ToolTemplate>
     <ToolTemplate>
       <StackPanel Margin="10" x:DataType="Tool">
@@ -402,7 +405,7 @@ public enum DocumentType
 ```
 
 ```xaml
-<DocumentDock ItemsSource="{Binding Documents}">
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}">
   <DocumentDock.DocumentTemplate>
     <DocumentTemplate>
       <StackPanel x:DataType="Document">
@@ -454,11 +457,11 @@ Assign the generator per dock:
   <local:MyGenerator x:Key="MyGenerator" />
 </Window.Resources>
 
-<ToolDock ItemsSource="{Binding Tools}"
+<ToolDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Tools}"
           ToolTemplate="{StaticResource ToolTemplate}"
           ItemContainerGenerator="{StaticResource MyGenerator}" />
 
-<DocumentDock ItemsSource="{Binding Documents}"
+<DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}"
               DocumentTemplate="{StaticResource DocumentTemplate}"
               ItemContainerGenerator="{StaticResource MyGenerator}" />
 ```
@@ -544,4 +547,5 @@ public class CommandDocument : INotifyPropertyChanged
 - [Document and Tool Content Guide](dock-content-guide.md) - Comprehensive content setup
 - [Dock Advanced Topics](dock-advanced.md) - Advanced docking scenarios
 - [Dock FAQ](dock-faq.md) - Common questions and troubleshooting
+- [`samples/DockQuickStartSample`](https://github.com/wieslawsoltes/Dock/tree/master/samples/DockQuickStartSample) - Minimal runnable XAML `ItemsSource` sample with compiled bindings
 - [`samples/DockXamlReactiveUISample`](https://github.com/wieslawsoltes/Dock/tree/master/samples/DockXamlReactiveUISample) - ReactiveUI sample using both document and tool items sources

--- a/docfx/articles/dock-mvvm.md
+++ b/docfx/articles/dock-mvvm.md
@@ -221,11 +221,11 @@ The following steps walk you through creating a very small application that uses
    }
    ```
 
-   Then use XAML with ItemsSource:
+   Then use XAML with ItemsSource. In a full window, name the root `RootWindow` and import the view model namespace as `vm` so the `ItemsSource` binding can explicitly read the window view model:
 
    ```xaml
    <DockControl>
-       <DocumentDock ItemsSource="{Binding Documents}">
+       <DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}">
            <DocumentDock.DocumentTemplate>
                <DocumentTemplate>
                    <StackPanel Margin="10" x:DataType="Document">

--- a/docfx/articles/dock-reference.md
+++ b/docfx/articles/dock-reference.md
@@ -220,6 +220,7 @@ In XAML you place `RootDock`, `ProportionalDock`, `ToolDock` or `DocumentDock` e
 
 **Sample applications:**
 - `samples/DockMvvmSample` – Full MVVM example with commands and data binding
+- `samples/DockQuickStartSample` – Minimal XAML `ItemsSource` quick-start with compiled bindings
 - `samples/DockReactiveUISample` – ReactiveUI variant with observables
 - `samples/DockXamlReactiveUISample` – ReactiveUI sample using both `DocumentDock.ItemsSource` and `ToolDock.ItemsSource`
 - `samples/DockReactiveUIWorkspaceSample` – ReactiveUI workspace snapshots and layout locking

--- a/docfx/articles/dock-xaml.md
+++ b/docfx/articles/dock-xaml.md
@@ -147,7 +147,7 @@ These steps outline how to set up a small Dock application that defines its layo
 
    **Option B: ItemsSource Data Binding (Recommended)**
 
-   For dynamic document management, use `ItemsSource` to bind to your data collections:
+   For dynamic document management, use `ItemsSource` to bind to your data collections. If this snippet is inside a window, name the window `RootWindow` and import the view model namespace as `vm`:
 
    ```xaml
    <DockControl InitializeLayout="True" InitializeFactory="True">
@@ -155,7 +155,7 @@ These steps outline how to set up a small Dock application that defines its layo
            <Factory />
        </DockControl.Factory>
        <RootDock>
-           <DocumentDock ItemsSource="{Binding Documents}">
+           <DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainViewModel)DataContext).Documents}">
                <DocumentDock.DocumentTemplate>
                    <DocumentTemplate>
                        <StackPanel Margin="10" x:DataType="Document">

--- a/docfx/articles/quick-start.md
+++ b/docfx/articles/quick-start.md
@@ -276,7 +276,8 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
            <dockFactory:Factory />
        </dock:DockControl.Factory>
        <dockModel:RootDock>
-           <dockModel:DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
+           <dockModel:DocumentDock CanCreateDocument="False"
+                                   ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
                <dockModel:DocumentDock.DocumentTemplate>
                    <dockModel:DocumentTemplate>
                        <StackPanel x:DataType="dockModel:Document" Margin="10">
@@ -297,6 +298,8 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    ```
 
    `RootDock` and `DocumentDock` are part of the Dock model tree, so their inherited binding context is a Dock model object, not your window view model. The explicit `#RootWindow.((vm:MainWindowViewModel)DataContext).Documents` source keeps compiled bindings from trying to cast a `RootDock` to `MainWindowViewModel`.
+
+   Keep `CanCreateDocument="False"` for source-backed documents unless you also provide a create path that adds a matching `FileDocument` to `MainWindowViewModel.Documents`.
 
    Initialize the view model from the application composition root (`App.axaml.cs`):
 

--- a/docfx/articles/quick-start.md
+++ b/docfx/articles/quick-start.md
@@ -203,6 +203,7 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    For more dynamic document management, use the ItemsSource approach. First, create a simple document model:
 
    ```csharp
+   using System.Collections.Generic;
    using System.ComponentModel;
    using System.Runtime.CompilerServices;
 
@@ -268,24 +269,24 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
            xmlns:dockModel="using:Dock.Model.Avalonia.Controls"
            xmlns:models="using:DockQuickStart"
            xmlns:vm="using:DockQuickStart"
+           x:Name="RootWindow"
            x:DataType="vm:MainWindowViewModel">
    <dock:DockControl InitializeLayout="True" InitializeFactory="True">
        <dock:DockControl.Factory>
            <dockFactory:Factory />
        </dock:DockControl.Factory>
        <dockModel:RootDock>
-           <dockModel:DocumentDock ItemsSource="{Binding Documents}">
+           <dockModel:DocumentDock ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
                <dockModel:DocumentDock.DocumentTemplate>
                    <dockModel:DocumentTemplate>
                        <StackPanel x:DataType="dockModel:Document" Margin="10">
                            <TextBlock Text="{Binding Title}" />
-                           <StackPanel DataContext="{Binding Context}">
-                               <StackPanel x:DataType="models:FileDocument">
-                                   <TextBox Text="{Binding Content}"
-                                            AcceptsReturn="True"
-                                            TextWrapping="Wrap" />
-                               </StackPanel>
-                           </StackPanel>
+                           <ContentControl DataContext="{Binding Context}">
+                               <TextBox x:DataType="models:FileDocument"
+                                        Text="{Binding Content}"
+                                        AcceptsReturn="True"
+                                        TextWrapping="Wrap" />
+                           </ContentControl>
                        </StackPanel>
                    </dockModel:DocumentTemplate>
                </dockModel:DocumentDock.DocumentTemplate>
@@ -295,7 +296,26 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    </Window>
    ```
 
-   Initialize the view model in `MainWindow.axaml.cs`:
+   `RootDock` and `DocumentDock` are part of the Dock model tree, so their inherited binding context is a Dock model object, not your window view model. The explicit `#RootWindow.((vm:MainWindowViewModel)DataContext).Documents` source keeps compiled bindings from trying to cast a `RootDock` to `MainWindowViewModel`.
+
+   Initialize the view model from the application composition root (`App.axaml.cs`):
+
+   ```csharp
+   public override void OnFrameworkInitializationCompleted()
+   {
+       if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+       {
+           desktop.MainWindow = new MainWindow
+           {
+               DataContext = new MainWindowViewModel()
+           };
+       }
+
+       base.OnFrameworkInitializationCompleted();
+   }
+   ```
+
+   Keep `MainWindow.axaml.cs` passive:
 
    ```csharp
    public partial class MainWindow : Window
@@ -303,7 +323,6 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
        public MainWindow()
        {
            InitializeComponent();
-           DataContext = new MainWindowViewModel();
        }
    }
    ```
@@ -331,7 +350,7 @@ This short guide shows how to set up Dock in a new Avalonia application. You wil
    <DockControl x:Name="Dock" />
    ```
 
-   > **💡 Tip**: The ItemsSource approach (Option B) is recommended for most scenarios as it provides automatic document management, data binding, and easier maintenance. See the [DocumentDock ItemsSource guide](dock-itemssource.md) for more details.
+   > **Tip**: The ItemsSource approach (Option B) is recommended for most scenarios as it provides automatic document management, data binding, and easier maintenance. See the [DocumentDock ItemsSource guide](dock-itemssource.md) and the runnable [`DockQuickStartSample`](https://github.com/wieslawsoltes/Dock/tree/master/samples/DockQuickStartSample) for more details.
 
    For instructions on mapping documents and tools to views see the [Views guide](dock-views.md).
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-      "version": "10.0.200",
+      "version": "10.0.201",
       "rollForward": "disable",
       "allowPrerelease": true
   }

--- a/samples/DockQuickStartSample/App.axaml
+++ b/samples/DockQuickStartSample/App.axaml
@@ -1,0 +1,11 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="DockQuickStartSample.App"
+             RequestedThemeVariant="Default">
+
+  <Application.Styles>
+    <FluentTheme />
+    <DockFluentTheme />
+  </Application.Styles>
+
+</Application>

--- a/samples/DockQuickStartSample/App.axaml.cs
+++ b/samples/DockQuickStartSample/App.axaml.cs
@@ -1,0 +1,31 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using DockQuickStartSample.ViewModels;
+
+namespace DockQuickStartSample;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+#if DOCK_USE_GENERATED_APP_INITIALIZE_COMPONENT
+        InitializeComponent();
+#else
+        AvaloniaXamlLoader.Load(this);
+#endif
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow
+            {
+                DataContext = new MainWindowViewModel()
+            };
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/samples/DockQuickStartSample/DockQuickStartSample.csproj
+++ b/samples/DockQuickStartSample/DockQuickStartSample.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <AvaloniaNameGeneratorBehavior>InitializeComponent</AvaloniaNameGeneratorBehavior>
+    <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <DockEnableGeneratedAppInitializeComponent>true</DockEnableGeneratedAppInitializeComponent>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+  <Import Project="..\..\build\Avalonia.props" />
+  <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
+  <Import Project="..\..\build\Avalonia.Desktop.props" />
+  <Import Project="..\..\build\ReactiveUI.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model.Avalonia\Dock.Model.Avalonia.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Fluent\Dock.Avalonia.Themes.Fluent.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/DockQuickStartSample/DockQuickStartSample.csproj
+++ b/samples/DockQuickStartSample/DockQuickStartSample.csproj
@@ -15,7 +15,7 @@
   <Import Project="..\..\build\Avalonia.props" />
   <Import Project="..\..\build\Avalonia.Themes.Fluent.props" />
   <Import Project="..\..\build\Avalonia.Desktop.props" />
-  <Import Project="..\..\build\ReactiveUI.props" />
+  <Import Project="..\..\build\Avalonia.ReactiveUI.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Dock.Avalonia\Dock.Avalonia.csproj" />

--- a/samples/DockQuickStartSample/MainWindow.axaml
+++ b/samples/DockQuickStartSample/MainWindow.axaml
@@ -44,7 +44,7 @@
                           ActiveDockable="{Binding #DocumentsPane}">
         <dockModel:DocumentDock x:Name="DocumentsPane"
                                 Id="DocumentsPane"
-                                CanCreateDocument="True"
+                                CanCreateDocument="False"
                                 ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
           <dockModel:DocumentDock.DocumentTemplate>
             <dockModel:DocumentTemplate>

--- a/samples/DockQuickStartSample/MainWindow.axaml
+++ b/samples/DockQuickStartSample/MainWindow.axaml
@@ -1,0 +1,79 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:dock="using:Dock.Avalonia.Controls"
+        xmlns:dockFactory="using:Dock.Model.Avalonia"
+        xmlns:dockModel="using:Dock.Model.Avalonia.Controls"
+        xmlns:models="using:DockQuickStartSample.Models"
+        xmlns:vm="using:DockQuickStartSample.ViewModels"
+        x:Class="DockQuickStartSample.MainWindow"
+        x:Name="RootWindow"
+        x:DataType="vm:MainWindowViewModel"
+        Title="Dock Quick Start Sample"
+        Width="960"
+        Height="640">
+
+  <Grid RowDefinitions="Auto,*">
+    <Border Grid.Row="0"
+            Padding="12"
+            Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
+      <DockPanel LastChildFill="False">
+        <StackPanel DockPanel.Dock="Left"
+                    Orientation="Horizontal"
+                    Spacing="8">
+          <Button Command="{Binding AddDocumentCommand}"
+                  Content="Add Document" />
+          <Button Command="{Binding ResetDocumentsCommand}"
+                  Content="Reset" />
+        </StackPanel>
+        <TextBlock DockPanel.Dock="Right"
+                   VerticalAlignment="Center"
+                   Text="{Binding Status}" />
+      </DockPanel>
+    </Border>
+
+    <dock:DockControl Grid.Row="1"
+                      InitializeFactory="True"
+                      InitializeLayout="True">
+      <dock:DockControl.Factory>
+        <dockFactory:Factory />
+      </dock:DockControl.Factory>
+
+      <dockModel:RootDock Id="Root"
+                          IsCollapsable="False"
+                          DefaultDockable="{Binding #DocumentsPane}"
+                          ActiveDockable="{Binding #DocumentsPane}">
+        <dockModel:DocumentDock x:Name="DocumentsPane"
+                                Id="DocumentsPane"
+                                CanCreateDocument="True"
+                                ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
+          <dockModel:DocumentDock.DocumentTemplate>
+            <dockModel:DocumentTemplate>
+              <Grid x:DataType="dockModel:Document"
+                    RowDefinitions="Auto,*"
+                    Margin="12"
+                    RowSpacing="8">
+                <TextBlock Text="{Binding Title}"
+                           FontSize="18"
+                           FontWeight="SemiBold" />
+
+                <Border Grid.Row="1"
+                        Padding="8"
+                        BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                        BorderThickness="1">
+                  <ContentControl DataContext="{Binding Context}">
+                    <TextBox x:DataType="models:FileDocument"
+                             Text="{Binding Content}"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             VerticalAlignment="Stretch"
+                             HorizontalAlignment="Stretch" />
+                  </ContentControl>
+                </Border>
+              </Grid>
+            </dockModel:DocumentTemplate>
+          </dockModel:DocumentDock.DocumentTemplate>
+        </dockModel:DocumentDock>
+      </dockModel:RootDock>
+    </dock:DockControl>
+  </Grid>
+</Window>

--- a/samples/DockQuickStartSample/MainWindow.axaml.cs
+++ b/samples/DockQuickStartSample/MainWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DockQuickStartSample;
+
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/samples/DockQuickStartSample/Models/FileDocument.cs
+++ b/samples/DockQuickStartSample/Models/FileDocument.cs
@@ -1,0 +1,23 @@
+using ReactiveUI;
+
+namespace DockQuickStartSample.Models;
+
+public sealed class FileDocument : ReactiveObject
+{
+    private string _title = string.Empty;
+    private string _content = string.Empty;
+
+    public string Title
+    {
+        get => _title;
+        set => this.RaiseAndSetIfChanged(ref _title, value);
+    }
+
+    public string Content
+    {
+        get => _content;
+        set => this.RaiseAndSetIfChanged(ref _content, value);
+    }
+
+    public bool CanClose { get; set; } = true;
+}

--- a/samples/DockQuickStartSample/Program.cs
+++ b/samples/DockQuickStartSample/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia;
 using Dock.Model.Avalonia;
+using ReactiveUI.Avalonia;
 
 namespace DockQuickStartSample;
 
@@ -16,6 +17,7 @@ internal static class Program
 
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            .UseReactiveUI()
             .LogToTrace();
     }
 }

--- a/samples/DockQuickStartSample/Program.cs
+++ b/samples/DockQuickStartSample/Program.cs
@@ -1,0 +1,21 @@
+using System;
+using Avalonia;
+using Dock.Model.Avalonia;
+
+namespace DockQuickStartSample;
+
+internal static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+        => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        GC.KeepAlive(typeof(Factory).Assembly);
+
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .LogToTrace();
+    }
+}

--- a/samples/DockQuickStartSample/README.md
+++ b/samples/DockQuickStartSample/README.md
@@ -1,0 +1,27 @@
+# Dock Quick Start Sample
+
+This sample is the runnable version of the documentation quick start for the
+`Dock.Model.Avalonia` XAML `ItemsSource` path.
+
+The important details are:
+
+- `App.axaml` registers Dock styles but does not register a view locator.
+- `MainWindowViewModel` and `FileDocument` use ReactiveUI change
+  notification and commands.
+- `MainWindow.axaml` creates the `DockControl`, `Factory`, `RootDock`, and
+  `DocumentDock` in XAML.
+- `DocumentDock.ItemsSource` binds to the window view model through an explicit
+  root source:
+
+  ```xaml
+  ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}"
+  ```
+
+- `DocumentTemplate` first binds to the generated Dock `Document`, then rebinds
+  a nested scope to `Document.Context` for the source `FileDocument`.
+
+Run it from the repository root:
+
+```bash
+dotnet run --project samples/DockQuickStartSample/DockQuickStartSample.csproj
+```

--- a/samples/DockQuickStartSample/README.md
+++ b/samples/DockQuickStartSample/README.md
@@ -17,6 +17,8 @@ The important details are:
   ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}"
   ```
 
+- `CanCreateDocument` is disabled because source-backed documents should be
+  added through `MainWindowViewModel.Documents`.
 - `DocumentTemplate` first binds to the generated Dock `Document`, then rebinds
   a nested scope to `Document.Context` for the source `FileDocument`.
 

--- a/samples/DockQuickStartSample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockQuickStartSample/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,64 @@
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Reactive;
+using DockQuickStartSample.Models;
+using ReactiveUI;
+
+namespace DockQuickStartSample.ViewModels;
+
+public sealed class MainWindowViewModel : ReactiveObject
+{
+    private int _nextDocumentNumber = 3;
+
+    public MainWindowViewModel()
+    {
+        Documents = new ObservableCollection<FileDocument>
+        {
+            new()
+            {
+                Title = "Document 1.txt",
+                Content = "This document is generated from MainWindowViewModel.Documents."
+            },
+            new()
+            {
+                Title = "Document 2.txt",
+                Content = "Edit this text. The tab is backed by a FileDocument model."
+            }
+        };
+
+        Documents.CollectionChanged += OnDocumentsChanged;
+        AddDocumentCommand = ReactiveCommand.Create(AddDocument);
+        ResetDocumentsCommand = ReactiveCommand.Create(ResetDocuments);
+    }
+
+    public ObservableCollection<FileDocument> Documents { get; }
+
+    public ReactiveCommand<Unit, Unit> AddDocumentCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> ResetDocumentsCommand { get; }
+
+    public string Status => $"{Documents.Count} document(s)";
+
+    private void AddDocument()
+    {
+        var documentNumber = _nextDocumentNumber++;
+        Documents.Add(new FileDocument
+        {
+            Title = $"Document {documentNumber}.txt",
+            Content = $"New document {documentNumber} created from the Add Document command."
+        });
+    }
+
+    private void ResetDocuments()
+    {
+        Documents.Clear();
+        _nextDocumentNumber = 1;
+        AddDocument();
+        AddDocument();
+    }
+
+    private void OnDocumentsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        this.RaisePropertyChanged(nameof(Status));
+    }
+}

--- a/samples/DockXamlReactiveUISample/Views/MainWindow.axaml
+++ b/samples/DockXamlReactiveUISample/Views/MainWindow.axaml
@@ -6,6 +6,7 @@
         xmlns:infra="using:DockXamlReactiveUISample.Infrastructure"
         xmlns:sampleModels="using:DockXamlReactiveUISample.Models"
         x:Class="DockXamlReactiveUISample.Views.MainWindow"
+        x:Name="RootWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="Dock ReactiveUI ItemsSource Sample"
         Width="1280"
@@ -143,7 +144,7 @@
       <model:RootDock x:Name="Root"
                       Id="Root"
                       IsCollapsable="False"
-                      RootDockCapabilityPolicy="{Binding RootDockCapabilityPolicy}"
+                      RootDockCapabilityPolicy="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).RootDockCapabilityPolicy}"
                       DefaultDockable="{Binding #MainLayout}"
                       ActiveDockable="{Binding #MainLayout}">
 
@@ -154,11 +155,11 @@
                             Title="Tools"
                             Alignment="Left"
                             Proportion="0.3"
-                            DockCapabilityPolicy="{Binding ToolDockCapabilityPolicy}"
+                            DockCapabilityPolicy="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).ToolDockCapabilityPolicy}"
                             ToolItemContainerTheme="SampleGeneratedToolContainerTheme"
                             ToolItemTemplateSelector="{StaticResource SampleToolItemTemplateSelector}"
-                            CanUpdateItemsSourceOnUnregister="{Binding ToolCanUpdateItemsSourceOnUnregister}"
-                            ItemsSource="{Binding Tools}">
+                            CanUpdateItemsSourceOnUnregister="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).ToolCanUpdateItemsSourceOnUnregister}"
+                            ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Tools}">
               <model:ToolDock.ItemContainerGenerator>
                 <infra:SampleDockItemContainerGenerator />
               </model:ToolDock.ItemContainerGenerator>
@@ -184,11 +185,11 @@
                                 Title="Documents"
                                 Proportion="0.7"
                                 CanCreateDocument="False"
-                                DockCapabilityPolicy="{Binding DocumentDockCapabilityPolicy}"
+                                DockCapabilityPolicy="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).DocumentDockCapabilityPolicy}"
                                 DocumentItemContainerTheme="SampleGeneratedDocumentContainerTheme"
                                 DocumentItemTemplateSelector="{StaticResource SampleDocumentItemTemplateSelector}"
-                                CanUpdateItemsSourceOnUnregister="{Binding DocumentCanUpdateItemsSourceOnUnregister}"
-                                ItemsSource="{Binding Documents}">
+                                CanUpdateItemsSourceOnUnregister="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).DocumentCanUpdateItemsSourceOnUnregister}"
+                                ItemsSource="{Binding #RootWindow.((vm:MainWindowViewModel)DataContext).Documents}">
               <model:DocumentDock.ItemContainerGenerator>
                 <infra:SampleDockItemContainerGenerator />
               </model:DocumentDock.ItemContainerGenerator>

--- a/samples/DockXamlSample/ItemsSourceExample.axaml
+++ b/samples/DockXamlSample/ItemsSourceExample.axaml
@@ -3,6 +3,7 @@
              xmlns:dock="using:Dock.Model.Avalonia.Controls"
              xmlns:local="using:DockXamlSample"
              x:Class="DockXamlSample.ItemsSourceExample"
+             x:Name="RootView"
              x:DataType="local:ItemsSourceExampleViewModel"
              x:CompileBindings="True">
 
@@ -33,7 +34,7 @@
         <DocumentDock x:Name="DocumentsPane" 
                       Id="DocumentsPane" 
                       CanCreateDocument="True"
-                      ItemsSource="{Binding Documents}">
+                      ItemsSource="{Binding #RootView.((local:ItemsSourceExampleViewModel)DataContext).Documents}">
           
           <!-- DocumentTemplate for rendering document content -->
           <DocumentDock.DocumentTemplate>

--- a/samples/DockXamlSample/ItemsSourceExample.axaml
+++ b/samples/DockXamlSample/ItemsSourceExample.axaml
@@ -33,7 +33,7 @@
         <!-- Direct DocumentDock with ItemsSource -->
         <DocumentDock x:Name="DocumentsPane" 
                       Id="DocumentsPane" 
-                      CanCreateDocument="True"
+                      CanCreateDocument="False"
                       ItemsSource="{Binding #RootView.((local:ItemsSourceExampleViewModel)DataContext).Documents}">
           
           <!-- DocumentTemplate for rendering document content -->

--- a/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
@@ -83,14 +83,19 @@ public class DelayedUniformTabPanelTests
             $"Expansion happened too early after second close. Elapsed={elapsedSinceSecondClose.TotalMilliseconds:F0}ms Delay={panel.ExpansionDelay.TotalMilliseconds:F0}ms");
     }
 
-    private static async Task<TimeSpan> WaitForTabWidthAsync(DelayedUniformTabPanel panel, double expectedWidth, TimeSpan timeout)
+    private static Task<TimeSpan> WaitForTabWidthAsync(DelayedUniformTabPanel panel, double expectedWidth, TimeSpan timeout)
+    {
+        return WaitForTabWidthAsync(panel, expectedWidth, 1000d, timeout);
+    }
+
+    private static async Task<TimeSpan> WaitForTabWidthAsync(DelayedUniformTabPanel panel, double expectedWidth, double layoutWidth, TimeSpan timeout)
     {
         var stopwatch = Stopwatch.StartNew();
 
         while (stopwatch.Elapsed < timeout)
         {
             Dispatcher.UIThread.RunJobs();
-            Layout(panel, 1000, 32);
+            Layout(panel, layoutWidth, 32);
 
             if (panel.Children.Count > 0 &&
                 Math.Abs(panel.Children[0].Bounds.Width - expectedWidth) <= 0.1)
@@ -122,12 +127,10 @@ public class DelayedUniformTabPanelTests
         Layout(panel, 600, 32);
         AssertTabWidth(panel, 122d);
 
-        await Task.Delay(80);
-        Dispatcher.UIThread.RunJobs();
-        Layout(panel, 600, 32);
-        var expandedWidth = panel.Children[0].Bounds.Width;
-        AssertTabWidth(panel, expandedWidth);
-        Assert.InRange(expandedWidth, 197d, 199d);
+        var elapsedSinceClose = await WaitForTabWidthAsync(panel, 197d, 600d, TimeSpan.FromMilliseconds(800));
+        Assert.True(
+            elapsedSinceClose >= panel.ExpansionDelay - TimeSpan.FromMilliseconds(20),
+            $"Expansion happened too early. Elapsed={elapsedSinceClose.TotalMilliseconds:F0}ms Delay={panel.ExpansionDelay.TotalMilliseconds:F0}ms");
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

- Add a full runnable `samples/DockQuickStartSample` for the XAML `Dock.Model.Avalonia` + `DocumentDock.ItemsSource` quick-start path.
- Update quick-start and ItemsSource-related docs to bind `ItemsSource` through an explicit named root source, e.g. `#RootWindow.((vm:MainWindowViewModel)DataContext).Documents`, so compiled bindings do not evaluate against `RootDock`.
- Update existing XAML ItemsSource samples to use the same explicit root binding pattern.

Fixes #1098.

## Validation

- `dotnet build /Users/wieslawsoltes/GitHub/Dock/samples/DockQuickStartSample/DockQuickStartSample.csproj -c Debug`
- `dotnet build /Users/wieslawsoltes/GitHub/Dock/samples/DockXamlSample/DockXamlSample.csproj -c Debug`
- `dotnet build /Users/wieslawsoltes/GitHub/Dock/samples/DockXamlReactiveUISample/DockXamlReactiveUISample.csproj -c Debug`

All builds succeeded. Existing warning remains: `NU1903` for `Tmds.DBus.Protocol` plus the pre-existing XML-doc warning in `Dock.Controls.Recycling` during the first sample build.