### PR TITLE
Prevent activation tracking from retaining dockables

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Avalonia;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
@@ -51,12 +52,17 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
     private DockSelectorOverlay? _selectorOverlay;
     private DockSelectorMode _selectorMode;
     private KeyGesture? _selectorGesture;
-    private readonly Dictionary<IDockable, long> _activationOrder = new();
+    private readonly ConditionalWeakTable<IDockable, ActivationOrderEntry> _activationOrder = new();
     private long _activationCounter;
     private IFactory? _subscribedFactory;
     private IFactory? _managedLayerFactory;
     private Window? _attachedWindow;
     private readonly List<WeakReference<IExternalDockSurface>> _externalDockSurfaces = new();
+
+    private sealed class ActivationOrderEntry
+    {
+        public long Value { get; set; }
+    }
 
     /// <summary>
     /// Defines the <see cref="Layout"/> property.
@@ -548,7 +554,7 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
         AttachFactoryEvents(layout.Factory);
         if (layout.ActiveDockable is { } activeDockable)
         {
-            _activationOrder[activeDockable] = ++_activationCounter;
+            RecordActivation(activeDockable);
         }
         _commandBarManager?.Attach(layout);
 
@@ -660,7 +666,7 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
             return;
         }
 
-        _activationOrder[e.Dockable] = ++_activationCounter;
+        RecordActivation(e.Dockable);
     }
 
     private void UpdateManagedWindowLayer(IDock? layout)
@@ -933,7 +939,6 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
         var dockables = new List<IDockable>();
         var visited = new HashSet<IDockable>();
         CollectDockables(root, dockables, visited);
-        PruneActivationOrder(dockables);
 
         var items = new List<DockSelectorItem>();
         foreach (var dockable in dockables)
@@ -956,7 +961,9 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
                 continue;
             }
 
-            _activationOrder.TryGetValue(dockable, out var activationOrder);
+            var activationOrder = _activationOrder.TryGetValue(dockable, out var entry)
+                ? entry.Value
+                : 0;
             var dockableRoot = factory.FindRoot(dockable, _ => true) as IRootDock;
             var isFloating = dockableRoot is not null && !ReferenceEquals(dockableRoot, root);
             var isHidden = root.HiddenDockables?.Contains(dockable) == true;
@@ -1039,19 +1046,10 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
         }
     }
 
-    private void PruneActivationOrder(IReadOnlyCollection<IDockable> dockables)
+    private void RecordActivation(IDockable dockable)
     {
-        if (_activationOrder.Count == 0)
-        {
-            return;
-        }
-
-        var current = new HashSet<IDockable>(dockables);
-        var stale = _activationOrder.Keys.Where(key => !current.Contains(key)).ToList();
-        foreach (var key in stale)
-        {
-            _activationOrder.Remove(key);
-        }
+        var entry = _activationOrder.GetValue(dockable, static _ => new ActivationOrderEntry());
+        entry.Value = ++_activationCounter;
     }
 
     private IDockable? ResolveActiveDockable(DockSelectorMode mode)

--- a/tests/Dock.Avalonia.LeakTests/DockControlActivationOrderLeakTests.cs
+++ b/tests/Dock.Avalonia.LeakTests/DockControlActivationOrderLeakTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Avalonia.Controls;
+using Dock.Avalonia.Controls;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+using static Dock.Avalonia.LeakTests.LeakTestHelpers;
+using static Dock.Avalonia.LeakTests.LeakTestSession;
+
+namespace Dock.Avalonia.LeakTests;
+
+[Collection("LeakTests")]
+public class DockControlActivationOrderLeakTests
+{
+    [ReleaseFact]
+    public void DockControl_ActivationOrder_DoesNotRetainClosedOrRemovedDockables()
+    {
+        var result = RunInSession(CreateClosedDockables);
+
+        AssertCollected(result.ClosedDockableRef, result.RemovedDockableRef);
+        GC.KeepAlive(result.DockControlKeepAlive);
+        GC.KeepAlive(result.FactoryKeepAlive);
+        GC.KeepAlive(result.LayoutKeepAlive);
+    }
+
+    private static ActivationOrderLeakResult CreateClosedDockables()
+    {
+        var factory = new Factory();
+        var firstDocument = new Document { Id = "closed" };
+        var secondDocument = new Document { Id = "removed" };
+        var documentDock = new DocumentDock
+        {
+            VisibleDockables = factory.CreateList<IDockable>(firstDocument, secondDocument),
+            ActiveDockable = firstDocument
+        };
+        var root = new RootDock
+        {
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>(documentDock),
+            ActiveDockable = documentDock,
+            DefaultDockable = documentDock
+        };
+
+        factory.InitLayout(root);
+
+        var dockControl = new DockControl
+        {
+            Factory = factory,
+            Layout = root,
+            InitializeFactory = false,
+            InitializeLayout = false
+        };
+
+        factory.SetActiveDockable(firstDocument);
+        factory.SetActiveDockable(secondDocument);
+
+        var closedDockableRef = new WeakReference(firstDocument);
+        var removedDockableRef = new WeakReference(secondDocument);
+
+        factory.CloseDockable(firstDocument);
+        factory.RemoveDockable(secondDocument, true);
+
+        return new ActivationOrderLeakResult(
+            closedDockableRef,
+            removedDockableRef,
+            dockControl,
+            factory,
+            root);
+    }
+
+    private sealed record ActivationOrderLeakResult(
+        WeakReference ClosedDockableRef,
+        WeakReference RemovedDockableRef,
+        DockControl DockControlKeepAlive,
+        Factory FactoryKeepAlive,
+        RootDock LayoutKeepAlive);
+}


### PR DESCRIPTION
Fixes #1126.

## What changed

- Replaced `DockControl`'s strong-key activation-order dictionary with weak-key activation metadata.
- Preserved MRU selector ordering while allowing closed or removed dockables to be garbage-collected immediately when no other owner remains.
- Removed selector-time stale-entry pruning, which could only release dockables after the selector was rebuilt.
- Added a Release leak regression test covering both `CloseDockable` and direct `RemoveDockable` while the owning `DockControl`, factory, and layout remain alive.

## Root cause

`DockControl._activationOrder` used `IDockable` instances as strong dictionary keys. Cleanup only ran while building selector items, so applications that never reopened the selector retained removed dockables for the lifetime of the control.

## Validation

- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore` — 666 passed.
- `dotnet test tests/Dock.Avalonia.LeakTests/Dock.Avalonia.LeakTests.csproj -c Release --no-restore` — 128 passed.