### PR TITLE
Preserve drags when dock controls detach

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -1448,6 +1448,11 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
 
     private void CaptureLostHandler(object? sender, PointerCaptureLostEventArgs e)
     {
+        if (TryTransferDragCapture(e.Pointer))
+        {
+            return;
+        }
+
         if (Layout?.Factory?.DockControls is { })
         {
             var position = new Point();
@@ -1455,6 +1460,37 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
             var action = DragAction.None;
             _dockControlState.Process(position, delta, EventType.CaptureLost, action, this, Layout.Factory.DockControls);
         }
+    }
+
+    internal bool TryTransferDragCapture(IPointer pointer)
+    {
+        if (this.GetVisualRoot() is not null
+            || !_dockControlState.HasActiveDrag
+            || Layout?.Factory?.DockControls is not { } dockControls)
+        {
+            return false;
+        }
+
+        foreach (var dockControl in DockHelpers.GetZOrderedDockControls(dockControls))
+        {
+            if (dockControl is not DockControl targetDockControl
+                || ReferenceEquals(targetDockControl, this)
+                || targetDockControl.GetVisualRoot() is null
+                || targetDockControl.DockControlState is not DockControlState targetState)
+            {
+                continue;
+            }
+
+            if (!_dockControlState.TryTransferDragTo(targetState, this, targetDockControl))
+            {
+                continue;
+            }
+
+            pointer.Capture(targetDockControl);
+            return true;
+        }
+
+        return false;
     }
 
     private void WheelChangedHandler(object? sender, PointerWheelEventArgs e)

--- a/src/Dock.Avalonia/Internal/DockControlState.cs
+++ b/src/Dock.Avalonia/Internal/DockControlState.cs
@@ -56,6 +56,20 @@ internal class DockDragContext
         UseGlobalOperation = false;
         HasResolvedOperation = false;
     }
+
+    public void CopyTo(DockDragContext target)
+    {
+        target.DragControl = DragControl;
+        target.DragStartPoint = DragStartPoint;
+        target.PointerPressed = PointerPressed;
+        target.DoDragDrop = DoDragDrop;
+        target.TargetPoint = TargetPoint;
+        target.TargetDockControl = TargetDockControl;
+        target.ResolvedOperation = ResolvedOperation;
+        target.UseGlobalOperation = UseGlobalOperation;
+        target.HasResolvedOperation = HasResolvedOperation;
+        target.DragOffset = DragOffset;
+    }
 }
 
 /// <summary>
@@ -72,6 +86,8 @@ internal class DockControlState : DockManagerState, IDockControlState
 
     private readonly DockDragContext _context = new();
     private readonly DragPreviewHelper _dragPreviewHelper = new();
+    private DockControlState? _transferTarget;
+    private DockControl? _activeDockControl;
 
     public IDragOffsetCalculator DragOffsetCalculator { get; set; }
 
@@ -144,23 +160,149 @@ internal class DockControlState : DockManagerState, IDockControlState
             return;
         }
 
-        _context.Start(dragControl, startPoint);
+        BeginDrag(dragControl, startPoint, activeDockControl);
         DropControl = null;
         activeDockControl.IsDraggingDock = true;
 
         if (dragControl.DataContext is IDockable targetDockable)
         {
             targetDockable = DragDockableResolver.Resolve(targetDockable);
-            DockHelpers.ShowWindows(targetDockable);
-            var sp = activeDockControl.PointToScreen(point);
-            Size? preferredPreviewSize = GetPreferredPreviewSize(dragControl);
-            _context.DragOffset = DragOffsetCalculator.CalculateOffset(
+            var canShowPreview = TryGetPreviewPlacement(
                 dragControl,
                 activeDockControl,
-                _context.DragStartPoint);
-            _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset, activeDockControl, preferredPreviewSize);
-            _context.DoDragDrop = true;
+                point,
+                out var screenPoint,
+                out var dragOffset);
+            if (canShowPreview)
+            {
+                _context.DragOffset = dragOffset;
+            }
+
+            DockHelpers.ShowWindows(targetDockable);
+            if (!_context.PointerPressed)
+            {
+                return;
+            }
+
+            var previewShown = false;
+            if (canShowPreview && activeDockControl.GetVisualRoot() is not null)
+            {
+                Size? preferredPreviewSize = GetPreferredPreviewSize(dragControl);
+                _dragPreviewHelper.Show(targetDockable, screenPoint, _context.DragOffset, activeDockControl, preferredPreviewSize);
+                previewShown = true;
+            }
+
+            CompleteDragActivation(previewShown);
         }
+    }
+
+    private void BeginDrag(Control dragControl, Point startPoint, DockControl activeDockControl)
+    {
+        _transferTarget = null;
+        _activeDockControl = activeDockControl;
+        _context.Start(dragControl, startPoint);
+    }
+
+    private bool TryGetPreviewPlacement(
+        Control dragControl,
+        DockControl activeDockControl,
+        Point point,
+        out PixelPoint screenPoint,
+        out PixelPoint dragOffset)
+    {
+        screenPoint = default;
+        dragOffset = _context.DragOffset;
+
+        if (activeDockControl.GetVisualRoot() is null)
+        {
+            LogDragState("Skipping drag preview placement: active dock control not attached to visual tree.");
+            return false;
+        }
+
+        screenPoint = activeDockControl.PointToScreen(point);
+        if (dragControl.GetVisualRoot() is null)
+        {
+            LogDragState("Using cached drag offset: dragged control not attached to visual tree.");
+            return true;
+        }
+
+        dragOffset = DragOffsetCalculator.CalculateOffset(
+            dragControl,
+            activeDockControl,
+            _context.DragStartPoint);
+        return true;
+    }
+
+    private void CompleteDragActivation(bool previewShown)
+    {
+        var owner = ResolveCurrentOwner();
+        if (!owner._context.PointerPressed)
+        {
+            if (previewShown)
+            {
+                _dragPreviewHelper.Hide();
+            }
+            return;
+        }
+
+        // When capture moved before a preview was shown, leave the transferred context
+        // below threshold so its next move can create the preview from an attached visual.
+        if (!ReferenceEquals(owner, this) && !previewShown)
+        {
+            return;
+        }
+
+        owner._context.DoDragDrop = true;
+        if (owner._activeDockControl is { } activeDockControl)
+        {
+            activeDockControl.IsDraggingDock = true;
+        }
+    }
+
+    private DockControlState ResolveCurrentOwner()
+    {
+        var owner = this;
+        while (owner._transferTarget is { } target && !ReferenceEquals(owner, target))
+        {
+            owner = target;
+        }
+
+        return owner;
+    }
+
+    internal bool HasActiveDrag => ResolveCurrentOwner()._context.PointerPressed;
+
+    internal bool TryTransferDragTo(
+        DockControlState target,
+        DockControl sourceDockControl,
+        DockControl targetDockControl)
+    {
+        var owner = ResolveCurrentOwner();
+        if (!ReferenceEquals(owner, this)
+            || !_context.PointerPressed
+            || ReferenceEquals(this, target)
+            || target._context.PointerPressed)
+        {
+            return false;
+        }
+
+        Leave();
+        DropControl = null;
+        _context.ClearResolvedOperation();
+
+        target._transferTarget = null;
+        target.DropControl = null;
+        target._context.End();
+        _context.CopyTo(target._context);
+        target._activeDockControl = targetDockControl;
+
+        _transferTarget = target;
+        _context.End();
+        _activeDockControl = null;
+        sourceDockControl.IsDraggingDock = false;
+        targetDockControl.IsDraggingDock = target._context.DoDragDrop;
+        LogDragState($"Transferred active drag to attached dock control '{targetDockControl.GetType().Name}'.");
+        return true;
     }
 
     private void Enter(Point point, DragAction dragAction, Visual relativeTo)
@@ -526,7 +668,7 @@ internal class DockControlState : DockManagerState, IDockControlState
                         break;
                     }
 
-                    _context.Start(dragControl, point);
+                    BeginDrag(dragControl, point, activeDockControl);
                     DropControl = null;
                     LogDragState($"Drag started from control '{dragControl.GetType().Name}' at {point}.");
                 }
@@ -578,7 +720,8 @@ internal class DockControlState : DockManagerState, IDockControlState
 
                     if (!executed && _context.DragControl?.DataContext is IDockable dockable &&
                         CanFloatDockable(dockable) &&
-                        inputActiveDockControl.Layout?.Factory is { } factory)
+                        inputActiveDockControl.Layout?.Factory is { } factory &&
+                        inputActiveDockControl.GetVisualRoot() is not null)
                     {
                         Float(point, inputActiveDockControl, dockable, factory, _context.DragOffset);
                         LogDragState($"Drop fallback: floating dockable '{dockable.Title}'.");
@@ -615,18 +758,39 @@ internal class DockControlState : DockManagerState, IDockControlState
                         if (_context.DragControl?.DataContext is IDockable targetDockable)
                         {
                             targetDockable = DragDockableResolver.Resolve(targetDockable);
+                            var canShowPreview = TryGetPreviewPlacement(
+                                _context.DragControl,
+                                inputActiveDockControl,
+                                point,
+                                out var previewPoint,
+                                out var dragOffset);
+                            if (canShowPreview)
+                            {
+                                _context.DragOffset = dragOffset;
+                            }
+
                             DockHelpers.ShowWindows(targetDockable);
-                            var sp = inputActiveDockControl.PointToScreen(point);
-                            Size? preferredPreviewSize = GetPreferredPreviewSize(_context.DragControl);
+                            if (!_context.PointerPressed)
+                            {
+                                LogDragState("Drag activation handed off while showing related windows.");
+                                break;
+                            }
 
-                            _context.DragOffset = DragOffsetCalculator.CalculateOffset(
-                                _context.DragControl, inputActiveDockControl, _context.DragStartPoint);
+                            var previewShown = false;
+                            if (canShowPreview && inputActiveDockControl.GetVisualRoot() is not null)
+                            {
+                                Size? preferredPreviewSize = GetPreferredPreviewSize(_context.DragControl);
+                                _dragPreviewHelper.Show(targetDockable, previewPoint, _context.DragOffset, inputActiveDockControl, preferredPreviewSize);
+                                previewShown = true;
+                                LogDragState($"Drag threshold reached for dockable '{targetDockable.Title}'. Showing preview.");
+                            }
 
-                            _dragPreviewHelper.Show(targetDockable, sp, _context.DragOffset, inputActiveDockControl, preferredPreviewSize);
-                            LogDragState($"Drag threshold reached for dockable '{targetDockable.Title}'. Showing preview.");
+                            CompleteDragActivation(previewShown);
                         }
-                        _context.DoDragDrop = true;
-                        activeDockControl.IsDraggingDock = true;
+                        else
+                        {
+                            CompleteDragActivation(previewShown: false);
+                        }
                         LogDragState("Drag operation activated.");
                     }
                     else
@@ -641,17 +805,17 @@ internal class DockControlState : DockManagerState, IDockControlState
                     Visual? targetDockControl = null;
                     Control? dropControl = null;
 
+                    if (inputActiveDockControl.GetVisualRoot() is null)
+                    {
+                        LogDragState("Move deferred: active dock control not attached to visual tree.");
+                        break;
+                    }
+
                     var screenPoint = inputActiveDockControl.PointToScreen(point);
                     var preview = "None";
 
                     foreach (var inputDockControl in DockHelpers.GetZOrderedDockControls(dockControls))
                     {
-                        if (inputActiveDockControl.GetVisualRoot() is null)
-                        {
-                            LogDragState("Skipping dock control search: active dock control not attached to visual tree.");
-                            continue;
-                        }
-
                         if (inputDockControl.GetVisualRoot() is null)
                         {
                             LogDragState($"Skipping dock control '{inputDockControl.GetType().Name}': not attached to visual tree.");

--- a/tests/Dock.Avalonia.HeadlessTests/DockControlStateTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DockControlStateTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
+using Avalonia.Input;
 using Dock.Avalonia.Controls;
 using Dock.Avalonia.Internal;
 using Dock.Model;
@@ -100,6 +101,159 @@ public class DockControlStateTests
         state.Process(new Point(), new Vector(), EventType.Released, DragAction.None, dock, docks);
 
         Assert.False(dock.IsDraggingDock);
+    }
+
+    [AvaloniaFact]
+    public void StartDrag_DetachedSource_DoesNotConvertPointToScreen()
+    {
+        var state = CreateState(new DockManager(new DockService()));
+        var dockControl = new DockControl();
+        var dragControl = new Control
+        {
+            DataContext = new Tool { CanDrag = true }
+        };
+        DockProperties.SetIsDragEnabled(dragControl, true);
+
+        state.StartDrag(dragControl, new Point(5, 5), new Point(20, 20), dockControl);
+        state.Process(
+            new Point(30, 30),
+            default,
+            EventType.Moved,
+            DragAction.Move,
+            dockControl,
+            new List<IDockControl> { dockControl });
+
+        Assert.True(dockControl.IsDraggingDock);
+
+        state.Process(
+            default,
+            default,
+            EventType.CaptureLost,
+            DragAction.None,
+            dockControl,
+            new List<IDockControl> { dockControl });
+    }
+
+    [AvaloniaFact]
+    public void Process_ThresholdMove_DetachedSource_DoesNotConvertPointToScreen()
+    {
+        var state = CreateState(new DockManager(new DockService()));
+        var dockControl = new DockControl();
+        var dragControl = new Control
+        {
+            DataContext = new object()
+        };
+        DockProperties.SetIsDragEnabled(dragControl, true);
+        state.StartDrag(dragControl, new Point(0, 0), new Point(0, 0), dockControl);
+        dragControl.DataContext = new Tool { CanDrag = true };
+
+        state.Process(
+            new Point(100, 100),
+            default,
+            EventType.Moved,
+            DragAction.Move,
+            dockControl,
+            new List<IDockControl> { dockControl });
+
+        Assert.True(dockControl.IsDraggingDock);
+
+        state.Process(
+            default,
+            default,
+            EventType.CaptureLost,
+            DragAction.None,
+            dockControl,
+            new List<IDockControl> { dockControl });
+    }
+
+    [AvaloniaFact]
+    public void DetachedSource_TransfersDragCaptureAndReleaseToAttachedDockControl()
+    {
+        var factory = new RecordingFactory();
+        var root = factory.CreateRootDock();
+        root.Factory = factory;
+        root.VisibleDockables = factory.CreateList<IDockable>();
+        var toolDock = factory.CreateToolDock();
+        toolDock.VisibleDockables = factory.CreateList<IDockable>();
+        var tool = factory.CreateTool();
+        tool.CanDrag = true;
+        factory.AddDockable(toolDock, tool);
+        toolDock.ActiveDockable = tool;
+        factory.AddDockable(root, toolDock);
+
+        var targetDockControl = new DockControl { Layout = root };
+        var sourceDockControl = new DockControl { Layout = root };
+        var dragControl = new Control { DataContext = new object() };
+        DockProperties.SetIsDragEnabled(dragControl, true);
+        var sourceHost = new Grid();
+        sourceHost.Children.Add(sourceDockControl);
+        sourceHost.Children.Add(dragControl);
+        var sourceWindow = new Window
+        {
+            Width = 300,
+            Height = 200,
+            Content = sourceHost
+        };
+        var targetWindow = new Window
+        {
+            Width = 300,
+            Height = 200,
+            Content = targetDockControl
+        };
+        var pointer = new global::Avalonia.Input.Pointer(1, PointerType.Mouse, true);
+
+        try
+        {
+            targetWindow.Show();
+            sourceWindow.Show();
+            targetWindow.UpdateLayout();
+            sourceWindow.UpdateLayout();
+
+            var sourceState = Assert.IsType<DockControlState>(sourceDockControl.DockControlState);
+            sourceState.StartDrag(
+                dragControl,
+                new Point(5, 5),
+                new Point(20, 20),
+                sourceDockControl);
+            dragControl.DataContext = tool;
+
+            sourceHost.Children.Remove(sourceDockControl);
+            sourceWindow.UpdateLayout();
+
+            Assert.True(sourceDockControl.TryTransferDragCapture(pointer));
+            Assert.Same(targetDockControl, pointer.Captured);
+            Assert.False(sourceDockControl.IsDraggingDock);
+            Assert.False(targetDockControl.IsDraggingDock);
+
+            var targetState = Assert.IsType<DockControlState>(targetDockControl.DockControlState);
+            targetState.Process(
+                new Point(100, 100),
+                default,
+                EventType.Moved,
+                DragAction.Move,
+                targetDockControl,
+                factory.DockControls);
+
+            Assert.True(targetDockControl.IsDraggingDock);
+
+            targetState.Process(
+                new Point(30, 30),
+                default,
+                EventType.Released,
+                DragAction.Move,
+                targetDockControl,
+                factory.DockControls);
+
+            Assert.Equal(1, factory.FloatCount);
+            Assert.Same(tool, factory.LastFloatedDockable);
+            Assert.False(targetDockControl.IsDraggingDock);
+        }
+        finally
+        {
+            pointer.Capture(null);
+            sourceWindow.Close();
+            targetWindow.Close();
+        }
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## What changed

- guard drag-preview and move screen-coordinate conversions when the source `DockControl` is detached
- preserve the active drag context across visual-tree teardown by transferring pointer capture to an attached `DockControl`
- prevent reentrant capture-lost cleanup from being overwritten when preview creation returns
- retain cached drag offsets so a transferred gesture can resume from an attached control

## Root cause

Preview/window creation can synchronously detach the source `DockControl` and raise capture-lost while `DockControlState.Process` is still on the stack. The outer move handler then resumed, reactivated the cleared context, and called `PointToScreen` on the detached visual. A root guard alone suppressed the exception but left the drag bound to the dead control.

## Validation

- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore` (675 passed)
- `dotnet test tests/Dock.Avalonia.UnitTests/Dock.Avalonia.UnitTests.csproj --no-restore` (77 passed)
- `dotnet restore && dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build` (all projects passed, including leak tests)
- `git diff --check`

Closes #1136