### PR TITLE
Propagate control recycling across dock controls

### DIFF
--- a/src/Dock.Avalonia/Controls/DockControl.axaml.cs
+++ b/src/Dock.Avalonia/Controls/DockControl.axaml.cs
@@ -520,7 +520,10 @@ public class DockControl : TemplatedControl, IDockControl, IDockSelectorService
 
         layout.Factory.DockControls.Add(this);
 
-        _factoryService.InitializeControlRecycling(this);
+        if (_contentControl is not null)
+        {
+            _factoryService.InitializeControlRecycling(this);
+        }
         UpdateManagedWindowLayer(layout);
 
         if (InitializeFactory)

--- a/src/Dock.Avalonia/Services/DockControlFactoryService.cs
+++ b/src/Dock.Avalonia/Services/DockControlFactoryService.cs
@@ -23,13 +23,15 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
         }
 
         var controlRecycling = ControlRecyclingDataTemplate.GetControlRecycling(control);
-        if (controlRecycling is null)
-        {
-            return;
-        }
 
         if (s_controlRecycling.TryGetValue(factory, out var shared))
         {
+            if (controlRecycling is null)
+            {
+                ControlRecyclingDataTemplate.SetControlRecycling(control, shared);
+                return;
+            }
+
             if (ReferenceEquals(shared, controlRecycling))
             {
                 return;
@@ -52,6 +54,12 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
             }
 
             return;
+        }
+
+        if (controlRecycling is null)
+        {
+            controlRecycling = new ControlRecycling();
+            ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
         }
 
         if (controlRecycling is ControlRecycling defaultRecycling)

--- a/src/Dock.Avalonia/Services/DockControlFactoryService.cs
+++ b/src/Dock.Avalonia/Services/DockControlFactoryService.cs
@@ -13,7 +13,14 @@ namespace Dock.Avalonia.Services;
 
 internal sealed class DockControlFactoryService : IDockControlFactoryService
 {
-    private static readonly ConditionalWeakTable<IFactory, IControlRecycling> s_controlRecycling = new();
+    private sealed class FactoryControlRecyclingState(IControlRecycling recycling, bool isFallback)
+    {
+        public IControlRecycling Recycling { get; set; } = recycling;
+
+        public bool IsFallback { get; set; } = isFallback;
+    }
+
+    private static readonly ConditionalWeakTable<IFactory, FactoryControlRecyclingState> s_controlRecycling = new();
 
     public void InitializeControlRecycling(DockControl control)
     {
@@ -24,8 +31,10 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
         var controlRecycling = ControlRecyclingDataTemplate.GetControlRecycling(control);
 
-        if (s_controlRecycling.TryGetValue(factory, out var shared))
+        if (s_controlRecycling.TryGetValue(factory, out var state))
         {
+            var shared = state.Recycling;
+
             if (controlRecycling is null)
             {
                 ControlRecyclingDataTemplate.SetControlRecycling(control, shared);
@@ -34,6 +43,15 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
             if (ReferenceEquals(shared, controlRecycling))
             {
+                return;
+            }
+
+            if (state.IsFallback)
+            {
+                var configured = CreateFactoryOwnedRecycling(controlRecycling);
+                state.Recycling = configured;
+                state.IsFallback = false;
+                PropagateControlRecycling(factory, configured);
                 return;
             }
 
@@ -48,30 +66,34 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
                 return;
             }
 
-            if (controlRecycling is ControlRecycling)
-            {
-                ControlRecyclingDataTemplate.SetControlRecycling(control, shared);
-            }
-
+            ControlRecyclingDataTemplate.SetControlRecycling(control, shared);
             return;
         }
 
+        var isFallback = controlRecycling is null;
         if (controlRecycling is null)
         {
             controlRecycling = new ControlRecycling();
-            ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
         }
 
-        if (controlRecycling is ControlRecycling defaultRecycling)
+        controlRecycling = CreateFactoryOwnedRecycling(controlRecycling);
+        ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
+        s_controlRecycling.Add(factory, new FactoryControlRecyclingState(controlRecycling, isFallback));
+    }
+
+    private static IControlRecycling CreateFactoryOwnedRecycling(IControlRecycling recycling)
+    {
+        return recycling is ControlRecycling defaultRecycling
+            ? new ControlRecycling { TryToUseIdAsKey = defaultRecycling.TryToUseIdAsKey }
+            : recycling;
+    }
+
+    private static void PropagateControlRecycling(IFactory factory, IControlRecycling recycling)
+    {
+        foreach (var dockControl in factory.DockControls.OfType<DockControl>())
         {
-            controlRecycling = new ControlRecycling
-            {
-                TryToUseIdAsKey = defaultRecycling.TryToUseIdAsKey
-            };
-            ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
+            ControlRecyclingDataTemplate.SetControlRecycling(dockControl, recycling);
         }
-
-        s_controlRecycling.Add(factory, controlRecycling);
     }
 
     public void CleanupFactory(DockControl control, IDock layout)
@@ -136,12 +158,12 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
     private static void PruneControlRecycling(IFactory factory, HashSet<IDockable> dockables)
     {
-        if (!s_controlRecycling.TryGetValue(factory, out var recycling))
+        if (!s_controlRecycling.TryGetValue(factory, out var state))
         {
             return;
         }
 
-        if (recycling is not ControlRecycling controlRecycling)
+        if (state.Recycling is not ControlRecycling controlRecycling)
         {
             return;
         }

--- a/src/Dock.Avalonia/Services/DockControlFactoryService.cs
+++ b/src/Dock.Avalonia/Services/DockControlFactoryService.cs
@@ -13,14 +13,7 @@ namespace Dock.Avalonia.Services;
 
 internal sealed class DockControlFactoryService : IDockControlFactoryService
 {
-    private sealed class FactoryControlRecyclingState(IControlRecycling recycling, bool isFallback)
-    {
-        public IControlRecycling Recycling { get; set; } = recycling;
-
-        public bool IsFallback { get; set; } = isFallback;
-    }
-
-    private static readonly ConditionalWeakTable<IFactory, FactoryControlRecyclingState> s_controlRecycling = new();
+    private static readonly ConditionalWeakTable<IFactory, IControlRecycling> s_controlRecycling = new();
 
     public void InitializeControlRecycling(DockControl control)
     {
@@ -31,38 +24,10 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
         var controlRecycling = ControlRecyclingDataTemplate.GetControlRecycling(control);
 
-        if (s_controlRecycling.TryGetValue(factory, out var state))
+        if (s_controlRecycling.TryGetValue(factory, out var shared))
         {
-            var shared = state.Recycling;
-
-            if (controlRecycling is null)
-            {
-                ControlRecyclingDataTemplate.SetControlRecycling(control, shared);
-                return;
-            }
-
             if (ReferenceEquals(shared, controlRecycling))
             {
-                return;
-            }
-
-            if (state.IsFallback)
-            {
-                var configured = CreateFactoryOwnedRecycling(controlRecycling);
-                state.Recycling = configured;
-                state.IsFallback = false;
-                PropagateControlRecycling(factory, configured);
-                return;
-            }
-
-            if (shared is ControlRecycling sharedRecycling && controlRecycling is ControlRecycling localRecycling)
-            {
-                if (sharedRecycling.TryToUseIdAsKey != localRecycling.TryToUseIdAsKey)
-                {
-                    sharedRecycling.TryToUseIdAsKey = localRecycling.TryToUseIdAsKey;
-                }
-
-                ControlRecyclingDataTemplate.SetControlRecycling(control, sharedRecycling);
                 return;
             }
 
@@ -70,7 +35,6 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
             return;
         }
 
-        var isFallback = controlRecycling is null;
         if (controlRecycling is null)
         {
             controlRecycling = new ControlRecycling();
@@ -78,7 +42,7 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
         controlRecycling = CreateFactoryOwnedRecycling(controlRecycling);
         ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
-        s_controlRecycling.Add(factory, new FactoryControlRecyclingState(controlRecycling, isFallback));
+        s_controlRecycling.Add(factory, controlRecycling);
     }
 
     private static IControlRecycling CreateFactoryOwnedRecycling(IControlRecycling recycling)
@@ -86,14 +50,6 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
         return recycling is ControlRecycling defaultRecycling
             ? new ControlRecycling { TryToUseIdAsKey = defaultRecycling.TryToUseIdAsKey }
             : recycling;
-    }
-
-    private static void PropagateControlRecycling(IFactory factory, IControlRecycling recycling)
-    {
-        foreach (var dockControl in factory.DockControls.OfType<DockControl>())
-        {
-            ControlRecyclingDataTemplate.SetControlRecycling(dockControl, recycling);
-        }
     }
 
     public void CleanupFactory(DockControl control, IDock layout)
@@ -158,12 +114,12 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
 
     private static void PruneControlRecycling(IFactory factory, HashSet<IDockable> dockables)
     {
-        if (!s_controlRecycling.TryGetValue(factory, out var state))
+        if (!s_controlRecycling.TryGetValue(factory, out var recycling))
         {
             return;
         }
 
-        if (state.Recycling is not ControlRecycling controlRecycling)
+        if (recycling is not ControlRecycling controlRecycling)
         {
             return;
         }

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
@@ -59,45 +59,100 @@ public class BoundContentControlReparentingTests
     }
 
     [AvaloniaFact]
-    public void DockControl_ExplicitCustomRecyclingReplacesGeneratedFactoryFallback()
+    public void MovingDocumentToDockControlWithCustomRecyclingUsesOriginalFactoryCache()
     {
         var factory = new Factory();
+        var model = new BoundControlContext();
+        var buildCount = 0;
+        var document = new Document
+        {
+            Id = "Document",
+            Title = "Document",
+            Context = model,
+            Content = new Func<IServiceProvider, object>(_ =>
+            {
+                buildCount++;
+                return new BoundContentControlView();
+            })
+        };
+        var source = new DocumentDock
+        {
+            Id = "Source",
+            VisibleDockables = factory.CreateList<IDockable>(document),
+            ActiveDockable = document
+        };
         var firstRoot = new RootDock
         {
             Id = "FirstRoot",
             Factory = factory,
-            VisibleDockables = factory.CreateList<IDockable>()
+            VisibleDockables = factory.CreateList<IDockable>(source),
+            ActiveDockable = source,
+            DefaultDockable = source
         };
-        var secondRoot = new RootDock
+        var firstDockControl = new DockControl
         {
-            Id = "SecondRoot",
             Factory = factory,
-            VisibleDockables = factory.CreateList<IDockable>()
+            Layout = firstRoot,
+            InitializeFactory = true,
+            InitializeLayout = true
         };
-        var firstDockControl = new DockControl { Layout = firstRoot };
-        var secondDockControl = new DockControl { Layout = secondRoot };
-        var customRecycling = new CustomControlRecycling();
-        ControlRecyclingDataTemplate.SetControlRecycling(secondDockControl, customRecycling);
         var firstWindow = new Window { Content = firstDockControl };
-        var secondWindow = new Window { Content = secondDockControl };
+        Window? secondWindow = null;
 
         firstWindow.Show();
         try
         {
-            firstDockControl.ApplyTemplate();
-            var fallback = Assert.IsType<ControlRecycling>(
+            firstWindow.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            firstWindow.UpdateLayout();
+            var sharedRecycling = Assert.IsType<ControlRecycling>(
                 ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
+            Assert.Equal(1, buildCount);
+            Assert.NotNull(model.SharedControl.GetVisualParent());
 
+            var target = new DocumentDock
+            {
+                Id = "Target",
+                VisibleDockables = factory.CreateList<IDockable>()
+            };
+            var secondRoot = new RootDock
+            {
+                Id = "SecondRoot",
+                Factory = factory,
+                VisibleDockables = factory.CreateList<IDockable>(target),
+                ActiveDockable = target,
+                DefaultDockable = target
+            };
+            var secondDockControl = new DockControl
+            {
+                Factory = factory,
+                Layout = secondRoot,
+                InitializeFactory = true,
+                InitializeLayout = true
+            };
+            var customRecycling = new CustomControlRecycling();
+            ControlRecyclingDataTemplate.SetControlRecycling(secondDockControl, customRecycling);
+            secondWindow = new Window { Content = secondDockControl };
             secondWindow.Show();
-            secondDockControl.ApplyTemplate();
+            secondWindow.UpdateLayout();
 
-            Assert.NotSame(fallback, customRecycling);
-            Assert.Same(customRecycling, ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
-            Assert.Same(customRecycling, ControlRecyclingDataTemplate.GetControlRecycling(secondDockControl));
+            Assert.NotSame(customRecycling, sharedRecycling);
+            Assert.Same(sharedRecycling, ControlRecyclingDataTemplate.GetControlRecycling(secondDockControl));
+
+            factory.MoveDockable(source, target, document, null);
+            firstWindow.UpdateLayout();
+            secondWindow.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            firstWindow.UpdateLayout();
+            secondWindow.UpdateLayout();
+
+            Assert.Same(target, document.Owner);
+            Assert.NotNull(model.SharedControl.GetVisualParent());
+            Assert.Equal(1, buildCount);
         }
         finally
         {
-            secondWindow.Close();
+            secondWindow?.Close();
             firstWindow.Close();
         }
     }

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Avalonia.Controls;
 using Avalonia.Controls.Recycling;
+using Avalonia.Controls.Recycling.Model;
 using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -49,6 +50,50 @@ public class BoundContentControlReparentingTests
 
             Assert.True(sharedRecycling.TryToUseIdAsKey);
             Assert.Same(sharedRecycling, ControlRecyclingDataTemplate.GetControlRecycling(secondDockControl));
+        }
+        finally
+        {
+            secondWindow.Close();
+            firstWindow.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void DockControl_ExplicitCustomRecyclingReplacesGeneratedFactoryFallback()
+    {
+        var factory = new Factory();
+        var firstRoot = new RootDock
+        {
+            Id = "FirstRoot",
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        var secondRoot = new RootDock
+        {
+            Id = "SecondRoot",
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        var firstDockControl = new DockControl { Layout = firstRoot };
+        var secondDockControl = new DockControl { Layout = secondRoot };
+        var customRecycling = new CustomControlRecycling();
+        ControlRecyclingDataTemplate.SetControlRecycling(secondDockControl, customRecycling);
+        var firstWindow = new Window { Content = firstDockControl };
+        var secondWindow = new Window { Content = secondDockControl };
+
+        firstWindow.Show();
+        try
+        {
+            firstDockControl.ApplyTemplate();
+            var fallback = Assert.IsType<ControlRecycling>(
+                ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
+
+            secondWindow.Show();
+            secondDockControl.ApplyTemplate();
+
+            Assert.NotSame(fallback, customRecycling);
+            Assert.Same(customRecycling, ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
+            Assert.Same(customRecycling, ControlRecyclingDataTemplate.GetControlRecycling(secondDockControl));
         }
         finally
         {
@@ -145,4 +190,23 @@ public class BoundContentControlReparentingTests
 public sealed class BoundControlContext
 {
     public Button SharedControl { get; } = new() { Content = "Shared control" };
+}
+
+internal sealed class CustomControlRecycling : IControlRecycling
+{
+    private readonly ControlRecycling _inner = new();
+
+    public bool TryToUseIdAsKey
+    {
+        get => _inner.TryToUseIdAsKey;
+        set => _inner.TryToUseIdAsKey = value;
+    }
+
+    public bool TryGetValue(object? data, out object? control) => _inner.TryGetValue(data, out control);
+
+    public void Add(object data, object control) => _inner.Add(data, control);
+
+    public object? Build(object? data, object? existing, object? parent) => _inner.Build(data, existing, parent);
+
+    public void Clear() => _inner.Clear();
 }

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
@@ -1,0 +1,148 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Recycling;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Dock.Avalonia.Controls;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public class BoundContentControlReparentingTests
+{
+    [AvaloniaFact]
+    public void DockControl_PropagatesConfiguredControlRecyclingAcrossFactory()
+    {
+        var factory = new Factory();
+        var recycling = new ControlRecycling { TryToUseIdAsKey = true };
+        var firstRoot = new RootDock
+        {
+            Id = "FirstRoot",
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        var secondRoot = new RootDock
+        {
+            Id = "SecondRoot",
+            Factory = factory,
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        var firstDockControl = new DockControl { Layout = firstRoot };
+        ControlRecyclingDataTemplate.SetControlRecycling(firstDockControl, recycling);
+        var secondDockControl = new DockControl { Layout = secondRoot };
+        var firstWindow = new Window { Content = firstDockControl };
+        var secondWindow = new Window { Content = secondDockControl };
+
+        firstWindow.Show();
+        try
+        {
+            firstDockControl.ApplyTemplate();
+            var sharedRecycling = Assert.IsType<ControlRecycling>(
+                ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
+
+            secondWindow.Show();
+            secondDockControl.ApplyTemplate();
+
+            Assert.True(sharedRecycling.TryToUseIdAsKey);
+            Assert.Same(sharedRecycling, ControlRecyclingDataTemplate.GetControlRecycling(secondDockControl));
+        }
+        finally
+        {
+            secondWindow.Close();
+            firstWindow.Close();
+        }
+    }
+
+    [AvaloniaFact]
+    public void MovingDocumentWithBoundControlContentBetweenDocks_ReparentsSharedControl()
+    {
+        var factory = new Factory();
+        var model = new BoundControlContext();
+        var buildCount = 0;
+        var document = new Document
+        {
+            Id = "Document",
+            Title = "Document",
+            Context = model,
+            Content = new Func<IServiceProvider, object>(_ =>
+            {
+                buildCount++;
+                return new BoundContentControlView();
+            })
+        };
+        var source = new DocumentDock
+        {
+            Id = "Source",
+            VisibleDockables = factory.CreateList<IDockable>(document),
+            ActiveDockable = document
+        };
+        var target = new DocumentDock
+        {
+            Id = "Target",
+            VisibleDockables = factory.CreateList<IDockable>()
+        };
+        var documents = new ProportionalDock
+        {
+            Id = "Documents",
+            Orientation = Orientation.Horizontal,
+            VisibleDockables = factory.CreateList<IDockable>(source, target),
+            ActiveDockable = source
+        };
+        var root = new RootDock
+        {
+            Id = "Root",
+            VisibleDockables = factory.CreateList<IDockable>(documents),
+            ActiveDockable = documents,
+            DefaultDockable = documents
+        };
+        var dockControl = new DockControl
+        {
+            Factory = factory,
+            Layout = root,
+            InitializeFactory = true,
+            InitializeLayout = true
+        };
+        var window = new Window
+        {
+            Width = 900,
+            Height = 600,
+            Content = dockControl
+        };
+
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            Assert.IsType<ControlRecycling>(ControlRecyclingDataTemplate.GetControlRecycling(dockControl));
+            Assert.NotNull(model.SharedControl.GetVisualParent());
+            Assert.Equal(1, buildCount);
+
+            factory.MoveDockable(source, target, document, null);
+            window.UpdateLayout();
+            Assert.Equal(1, buildCount);
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            Assert.Same(target, document.Owner);
+            Assert.NotNull(model.SharedControl.GetVisualParent());
+            Assert.Equal(1, buildCount);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+}
+
+public sealed class BoundControlContext
+{
+    public Button SharedControl { get; } = new() { Content = "Shared control" };
+}

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlView.axaml
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlView.axaml
@@ -1,0 +1,13 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="using:Dock.Avalonia.HeadlessTests"
+             xmlns:model="using:Dock.Model.Avalonia.Controls"
+             x:Class="Dock.Avalonia.HeadlessTests.BoundContentControlView"
+             x:DataType="model:Document"
+             x:CompileBindings="True">
+  <StackPanel DataContext="{Binding Context}">
+    <StackPanel x:DataType="local:BoundControlContext">
+      <ContentControl Content="{Binding SharedControl}" />
+    </StackPanel>
+  </StackPanel>
+</UserControl>

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlView.axaml.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Dock.Avalonia.HeadlessTests;
+
+public partial class BoundContentControlView : UserControl
+{
+    public BoundContentControlView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
## Summary

- initialize a factory-owned control recycler when an application does not configure one
- make the first recycler registered for an `IFactory` authoritative and propagate that exact instance to every later `DockControl`
- preserve the original factory cache when later controls carry different custom `IControlRecycling` implementations
- defer initialization until the control template exists so application styles remain authoritative for the initial registration
- cover configured propagation and stateful bound-`ContentControl` document moves with compiled-binding Avalonia Headless tests

## Root cause

A `DockControl` without an explicit `ControlRecycling` setting returned early during factory initialization. When a document moved to another dock/control, Dock could build its content template again instead of transferring the cached root. Two template roots then kept bindings to the same control, producing the duplicate visual-parent exception reported in #1102.

The fix gives each factory one stable recycler. The first effective recycler—configured or generated—is retained for that factory and assigned to every subsequent dock control, so cached template roots are neither split nor abandoned.

## Validation

- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore --logger "console;verbosity=minimal"` (678 passed)
- `dotnet test tests/Dock.Controls.Recycling.UnitTests/Dock.Controls.Recycling.UnitTests.csproj --no-restore --logger "console;verbosity=minimal"` (20 passed)
- `dotnet test tests/Dock.Model.Avalonia.UnitTests/Dock.Model.Avalonia.UnitTests.csproj --no-restore --logger "console;verbosity=minimal"` (170 passed)
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release --no-restore --nologo` (`net8.0` and `net10.0`, no errors)
- `git diff --check`

Fixes #1102