### PR TITLE
Propagate the configured recycling instance

### DIFF
--- a/src/Dock.Avalonia/Services/DockControlFactoryService.cs
+++ b/src/Dock.Avalonia/Services/DockControlFactoryService.cs
@@ -40,16 +40,8 @@ internal sealed class DockControlFactoryService : IDockControlFactoryService
             controlRecycling = new ControlRecycling();
         }
 
-        controlRecycling = CreateFactoryOwnedRecycling(controlRecycling);
         ControlRecyclingDataTemplate.SetControlRecycling(control, controlRecycling);
         s_controlRecycling.Add(factory, controlRecycling);
-    }
-
-    private static IControlRecycling CreateFactoryOwnedRecycling(IControlRecycling recycling)
-    {
-        return recycling is ControlRecycling defaultRecycling
-            ? new ControlRecycling { TryToUseIdAsKey = defaultRecycling.TryToUseIdAsKey }
-            : recycling;
     }
 
     public void CleanupFactory(DockControl control, IDock layout)

--- a/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/BoundContentControlReparentingTests.cs
@@ -16,10 +16,13 @@ namespace Dock.Avalonia.HeadlessTests;
 public class BoundContentControlReparentingTests
 {
     [AvaloniaFact]
-    public void DockControl_PropagatesConfiguredControlRecyclingAcrossFactory()
+    public void DockControl_PropagatesOriginalConfiguredControlRecyclingAcrossFactory()
     {
         var factory = new Factory();
         var recycling = new ControlRecycling { TryToUseIdAsKey = true };
+        var cacheKey = new object();
+        var cachedControl = new Border();
+        recycling.Add(cacheKey, cachedControl);
         var firstRoot = new RootDock
         {
             Id = "FirstRoot",
@@ -44,6 +47,10 @@ public class BoundContentControlReparentingTests
             firstDockControl.ApplyTemplate();
             var sharedRecycling = Assert.IsType<ControlRecycling>(
                 ControlRecyclingDataTemplate.GetControlRecycling(firstDockControl));
+
+            Assert.Same(recycling, sharedRecycling);
+            Assert.True(sharedRecycling.TryGetValue(cacheKey, out var cached));
+            Assert.Same(cachedControl, cached);
 
             secondWindow.Show();
             secondDockControl.ApplyTemplate();


### PR DESCRIPTION
## Summary

- retain the first configured `IControlRecycling` instance as the factory-authoritative recycler
- propagate that exact instance to subsequent `DockControl`s instead of replacing a concrete `ControlRecycling` with a partial copy
- verify that configured identity and pre-existing cache state survive initialization

## Rationale

The follow-up in #1138 correctly established one stable recycler per factory, but the concrete `ControlRecycling` path still created a new object and copied only `TryToUseIdAsKey`. That discarded the configured instance's cache, bindings, identity, and any future state that is not represented by that one property.

A generated recycler is still created when no setting exists. When a recycler is configured, the configuration is now honored as the actual stateful service and propagated unchanged.

## Validation

- regression test fails on `master` because the configured instance is replaced
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore --filter FullyQualifiedName~BoundContentControlReparentingTests` (3 passed)
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore` (678 passed)
- `dotnet build src/Dock.Avalonia/Dock.Avalonia.csproj -c Release --no-restore --nologo` (`net8.0` and `net10.0`, 0 errors; 2 pre-existing XML-documentation warnings)
- `git diff --check`

Follow-up to #1138.