### PR TITLE
Keep tool chrome grip clear of titles

### DIFF
--- a/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent/Controls/ToolChromeControl.axaml
@@ -164,14 +164,14 @@
                   ContextFlyout="{TemplateBinding ToolFlyout}"
                   Grid.Row="{Binding GripMode, Converter={x:Static GripModeConverters.GridRowAutoHideConverter}}">
             <Grid x:Name="PART_Grip">
-              <Grid ColumnDefinitions="*,Auto"
+              <Grid ColumnDefinitions="*,Auto,Auto"
                     Margin="{DynamicResource DockToolChromeHeaderMargin}">
                 <Panel Grid.Column="0" HorizontalAlignment="Left">
                   <TextBlock x:Name="PART_Title"
                              TextTrimming="CharacterEllipsis"
                              Text="{Binding ActiveDockable.Title, FallbackValue=TITLE}" />
                 </Panel>
-                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                <StackPanel Grid.Column="2" Orientation="Horizontal">
                   <Button x:Name="PART_MenuButton"
                           Theme="{TemplateBinding MenuButtonTheme}"
                           Flyout="{TemplateBinding ToolFlyout}">
@@ -228,7 +228,7 @@
                     </Viewbox>
                   </Button>
                 </StackPanel>
-                <Grid x:Name="PART_Grid" />
+                <Grid x:Name="PART_Grid" Grid.Column="1" />
               </Grid>
             </Grid>
           </Border>

--- a/tests/Dock.Avalonia.Themes.UnitTests/ToolChromeControlLayoutTests.cs
+++ b/tests/Dock.Avalonia.Themes.UnitTests/ToolChromeControlLayoutTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using Avalonia;
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Dock.Avalonia.Controls;
+using Dock.Avalonia.Themes.Fluent;
+using Dock.Avalonia.Themes.Simple;
+using Dock.Model.Avalonia;
+using Dock.Model.Avalonia.Controls;
+using Dock.Model.Core;
+using Xunit;
+
+namespace Dock.Avalonia.Themes.UnitTests;
+
+[Collection(ThemeResourceIsolationCollection.Name)]
+public class ToolChromeControlLayoutTests
+{
+    [AvaloniaTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Header_Separates_Long_Title_Grip_And_Buttons(bool useSimpleTheme)
+    {
+        var factory = new Factory();
+        var tool = new Tool { Title = "Tool One With A Long Title That Must Be Trimmed" };
+        var toolDock = new ToolDock
+        {
+            Factory = factory,
+            VisibleDockables = new AvaloniaList<IDockable> { tool },
+            ActiveDockable = tool
+        };
+        var chrome = new ToolChromeControl
+        {
+            Width = 300,
+            DataContext = toolDock
+        };
+        var window = new Window
+        {
+            Width = 300,
+            Height = 200,
+            Content = chrome
+        };
+        Styles theme = useSimpleTheme ? new DockSimpleTheme() : new DockFluentTheme();
+        window.Styles.Add(theme);
+        window.Resources["DockChromeGripBrush"] = Brushes.Red;
+
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            chrome.ApplyTemplate();
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            var title = FindNamedControl<TextBlock>(chrome, "PART_Title");
+            var grip = FindNamedControl<Grid>(chrome, "PART_Grid");
+            var header = Assert.IsType<Grid>(grip.Parent);
+            var titleHost = Assert.IsAssignableFrom<Panel>(title.Parent);
+            var buttonStrip = Assert.Single(header.Children.OfType<StackPanel>());
+            var gripBrush = Assert.IsAssignableFrom<ISolidColorBrush>(grip.Background);
+
+            Assert.Equal(Colors.Red, gripBrush.Color);
+            Assert.Equal(0, Grid.GetColumn(titleHost));
+            Assert.Equal(1, Grid.GetColumn(grip));
+            Assert.Equal(2, Grid.GetColumn(buttonStrip));
+            Assert.True(
+                titleHost.Bounds.Right <= grip.Bounds.Left,
+                $"Title host {titleHost.Bounds} overlaps grip {grip.Bounds} in header {header.Bounds}.");
+            Assert.True(
+                grip.Bounds.Right <= buttonStrip.Bounds.Left,
+                $"Grip {grip.Bounds} overlaps button strip {buttonStrip.Bounds} in header {header.Bounds}.");
+            Assert.True(
+                buttonStrip.Bounds.Right <= header.Bounds.Width,
+                $"Button strip {buttonStrip.Bounds} exceeds header {header.Bounds}.");
+            Assert.True(grip.Bounds.Width >= 12d);
+            Assert.Equal(TextTrimming.CharacterEllipsis, title.TextTrimming);
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    private static T FindNamedControl<T>(Control root, string name) where T : Control
+    {
+        T? control = root.GetVisualDescendants().OfType<T>().FirstOrDefault(x => x.Name == name);
+        return Assert.IsType<T>(control);
+    }
+}


### PR DESCRIPTION
## Summary

- give the tool title, drag grip, and chrome buttons distinct grid columns
- keep the title in the star-sized column so long titles remain constrained and ellipsized
- add rendered Avalonia Headless layout coverage for both Fluent and Simple themes with an opaque grip brush

## Root cause

The tool header was changed from a `DockPanel` to a two-column `Grid`, but `PART_Grid` was left without a `Grid.Column`. It therefore defaulted to the title column and painted/hit-tested over `PART_Title` whenever `DockChromeGripBrush` was visible.

The literal `Auto,*,Auto` proposal was tested but made the long title measure to 572 px inside a 282 px header and pushed the grip/buttons out of bounds. The implemented `*,Auto,Auto` layout reserves separate auto-sized columns for the grip and buttons while the title keeps the bounded star column required for `CharacterEllipsis`.

## Validation

- regression test fails on the old template because `PART_Grid` resolves to column 0
- both Fluent and Simple rendered layout cases verify an opaque grip, distinct non-overlapping bounds, in-header buttons, minimum grip width, and ellipsis configuration
- `dotnet test tests/Dock.Avalonia.Themes.UnitTests/Dock.Avalonia.Themes.UnitTests.csproj --no-restore` (66 passed)
- `dotnet test tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj --no-restore` (678 passed)
- Release builds for Fluent, Simple, and Browser themes succeeded for `net8.0` and `net10.0` (0 errors; only 2 pre-existing XML-documentation warnings on the first dependency build)
- `git diff --check`

Fixes #1139.