### PR TITLE
Bump version to 12.1.0.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>12.1.0.2</VersionPrefix>
+    <VersionPrefix>12.1.0.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>


### PR DESCRIPTION
## Summary

- bump the package version from `12.1.0.2` to `12.1.0.3`
- prepare the release containing the fixes merged after `v12.1.0.2`

## Validation

- `dotnet build -c Release --no-restore --nologo`
- `dotnet test -c Release --no-build --nologo --logger "console;verbosity=minimal"`
- `dotnet pack -c Release --no-build --nologo` (30 packages at `12.1.0.3`)