### PR TITLE
Add source-linked Avalonia 11 package lane

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>12.1.0.3</VersionPrefix>
+    <VersionPrefix>12.1.0.4</VersionPrefix>
+    <DockV11VersionPrefix>11.3.20</DockV11VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,11 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <AvaloniaVersion>12.1.0</AvaloniaVersion>
+    <Avalonia11Version>11.3.20</Avalonia11Version>
+    <ReactiveUIAvalonia11Version>11.4.13</ReactiveUIAvalonia11Version>
+    <ReactiveUI23Version>23.2.28</ReactiveUI23Version>
+    <ReactiveUISourceGenerators2Version>2.6.1</ReactiveUISourceGenerators2Version>
+    <SystemReactive6Version>6.1.0</SystemReactive6Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/Dock.slnx
+++ b/Dock.slnx
@@ -31,6 +31,7 @@
     <File Path="build/Avalonia.Diagnostics.props" />
     <File Path="build/Avalonia.Headless.props" />
     <File Path="build/Avalonia.props" />
+    <File Path="build/Dock.Avalonia.v11.props" />
     <File Path="build/Avalonia.Themes.Fluent.props" />
     <File Path="build/Avalonia.Themes.Simple.props" />
     <File Path="build/Avalonia.Web.props" />
@@ -64,6 +65,7 @@
     <Project Path="samples/DockReactiveUIDiSample/DockReactiveUIDiSample.csproj" />
     <Project Path="samples/DockReactiveUIRoutingSample/DockReactiveUIRoutingSample.csproj" />
     <Project Path="samples/DockReactiveUISample/DockReactiveUISample.csproj" />
+    <Project Path="samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj" />
     <Project Path="samples/DockReactiveUIRiderSample/DockReactiveUIRiderSample.csproj" />
     <Project Path="samples/DockReactiveUIManagedSample/DockReactiveUIManagedSample.csproj" />
     <Project Path="samples/DockXamlReactiveUISample/DockXamlReactiveUISample.csproj" />
@@ -80,15 +82,24 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Dock.Avalonia.Diagnostics/Dock.Avalonia.Diagnostics.csproj" />
+    <Project Path="src/Dock.Avalonia.Diagnostics.v11/Dock.Avalonia.Diagnostics.v11.csproj" />
     <Project Path="src/Dock.Avalonia.Themes.Browser/Dock.Avalonia.Themes.Browser.csproj" />
+    <Project Path="src/Dock.Avalonia.Themes.Browser.v11/Dock.Avalonia.Themes.Browser.v11.csproj" />
     <Project Path="src/Dock.Avalonia.Themes.Fluent/Dock.Avalonia.Themes.Fluent.csproj" />
+    <Project Path="src/Dock.Avalonia.Themes.Fluent.v11/Dock.Avalonia.Themes.Fluent.v11.csproj" />
     <Project Path="src/Dock.Avalonia.Themes.Simple/Dock.Avalonia.Themes.Simple.csproj" />
+    <Project Path="src/Dock.Avalonia.Themes.Simple.v11/Dock.Avalonia.Themes.Simple.v11.csproj" />
     <Project Path="src/Dock.Avalonia/Dock.Avalonia.csproj" />
+    <Project Path="src/Dock.Avalonia.v11/Dock.Avalonia.v11.csproj" />
     <Project Path="src/Dock.Controls.DeferredContentControl/Dock.Controls.DeferredContentControl.csproj" />
+    <Project Path="src/Dock.Controls.DeferredContentControl.v11/Dock.Controls.DeferredContentControl.v11.csproj" />
     <Project Path="src/Dock.Controls.ProportionalStackPanel/Dock.Controls.ProportionalStackPanel.csproj" />
+    <Project Path="src/Dock.Controls.ProportionalStackPanel.v11/Dock.Controls.ProportionalStackPanel.v11.csproj" />
     <Project Path="src/Dock.Controls.Recycling.Model/Dock.Controls.Recycling.Model.csproj" />
     <Project Path="src/Dock.Controls.Recycling/Dock.Controls.Recycling.csproj" />
+    <Project Path="src/Dock.Controls.Recycling.v11/Dock.Controls.Recycling.v11.csproj" />
     <Project Path="src/Dock.MarkupExtension/Dock.MarkupExtension.csproj" />
+    <Project Path="src/Dock.MarkupExtension.v11/Dock.MarkupExtension.v11.csproj" />
     <Project Path="src/Dock.Model.Avalonia/Dock.Model.Avalonia.csproj" />
     <Project Path="src/Dock.Model.CaliburMicro/Dock.Model.CaliburMicro.csproj" />
     <Project Path="src/Dock.Model.Inpc/Dock.Model.Inpc.csproj" />
@@ -96,6 +107,7 @@
     <Project Path="src/Dock.Model.Prism/Dock.Model.Prism.csproj" />
     <Project Path="src/Dock.Model.ReactiveProperty/Dock.Model.ReactiveProperty.csproj" />
     <Project Path="src/Dock.Model.ReactiveUI/Dock.Model.ReactiveUI.csproj" />
+    <Project Path="src/Dock.Model.ReactiveUI.v11/Dock.Model.ReactiveUI.v11.csproj" />
     <Project Path="src/Dock.Model.ReactiveUI.Services/Dock.Model.ReactiveUI.Services.csproj" />
     <Project Path="src/Dock.Model.ReactiveUI.Services.Avalonia/Dock.Model.ReactiveUI.Services.Avalonia.csproj" />
     <Project Path="src/Dock.Model.ReactiveUI.Reactive/Dock.Model.ReactiveUI.Reactive.csproj" />
@@ -109,8 +121,10 @@
     <Project Path="src/Dock.Serializer.Xml/Dock.Serializer.Xml.csproj" />
     <Project Path="src/Dock.Serializer.Yaml/Dock.Serializer.Yaml.csproj" />
     <Project Path="src/Dock.Settings/Dock.Settings.csproj" />
+    <Project Path="src/Dock.Settings.v11/Dock.Settings.v11.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Dock.Avalonia.v11.HeadlessTests/Dock.Avalonia.v11.HeadlessTests.csproj" />
     <Project Path="tests/Dock.Avalonia.Diagnostics.UnitTests/Dock.Avalonia.Diagnostics.UnitTests.csproj" />
     <Project Path="tests/Dock.Avalonia.LeakTests/Dock.Avalonia.LeakTests.csproj" />
     <Project Path="tests/Dock.Avalonia.HeadlessTests/Dock.Avalonia.HeadlessTests.csproj" />

--- a/README.md
+++ b/README.md
@@ -67,24 +67,6 @@ Install-Package Dock.Avalonia.Themes.Browser
 Install-Package Dock.Controls.DeferredContentControl
 ```
 
-### Avalonia 11 packages
-
-Applications that remain on Avalonia 11 should use the `.v11` package lane. These packages are source-linked from the current Dock implementation, target Avalonia 11.3.20, and must not be mixed with the unsuffixed Avalonia 12 Dock packages.
-
-```powershell
-Install-Package Dock.Avalonia.v11
-Install-Package Dock.Avalonia.Diagnostics.v11
-Install-Package Dock.Avalonia.Themes.Fluent.v11
-Install-Package Dock.Avalonia.Themes.Browser.v11
-Install-Package Dock.Avalonia.Themes.Simple.v11
-```
-
-The Avalonia 11 ReactiveUI sample can be built with:
-
-```bash
-dotnet build samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj -c Release
-```
-
 **Available NuGet packages:**
 
 | NuGet | Package | Downloads |
@@ -118,6 +100,24 @@ dotnet build samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj -c
 | [![NuGet](https://img.shields.io/nuget/v/Dock.Serializer.Xml.svg)](https://www.nuget.org/packages/Dock.Serializer.Xml) | [`Dock.Serializer.Xml`](https://www.nuget.org/packages/Dock.Serializer.Xml) | [![Downloads](https://img.shields.io/nuget/dt/Dock.Serializer.Xml.svg)](https://www.nuget.org/packages/Dock.Serializer.Xml) |
 | [![NuGet](https://img.shields.io/nuget/v/Dock.Serializer.Yaml.svg)](https://www.nuget.org/packages/Dock.Serializer.Yaml) | [`Dock.Serializer.Yaml`](https://www.nuget.org/packages/Dock.Serializer.Yaml) | [![Downloads](https://img.shields.io/nuget/dt/Dock.Serializer.Yaml.svg)](https://www.nuget.org/packages/Dock.Serializer.Yaml) |
 | [![NuGet](https://img.shields.io/nuget/v/Dock.Settings.svg)](https://www.nuget.org/packages/Dock.Settings) | [`Dock.Settings`](https://www.nuget.org/packages/Dock.Settings) | [![Downloads](https://img.shields.io/nuget/dt/Dock.Settings.svg)](https://www.nuget.org/packages/Dock.Settings) |
+
+### Avalonia 11 packages
+
+Applications that remain on Avalonia 11 should use the `.v11` package lane. These packages are source-linked from the current Dock implementation, target Avalonia 11.3.20, and must not be mixed with the unsuffixed Avalonia 12 Dock packages.
+
+```powershell
+Install-Package Dock.Avalonia.v11
+Install-Package Dock.Avalonia.Diagnostics.v11
+Install-Package Dock.Avalonia.Themes.Fluent.v11
+Install-Package Dock.Avalonia.Themes.Browser.v11
+Install-Package Dock.Avalonia.Themes.Simple.v11
+```
+
+The Avalonia 11 ReactiveUI sample can be built with:
+
+```bash
+dotnet build samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj -c Release
+```
 
 ## Nightly Packages
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ Install-Package Dock.Avalonia.Themes.Browser
 Install-Package Dock.Controls.DeferredContentControl
 ```
 
+### Avalonia 11 packages
+
+Applications that remain on Avalonia 11 should use the `.v11` package lane. These packages are source-linked from the current Dock implementation, target Avalonia 11.3.20, and must not be mixed with the unsuffixed Avalonia 12 Dock packages.
+
+```powershell
+Install-Package Dock.Avalonia.v11
+Install-Package Dock.Avalonia.Diagnostics.v11
+Install-Package Dock.Avalonia.Themes.Fluent.v11
+Install-Package Dock.Avalonia.Themes.Browser.v11
+Install-Package Dock.Avalonia.Themes.Simple.v11
+```
+
+The Avalonia 11 ReactiveUI sample can be built with:
+
+```bash
+dotnet build samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj -c Release
+```
+
 **Available NuGet packages:**
 
 | NuGet | Package | Downloads |

--- a/build/Dock.Avalonia.v11.props
+++ b/build/Dock.Avalonia.v11.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <VersionPrefix>$(DockV11VersionPrefix)</VersionPrefix>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Nullable>enable</Nullable>
     <AssemblyName>$(DockSourceProjectName)</AssemblyName>

--- a/build/Dock.Avalonia.v11.props
+++ b/build/Dock.Avalonia.v11.props
@@ -1,0 +1,35 @@
+<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
+    <AssemblyName>$(DockSourceProjectName)</AssemblyName>
+    <RootNamespace Condition="'$(RootNamespace)' == ''">$(DockSourceProjectName)</RootNamespace>
+    <PackageId>$(DockSourceProjectName).v11</PackageId>
+    <DefineConstants>$(DefineConstants);AVALONIA_11</DefineConstants>
+  </PropertyGroup>
+
+  <Import Project="SignAssembly.props" />
+  <Import Project="SourceLink.props" />
+  <Import Project="ReferenceAssemblies.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" VersionOverride="$(Avalonia11Version)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(DockSourceProjectDirectory)\**\*.cs"
+             Exclude="$(DockSourceProjectDirectory)\bin\**;$(DockSourceProjectDirectory)\obj\**;$(DockAvalonia11CompileExcludes)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <AvaloniaXaml Include="$(DockSourceProjectDirectory)\**\*.axaml"
+                  Exclude="$(DockSourceProjectDirectory)\bin\**;$(DockSourceProjectDirectory)\obj\**;$(DockAvalonia11ResourceExcludes)">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </AvaloniaXaml>
+    <AvaloniaResource Include="$(DockSourceProjectDirectory)\Assets\*"
+                      Condition="Exists('$(DockSourceProjectDirectory)\Assets')">
+      <Link>Assets\%(Filename)%(Extension)</Link>
+    </AvaloniaResource>
+  </ItemGroup>
+</Project>

--- a/samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj
+++ b/samples/DockReactiveUISample.v11/DockReactiveUISample.v11.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>WinExe</OutputType>
+    <AssemblyName>DockReactiveUISample</AssemblyName>
+    <RootNamespace>DockReactiveUISample</RootNamespace>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
+    <AvaloniaNameGeneratorBehavior>InitializeComponent</AvaloniaNameGeneratorBehavior>
+    <DockEnableGeneratedAppInitializeComponent>true</DockEnableGeneratedAppInitializeComponent>
+    <DefineConstants>$(DefineConstants);AVALONIA_11</DefineConstants>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="Avalonia.Desktop" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="Avalonia.Fonts.Inter" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="ReactiveUI.Avalonia" VersionOverride="$(ReactiveUIAvalonia11Version)" />
+    <PackageReference Include="ReactiveUI" VersionOverride="$(ReactiveUI23Version)" />
+    <PackageReference Include="System.Reactive" VersionOverride="$(SystemReactive6Version)" />
+    <PackageReference Include="StaticViewLocator">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\DockReactiveUISample\**\*.cs"
+             Exclude="..\DockReactiveUISample\bin\**;..\DockReactiveUISample\obj\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <AvaloniaXaml Include="..\DockReactiveUISample\**\*.axaml"
+                  Exclude="..\DockReactiveUISample\bin\**;..\DockReactiveUISample\obj\**;..\DockReactiveUISample\Views\MainView.axaml">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </AvaloniaXaml>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dock.Model.ReactiveUI.v11\Dock.Model.ReactiveUI.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Diagnostics.v11\Dock.Avalonia.Diagnostics.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Fluent.v11\Dock.Avalonia.Themes.Fluent.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Serializer.Newtonsoft\Dock.Serializer.Newtonsoft.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/DockReactiveUISample.v11/Views/MainView.axaml
+++ b/samples/DockReactiveUISample.v11/Views/MainView.axaml
@@ -1,0 +1,85 @@
+<UserControl x:Class="DockReactiveUISample.Views.MainView"
+             xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:dmc="using:Dock.Model.Controls"
+             xmlns:vm="using:DockReactiveUISample.ViewModels"
+             mc:Ignorable="d"
+             d:DesignWidth="1000" d:DesignHeight="550"
+             x:DataType="vm:MainWindowViewModel" x:CompileBindings="True"
+             FontFamily="avares://Avalonia.Fonts.Inter/Assets#Inter">
+  <Design.DataContext>
+    <vm:MainWindowViewModel />
+  </Design.DataContext>
+  <UserControl.Resources>
+    <StreamGeometry x:Key="DarkTheme">M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10Zm0-2V4a8 8 0 1 1 0 16Z</StreamGeometry>
+  </UserControl.Resources>
+  <Grid RowDefinitions="Auto,*,Auto" ColumnDefinitions="Auto,*" Background="Transparent">
+    <Menu Grid.Row="0" Grid.Column="0" VerticalAlignment="Top">
+      <MenuItem Header="_File">
+        <MenuItem Header="_New Layout" Command="{Binding NewLayout}" />
+      </MenuItem>
+      <MenuItem Header="_Window" DataContext="{Binding Layout}">
+        <MenuItem Header="_Exit Windows" Command="{Binding ExitWindows}" />
+        <Separator />
+        <MenuItem Header="_Show Windows" Command="{Binding ShowWindows}" />
+      </MenuItem>
+    </Menu>
+    <Panel x:Name="ToolBar" DataContext="{Binding Layout}" Grid.Row="0" Grid.Column="1">
+      <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,200,Auto,Auto,Auto"
+            HorizontalAlignment="Right"
+            Margin="4"
+            x:DataType="dmc:IRootDock">
+        <Grid.Styles>
+          <Style Selector="Button">
+            <Setter Property="Margin" Value="0" />
+            <Setter Property="Padding" Value="4" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+          </Style>
+          <Style Selector="TextBox">
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Margin" Value="4,0,4,0" />
+            <Setter Property="Padding" Value="4" />
+            <Setter Property="VerticalAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+          </Style>
+          <Style Selector="ComboBox">
+            <Setter Property="Margin" Value="4,0,0,0" />
+            <Setter Property="Padding" Value="4" />
+          </Style>
+        </Grid.Styles>
+        <Button Content="Back" Command="{Binding GoBack}" IsEnabled="{Binding CanGoBack}" Grid.Column="0" />
+        <Button Content="Forward" Command="{Binding GoForward}" IsEnabled="{Binding CanGoForward}" Grid.Column="1" />
+        <Button Content="Dashboard" Command="{Binding Navigate}" CommandParameter="Dashboard" Grid.Column="2" />
+        <Button Content="Home" Command="{Binding Navigate}" CommandParameter="{Binding DefaultDockable}"
+                Grid.Column="3" />
+        <TextBox x:Name="Id" Text="" Watermark="Dashboard" UseFloatingWatermark="True" Grid.Column="4" />
+        <Button Content="Navigate" Command="{Binding Navigate}" CommandParameter="{Binding #Id.Text}" Grid.Column="5" />
+        <ComboBox x:Name="PresetComboBox"
+                  Grid.Column="6"
+                  Width="160"
+                  HorizontalContentAlignment="Left" />
+        <Button x:Name="ThemeButton" Grid.Column="7" Background="Transparent">
+          <PathIcon Width="24" Height="24" Opacity="0.6" Data="{StaticResource DarkTheme}"/>
+        </Button>
+      </Grid>
+    </Panel>
+    <DockControl x:Name="DockControl" Layout="{Binding Layout}" Margin="4"
+                 Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" />
+    <Border Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            Margin="4,0,4,4"
+            Padding="6,2"
+            Background="{DynamicResource DockThemeBackgroundLowBrush}"
+            BorderBrush="{DynamicResource DockThemeBorderMidBrush}"
+            BorderThickness="1"
+            CornerRadius="4">
+      <TextBlock Text="{Binding GlobalStatus}"
+                 VerticalAlignment="Center"
+                 TextTrimming="CharacterEllipsis" />
+    </Border>
+  </Grid>
+</UserControl>

--- a/samples/DockReactiveUISample/Program.cs
+++ b/samples/DockReactiveUISample/Program.cs
@@ -1,7 +1,11 @@
 // Copyright (c) Wiesław Šoltés. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using Avalonia;
+#if AVALONIA_11
+using ReactiveUI.Avalonia;
+#else
 using ReactiveUI.Avalonia.Reactive;
+#endif
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Dock.Settings;

--- a/samples/DockReactiveUISample/ViewLocator.cs
+++ b/samples/DockReactiveUISample/ViewLocator.cs
@@ -3,7 +3,11 @@ using Avalonia.Controls;
 using Avalonia.Controls.Templates;
 //using CommunityToolkit.Mvvm.ComponentModel;
 using Dock.Model.Core;
+#if AVALONIA_11
+using ReactiveUI;
+#else
 using ReactiveUI.Reactive;
+#endif
 using StaticViewLocator;
 
 namespace DockReactiveUISample;

--- a/samples/DockReactiveUISample/ViewModels/Docks/CustomDocumentDock.cs
+++ b/samples/DockReactiveUISample/ViewModels/Docks/CustomDocumentDock.cs
@@ -1,7 +1,11 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using DockReactiveUISample.ViewModels.Documents;
 using Dock.Model.ReactiveUI.Controls;
+#if AVALONIA_11
+using ReactiveUI;
+#else
 using ReactiveUI.Reactive;
+#endif
 
 namespace DockReactiveUISample.ViewModels.Docks;
 

--- a/samples/DockReactiveUISample/ViewModels/MainWindowViewModel.cs
+++ b/samples/DockReactiveUISample/ViewModels/MainWindowViewModel.cs
@@ -4,7 +4,11 @@ using System.Windows.Input;
 using DockReactiveUISample.Models;
 using Dock.Model.Controls;
 using Dock.Model.Core;
+#if AVALONIA_11
+using ReactiveUI;
+#else
 using ReactiveUI.Reactive;
+#endif
 
 namespace DockReactiveUISample.ViewModels;
 

--- a/src/Dock.Avalonia.Diagnostics.v11/Dock.Avalonia.Diagnostics.v11.csproj
+++ b/src/Dock.Avalonia.Diagnostics.v11/Dock.Avalonia.Diagnostics.v11.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Avalonia.Diagnostics</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Avalonia.Diagnostics</DockSourceProjectDirectory>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Avalonia.Themes.Browser.v11/Dock.Avalonia.Themes.Browser.v11.csproj
+++ b/src/Dock.Avalonia.Themes.Browser.v11/Dock.Avalonia.Themes.Browser.v11.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Avalonia.Themes.Browser</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Avalonia.Themes.Browser</DockSourceProjectDirectory>
+    <DockAvalonia11ResourceExcludes>$(DockSourceProjectDirectory)\Styles\Controls\HostWindow.axaml</DockAvalonia11ResourceExcludes>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+    <ProjectReference Include="..\Dock.Avalonia.Themes.Fluent.v11\Dock.Avalonia.Themes.Fluent.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Avalonia.Themes.Browser.v11/Styles/Controls/HostWindow.axaml
+++ b/src/Dock.Avalonia.Themes.Browser.v11/Styles/Controls/HostWindow.axaml
@@ -1,0 +1,135 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+                    xmlns:platform="clr-namespace:Avalonia.Platform;assembly=Avalonia.Controls"
+                    x:CompileBindings="True"
+                    x:DataType="controls:IRootDock">
+  <Design.PreviewWith>
+    <HostWindow IsToolWindow="False" Width="300" Height="400" />
+  </Design.PreviewWith>
+
+  <IntLessThanConverter x:Key="LessThan2" TrueIfLessThan="2" />
+  <OnPlatform x:Key="DockHostWindowChromeHints"
+              x:TypeArguments="platform:ExtendClientAreaChromeHints"
+              Default="PreferSystemChrome"
+              macOS="Default, PreferSystemChrome, OSXThickTitleBar"
+              Windows="PreferSystemChrome" />
+
+  <ControlTheme x:Key="{x:Type HostWindow}" TargetType="HostWindow">
+    <Setter Property="(AutomationProperties.AutomationId)" Value="{Binding Id}" />
+    <Setter Property="(AutomationProperties.Name)" Value="{Binding Title}" />
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+    <Setter Property="(DockProperties.DockGroup)" Value="{Binding DockGroup}" />
+    <Setter Property="Background" Value="{DynamicResource DockSurfaceEditorBrush}" />
+    <Setter Property="Padding" Value="{DynamicResource DockHostWindowContentPadding}" />
+    <Setter Property="(TextElement.FontSize)" Value="{DynamicResource DockFontSizeNormal}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource DockTabForegroundBrush}" />
+    <Setter Property="WindowState" Value="Normal" />
+    <Setter Property="UseLayoutRounding" Value="True" />
+    <Setter Property="Title" Value="{Binding FocusedDockable.Title}" />
+    <Setter Property="Topmost" Value="{Binding Window.Topmost}" />
+    <Setter Property="SystemDecorations" Value="Full" />
+    <Setter Property="ToolChromeControlsWholeWindow" Value="{Binding OpenedDockablesCount, Converter={StaticResource LessThan2}}" />
+    <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+    <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+    <Setter Property="ExtendClientAreaChromeHints" Value="{DynamicResource DockHostWindowChromeHints}" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+          <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+          <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+          <VisualLayerManager>
+            <VisualLayerManager.ChromeOverlayLayer>
+              <HostWindowTitleBar Name="PART_TitleBar" />
+            </VisualLayerManager.ChromeOverlayLayer>
+            <ContentPresenter Name="PART_ContentPresenter"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Content="{TemplateBinding Content}"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </VisualLayerManager>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Setter Property="Content" Value="{Binding}" />
+    <Setter Property="ContentTemplate">
+      <DataTemplate x:DataType="controls:IRootDock">
+        <Panel Margin="{Binding $parent[HostWindow].OffScreenMargin}">
+          <Panel Margin="{Binding $parent[HostWindow].WindowDecorationMargin}">
+            <OverlayHost VisualTreeLifecycleBehavior.IsEnabled="True">
+              <DockControl Layout="{Binding}" />
+            </OverlayHost>
+          </Panel>
+        </Panel>
+      </DataTemplate>
+    </Setter>
+
+    <Style Selector="^:documentwindow">
+      <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+      <Style Selector="^:documentchromecontrolswindow">
+        <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:toolwindow">
+      <Setter Property="SystemDecorations" Value="Full" />
+      <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+      <Style Selector="^:toolchromecontrolswindow">
+        <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+      </Style>
+
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Panel>
+            <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+            <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+            <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+            <VisualLayerManager>
+              <VisualLayerManager.ChromeOverlayLayer />
+              <ContentPresenter Name="PART_ContentPresenter"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                Content="{TemplateBinding Content}"
+                                Margin="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </VisualLayerManager>
+          </Panel>
+        </ControlTemplate>
+      </Setter>
+
+      <Setter Property="Content" Value="{Binding}" />
+      <Setter Property="ContentTemplate">
+        <DataTemplate x:DataType="controls:IRootDock">
+          <Panel Margin="{Binding $parent[HostWindow].OffScreenMargin}">
+            <OverlayHost VisualTreeLifecycleBehavior.IsEnabled="True">
+              <DockControl Layout="{Binding}" />
+            </OverlayHost>
+          </Panel>
+        </DataTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:toolwindow">
+      <Setter Property="Background" Value="{DynamicResource DockSurfaceEditorBrush}" />
+      <Setter Property="TransparencyLevelHint" Value="None" />
+      <Setter Property="Opacity" Value="1.0" />
+    </Style>
+
+    <Style Selector="^:toolwindow:dragging">
+      <Setter Property="Background" Value="{x:Null}" />
+      <Setter Property="TransparencyLevelHint" Value="Transparent" />
+      <Setter Property="Opacity" Value="0.5" />
+    </Style>
+
+    <Style Selector="^TitleBar /template/ Border#PART_Background">
+      <Setter Property="IsHitTestVisible" Value="True" />
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/DockAdornerWindow.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/DockAdornerWindow.axaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <ControlTheme x:Key="{x:Type DockAdornerWindow}" TargetType="DockAdornerWindow"
+                BasedOn="{StaticResource {x:Type Window}}">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+    <Setter Property="CanResize" Value="False" />
+    <Setter Property="ShowActivated" Value="False" />
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="TransparencyLevelHint" Value="Transparent" />
+    <Setter Property="SizeToContent" Value="WidthAndHeight" />
+    <Setter Property="Topmost" Value="False" />
+    <Setter Property="IsHitTestVisible" Value="False" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/DragPreviewWindow.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/DragPreviewWindow.axaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <ControlTheme x:Key="{x:Type DragPreviewWindow}" TargetType="DragPreviewWindow"
+                BasedOn="{StaticResource {x:Type Window}}">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+    <Setter Property="CanResize" Value="False" />
+    <Setter Property="ShowActivated" Value="False" />
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="TransparencyLevelHint" Value="Transparent" />
+    <Setter Property="SizeToContent" Value="WidthAndHeight" />
+    <Setter Property="Topmost" Value="True" />
+    <Setter Property="IsHitTestVisible" Value="False" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/HostWindow.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/HostWindow.axaml
@@ -1,0 +1,127 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:controls="clr-namespace:Dock.Model.Controls;assembly=Dock.Model"
+                    x:CompileBindings="True"
+                    x:DataType="controls:IRootDock">
+  <Design.PreviewWith>
+    <HostWindow IsToolWindow="False" Width="300" Height="400" />
+  </Design.PreviewWith>
+
+  <IntLessThanConverter x:Key="LessThan2" TrueIfLessThan="2" />
+
+  <ControlTheme x:Key="{x:Type HostWindow}" TargetType="HostWindow">
+    <Setter Property="(AutomationProperties.AutomationId)" Value="{Binding Id}" />
+    <Setter Property="(AutomationProperties.Name)" Value="{Binding Title}" />
+    <Setter Property="(DockProperties.IsDragEnabled)" Value="{Binding CanDrag}" />
+    <Setter Property="(DockProperties.IsDropEnabled)" Value="{Binding CanDrop}" />
+    <Setter Property="(DockProperties.DockGroup)" Value="{Binding DockGroup}" />
+    <Setter Property="Background" Value="{DynamicResource DockSurfaceEditorBrush}" />
+    <Setter Property="(TextElement.FontSize)" Value="{DynamicResource DockFontSizeNormal}" />
+    <Setter Property="TextBlock.Foreground" Value="{DynamicResource DockTabForegroundBrush}" />
+    <Setter Property="WindowState" Value="Normal" />
+    <Setter Property="UseLayoutRounding" Value="True" />
+    <Setter Property="Title" Value="{Binding FocusedDockable.Title}" />
+    <Setter Property="Topmost" Value="{Binding Window.Topmost}" />
+    <Setter Property="SystemDecorations" Value="Full" />
+    <Setter Property="ToolChromeControlsWholeWindow" Value="{Binding OpenedDockablesCount, Converter={StaticResource LessThan2}}" />
+    <Setter Property="ExtendClientAreaToDecorationsHint" Value="False" />
+    <Setter Property="ExtendClientAreaChromeHints" Value="PreferSystemChrome" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel>
+          <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+          <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+          <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+          <VisualLayerManager>
+            <VisualLayerManager.ChromeOverlayLayer>
+              <HostWindowTitleBar Name="PART_TitleBar" />
+            </VisualLayerManager.ChromeOverlayLayer>
+            <DeferredContentPresenter Name="PART_ContentPresenter"
+                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                      Content="{TemplateBinding Content}"
+                                      Margin="{TemplateBinding Padding}"
+                                      HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                      VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </VisualLayerManager>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Setter Property="Content" Value="{Binding}" />
+    <Setter Property="ContentTemplate">
+      <DataTemplate x:DataType="controls:IRootDock">
+        <Panel Margin="{Binding $parent[HostWindow].OffScreenMargin}">
+          <Panel Margin="{Binding $parent[HostWindow].WindowDecorationMargin}">
+            <OverlayHost VisualTreeLifecycleBehavior.IsEnabled="True">
+              <DockControl Layout="{Binding}" />
+            </OverlayHost>
+          </Panel>
+        </Panel>
+      </DataTemplate>
+    </Setter>
+
+    <Style Selector="^:documentwindow">
+      <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+      <Style Selector="^:documentchromecontrolswindow">
+        <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+      </Style>
+    </Style>
+
+    <Style Selector="^:toolwindow">
+      <Setter Property="SystemDecorations" Value="Full" />
+      <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+      <Style Selector="^:toolchromecontrolswindow">
+        <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+      </Style>
+
+      <Setter Property="Template">
+        <ControlTemplate>
+          <Panel>
+            <Border Name="PART_TransparencyFallback" IsHitTestVisible="False" />
+            <Border Background="{TemplateBinding Background}" IsHitTestVisible="False" />
+            <Panel Background="Transparent" Margin="{TemplateBinding WindowDecorationMargin}" />
+            <VisualLayerManager>
+              <VisualLayerManager.ChromeOverlayLayer />
+              <DeferredContentPresenter Name="PART_ContentPresenter"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        Content="{TemplateBinding Content}"
+                                        Margin="{TemplateBinding Padding}"
+                                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+            </VisualLayerManager>
+          </Panel>
+        </ControlTemplate>
+      </Setter>
+
+      <Setter Property="Content" Value="{Binding}" />
+      <Setter Property="ContentTemplate">
+        <DataTemplate x:DataType="controls:IRootDock">
+          <Panel Margin="{Binding $parent[HostWindow].OffScreenMargin}">
+            <OverlayHost VisualTreeLifecycleBehavior.IsEnabled="True">
+              <DockControl Layout="{Binding}" />
+            </OverlayHost>
+          </Panel>
+        </DataTemplate>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:toolwindow">
+      <Setter Property="Background" Value="{DynamicResource DockSurfaceEditorBrush}" />
+      <Setter Property="TransparencyLevelHint" Value="None" />
+      <Setter Property="Opacity" Value="1.0" />
+    </Style>
+
+    <Style Selector="^:toolwindow:dragging">
+      <Setter Property="Background" Value="{x:Null}" />
+      <Setter Property="TransparencyLevelHint" Value="Transparent" />
+      <Setter Property="Opacity" Value="0.5" />
+    </Style>
+
+    <Style Selector="^TitleBar /template/ Border#PART_Background">
+      <Setter Property="IsHitTestVisible" Value="True" />
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/HostWindowTitleBar.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/HostWindowTitleBar.axaml
@@ -1,0 +1,60 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <Design.PreviewWith>
+    <Border>
+      <HostWindowTitleBar Background="SkyBlue" Height="30" Width="300" Foreground="Black" />
+    </Border>
+  </Design.PreviewWith>
+
+  <ControlTheme x:Key="{x:Type HostWindowTitleBar}" TargetType="HostWindowTitleBar">
+    <Setter Property="Foreground" Value="{DynamicResource DockTabForegroundBrush}"/>
+    <Setter Property="VerticalAlignment" Value="Top" />
+    <Setter Property="HorizontalAlignment" Value="Stretch" />
+    <Setter Property="Background" Value="Transparent" />
+
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Panel HorizontalAlignment="{TemplateBinding HorizontalAlignment}" VerticalAlignment="Stretch">
+          <Panel x:Name="PART_MouseTracker" Height="{DynamicResource DockHostTitleBarMouseTrackerHeight}" VerticalAlignment="Top" />
+          <Panel x:Name="PART_Container">
+            <Border x:Name="PART_Background" Background="{TemplateBinding Background}" />
+            <CaptionButtons x:Name="PART_CaptionButtons"
+                            VerticalAlignment="Top"
+                            HorizontalAlignment="Right"
+                            Foreground="{TemplateBinding Foreground}" />
+          </Panel>
+        </Panel>
+      </ControlTemplate>
+    </Setter>
+
+    <Style Selector="^:fullscreen">
+      <Setter Property="Background" Value="{DynamicResource SystemAccentColor}" />
+    </Style>
+
+    <Style Selector="^/template/ Border#PART_Background">
+      <Setter Property="IsHitTestVisible" Value="False" />
+    </Style>
+
+    <Style Selector="^:fullscreen /template/ Border#PART_Background">
+      <Setter Property="IsHitTestVisible" Value="True" />
+    </Style>
+
+    <Style Selector="^:fullscreen /template/ Panel#PART_MouseTracker">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+
+    <Style Selector="^:fullscreen /template/ Panel#PART_Container">
+      <Setter Property="RenderTransform" Value="translateY(-30px)" />
+      <Setter Property="Transitions">
+        <Transitions>
+          <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.25" />
+        </Transitions>
+      </Setter>
+    </Style>
+
+    <Style Selector="^:fullscreen:pointerover /template/ Panel#PART_Container">
+      <Setter Property="RenderTransform" Value="none" />
+    </Style>
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/PinnedDockWindow.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/PinnedDockWindow.axaml
@@ -1,0 +1,16 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    x:CompileBindings="True">
+  <ControlTheme x:Key="{x:Type PinnedDockWindow}" TargetType="PinnedDockWindow"
+                BasedOn="{StaticResource {x:Type Window}}">
+    <Setter Property="SystemDecorations" Value="None" />
+    <Setter Property="ShowInTaskbar" Value="False" />
+    <Setter Property="CanResize" Value="False" />
+    <Setter Property="ShowActivated" Value="False" />
+    <Setter Property="Background" Value="{x:Null}" />
+    <Setter Property="TransparencyLevelHint" Value="Transparent" />
+    <Setter Property="SizeToContent" Value="Manual" />
+    <Setter Property="Topmost" Value="False" />
+    <Setter Property="IsHitTestVisible" Value="True" />
+  </ControlTheme>
+</ResourceDictionary>

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Controls/WindowDrawnDecorations.axaml
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Controls/WindowDrawnDecorations.axaml
@@ -1,0 +1,2 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />

--- a/src/Dock.Avalonia.Themes.Fluent.v11/Dock.Avalonia.Themes.Fluent.v11.csproj
+++ b/src/Dock.Avalonia.Themes.Fluent.v11/Dock.Avalonia.Themes.Fluent.v11.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Avalonia.Themes.Fluent</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Avalonia.Themes.Fluent</DockSourceProjectDirectory>
+    <DockAvalonia11ResourceExcludes>$(DockSourceProjectDirectory)\Controls\DockAdornerWindow.axaml;$(DockSourceProjectDirectory)\Controls\DragPreviewWindow.axaml;$(DockSourceProjectDirectory)\Controls\HostWindow.axaml;$(DockSourceProjectDirectory)\Controls\HostWindowTitleBar.axaml;$(DockSourceProjectDirectory)\Controls\PinnedDockWindow.axaml;$(DockSourceProjectDirectory)\Controls\WindowDrawnDecorations.axaml</DockAvalonia11ResourceExcludes>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Avalonia.Themes.Simple.v11/Dock.Avalonia.Themes.Simple.v11.csproj
+++ b/src/Dock.Avalonia.Themes.Simple.v11/Dock.Avalonia.Themes.Simple.v11.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Avalonia.Themes.Simple</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Avalonia.Themes.Simple</DockSourceProjectDirectory>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <AvaloniaResource Include="..\Dock.Avalonia.Themes.Fluent\Controls\**\*.axaml"
+                      Exclude="..\Dock.Avalonia.Themes.Fluent\Controls\DockAdornerWindow.axaml;..\Dock.Avalonia.Themes.Fluent\Controls\DragPreviewWindow.axaml;..\Dock.Avalonia.Themes.Fluent\Controls\HostWindow.axaml;..\Dock.Avalonia.Themes.Fluent\Controls\HostWindowTitleBar.axaml;..\Dock.Avalonia.Themes.Fluent\Controls\PinnedDockWindow.axaml;..\Dock.Avalonia.Themes.Fluent\Controls\WindowDrawnDecorations.axaml">
+      <Link>Controls\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </AvaloniaResource>
+    <AvaloniaResource Include="..\Dock.Avalonia.Themes.Fluent.v11\Controls\**\*.axaml">
+      <Link>Controls\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </AvaloniaResource>
+    <AvaloniaResource Include="..\Dock.Avalonia.Themes.Fluent\Assets\*">
+      <Link>Assets\%(Filename)%(Extension)</Link>
+    </AvaloniaResource>
+    <ProjectReference Include="..\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Avalonia.v11/Dock.Avalonia.v11.csproj
+++ b/src/Dock.Avalonia.v11/Dock.Avalonia.v11.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Avalonia</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Avalonia</DockSourceProjectDirectory>
+    <DockAvalonia11CompileExcludes>$(DockSourceProjectDirectory)\Internal\VisualRootCompatExtensions.cs</DockAvalonia11CompileExcludes>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Controls.DeferredContentControl.v11\Dock.Controls.DeferredContentControl.v11.csproj" />
+    <ProjectReference Include="..\Dock.Controls.ProportionalStackPanel.v11\Dock.Controls.ProportionalStackPanel.v11.csproj" />
+    <ProjectReference Include="..\Dock.Controls.Recycling.v11\Dock.Controls.Recycling.v11.csproj" />
+    <ProjectReference Include="..\Dock.MarkupExtension.v11\Dock.MarkupExtension.v11.csproj" />
+    <ProjectReference Include="..\Dock.Model\Dock.Model.csproj" />
+    <ProjectReference Include="..\Dock.Settings.v11\Dock.Settings.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindow.axaml.cs
@@ -7,8 +7,14 @@ using Avalonia;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+#if AVALONIA_11
+using Avalonia.Controls.Primitives;
+#endif
 using Avalonia.Input;
 using Avalonia.Interactivity;
+#if AVALONIA_11
+using Avalonia.VisualTree;
+#endif
 using Dock.Avalonia.Automation.Peers;
 using Dock.Avalonia.Internal;
 using Dock.Model;
@@ -22,10 +28,16 @@ namespace Dock.Avalonia.Controls;
 /// Interaction logic for <see cref="HostWindow"/> xaml.
 /// </summary>
 [PseudoClasses(":toolwindow", ":dragging", ":toolchromecontrolswindow", ":documentchromecontrolswindow")]
+#if AVALONIA_11
+[TemplatePart("PART_TitleBar", typeof(HostWindowTitleBar))]
+#endif
 public class HostWindow : Window, IHostWindow
 {
     private readonly HostWindowState _hostWindowState;
     private List<Control> _chromeGrips = new();
+#if AVALONIA_11
+    private HostWindowTitleBar? _hostWindowTitleBar;
+#endif
     private bool _mouseDown, _draggingWindow;
     private double _normalX = double.NaN;
     private double _normalY = double.NaN;
@@ -123,6 +135,28 @@ public class HostWindow : Window, IHostWindow
     {
         return new HostWindowAutomationPeer(this);
     }
+
+#if AVALONIA_11
+    /// <inheritdoc/>
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        _hostWindowTitleBar = e.NameScope.Find<HostWindowTitleBar>("PART_TitleBar");
+        if (_hostWindowTitleBar is { })
+        {
+            _hostWindowTitleBar.ApplyTemplate();
+
+            if (_hostWindowTitleBar.BackgroundControl is { })
+            {
+                _hostWindowTitleBar.BackgroundControl.PointerPressed += (_, args) =>
+                {
+                    MoveDrag(args);
+                };
+            }
+        }
+    }
+#endif
 
     private PixelPoint ClientPointToScreenRelativeToWindow(Point clientPoint)
     {

--- a/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
+++ b/src/Dock.Avalonia/Controls/HostWindowTitleBar.axaml.cs
@@ -5,6 +5,9 @@ using Avalonia;
 using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
+#if AVALONIA_11
+using Avalonia.Controls.Chrome;
+#endif
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
 using Dock.Avalonia.Automation.Peers;
@@ -15,7 +18,12 @@ namespace Dock.Avalonia.Controls;
 /// Interaction logic for <see cref="HostWindowTitleBar"/> xaml.
 /// </summary>
 [TemplatePart("PART_Background", typeof(Control))]
-public class HostWindowTitleBar : TemplatedControl
+public class HostWindowTitleBar :
+#if AVALONIA_11
+    TitleBar
+#else
+    TemplatedControl
+#endif
 {
     internal Control? BackgroundControl { get; private set; }
 

--- a/src/Dock.Controls.DeferredContentControl.v11/Dock.Controls.DeferredContentControl.v11.csproj
+++ b/src/Dock.Controls.DeferredContentControl.v11/Dock.Controls.DeferredContentControl.v11.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Controls.DeferredContentControl</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Controls.DeferredContentControl</DockSourceProjectDirectory>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+</Project>

--- a/src/Dock.Controls.ProportionalStackPanel.v11/Dock.Controls.ProportionalStackPanel.v11.csproj
+++ b/src/Dock.Controls.ProportionalStackPanel.v11/Dock.Controls.ProportionalStackPanel.v11.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Controls.ProportionalStackPanel</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Controls.ProportionalStackPanel</DockSourceProjectDirectory>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+</Project>

--- a/src/Dock.Controls.Recycling.v11/Dock.Controls.Recycling.v11.csproj
+++ b/src/Dock.Controls.Recycling.v11/Dock.Controls.Recycling.v11.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Controls.Recycling</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Controls.Recycling</DockSourceProjectDirectory>
+    <RootNamespace>Avalonia.Controls.Recycling</RootNamespace>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Controls.Recycling.Model\Dock.Controls.Recycling.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.MarkupExtension.v11/Dock.MarkupExtension.v11.csproj
+++ b/src/Dock.MarkupExtension.v11/Dock.MarkupExtension.v11.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.MarkupExtension</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.MarkupExtension</DockSourceProjectDirectory>
+    <RootNamespace>Avalonia.MarkupExtension</RootNamespace>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+</Project>

--- a/src/Dock.Model.ReactiveUI.v11/Dock.Model.ReactiveUI.v11.csproj
+++ b/src/Dock.Model.ReactiveUI.v11/Dock.Model.ReactiveUI.v11.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <VersionPrefix>$(DockV11VersionPrefix)</VersionPrefix>
     <AssemblyName>Dock.Model.ReactiveUI</AssemblyName>
     <RootNamespace>Dock.Model.ReactiveUI</RootNamespace>
     <PackageId>Dock.Model.ReactiveUI.v11</PackageId>

--- a/src/Dock.Model.ReactiveUI.v11/Dock.Model.ReactiveUI.v11.csproj
+++ b/src/Dock.Model.ReactiveUI.v11/Dock.Model.ReactiveUI.v11.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Dock.Model.ReactiveUI</AssemblyName>
+    <RootNamespace>Dock.Model.ReactiveUI</RootNamespace>
+    <PackageId>Dock.Model.ReactiveUI.v11</PackageId>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
+    <DefineConstants>$(DefineConstants);REACTIVEUI_23</DefineConstants>
+  </PropertyGroup>
+
+  <Import Project="..\..\build\SourceLink.props" />
+  <Import Project="..\..\build\ReferenceAssemblies.props" />
+
+  <ItemGroup>
+    <Compile Include="..\Dock.Model.ReactiveUI\**\*.cs"
+             Exclude="..\Dock.Model.ReactiveUI\bin\**;..\Dock.Model.ReactiveUI\obj\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <PackageReference Include="ReactiveUI" VersionOverride="$(ReactiveUI23Version)" />
+    <PackageReference Include="System.Reactive" VersionOverride="$(SystemReactive6Version)" />
+    <PackageReference Include="ReactiveUI.SourceGenerators"
+                      VersionOverride="$(ReactiveUISourceGenerators2Version)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <ProjectReference Include="..\Dock.Model\Dock.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Dock.Model.ReactiveUI/Core/DockBase.cs
+++ b/src/Dock.Model.ReactiveUI/Core/DockBase.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 using System.Collections.Generic;
 using System.Reactive;
-#if !DOCK_REACTIVEUI_REACTIVE
+#if !DOCK_REACTIVEUI_REACTIVE && !REACTIVEUI_23
 using Unit = ReactiveUI.Primitives.RxVoid;
 #endif
 using System.Runtime.Serialization;

--- a/src/Dock.Settings.v11/Dock.Settings.v11.csproj
+++ b/src/Dock.Settings.v11/Dock.Settings.v11.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DockSourceProjectName>Dock.Settings</DockSourceProjectName>
+    <DockSourceProjectDirectory>..\Dock.Settings</DockSourceProjectDirectory>
+  </PropertyGroup>
+  <Import Project="..\..\build\Dock.Avalonia.v11.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\Dock.Model\Dock.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Dock.Avalonia.HeadlessTests/DeferredContentControlTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DeferredContentControlTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Controls;
@@ -1190,7 +1192,7 @@ public class DeferredContentControlTests
     }
 
     [AvaloniaFact]
-    public void DeferredContentPresenter_AutoScheduled_Time_Budget_Materializes_In_ItemsControl()
+    public async Task DeferredContentPresenter_AutoScheduled_Time_Budget_Materializes_In_ItemsControl()
     {
         var firstTemplate = new CountingTemplate(() => new Border
         {
@@ -1203,7 +1205,7 @@ public class DeferredContentControlTests
         var slots = new[]
         {
             new PresenterSlot("First", firstTemplate, order: -5, delay: TimeSpan.Zero),
-            new PresenterSlot("Second", secondTemplate, order: 10, delay: TimeSpan.FromMilliseconds(300))
+            new PresenterSlot("Second", secondTemplate, order: 10, delay: TimeSpan.FromMinutes(1))
         };
         var timeline = new DeferredContentPresentationTimeline
         {
@@ -1267,18 +1269,21 @@ public class DeferredContentControlTests
 
             Assert.All(new[] { firstPresenter, secondPresenter }, presenter => Assert.Null(presenter.Child));
 
-            Thread.Sleep(40);
-            Dispatcher.UIThread.RunJobs();
-            window.UpdateLayout();
+            await PumpDispatcherUntilAsync(
+                window,
+                () => firstTemplate.BuildCount == 1,
+                TimeSpan.FromSeconds(2));
 
             Assert.Equal(1, firstTemplate.BuildCount);
             Assert.Equal(0, secondTemplate.BuildCount);
             Assert.NotNull(firstPresenter.Child);
             Assert.Null(secondPresenter.Child);
 
-            Thread.Sleep(320);
-            Dispatcher.UIThread.RunJobs();
-            window.UpdateLayout();
+            DeferredContentScheduling.SetDelay(secondHost, TimeSpan.Zero);
+            await PumpDispatcherUntilAsync(
+                window,
+                () => secondTemplate.BuildCount == 1,
+                TimeSpan.FromSeconds(2));
 
             Assert.Equal(1, secondTemplate.BuildCount);
             Assert.NotNull(secondPresenter.Child);
@@ -1876,6 +1881,29 @@ public class DeferredContentControlTests
         timeline.FlushPendingBatchForTesting();
         Dispatcher.UIThread.RunJobs();
         window.UpdateLayout();
+    }
+
+    private static async Task PumpDispatcherUntilAsync(Window window, Func<bool> condition, TimeSpan timeout)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        do
+        {
+            Dispatcher.UIThread.RunJobs();
+            window.UpdateLayout();
+
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+        while (stopwatch.Elapsed < timeout);
+
+        Dispatcher.UIThread.RunJobs();
+        window.UpdateLayout();
+        Assert.True(condition(), $"The expected dispatcher state was not reached within {timeout}.");
     }
 
     private sealed class DeferredBatchLimitScope : IDisposable

--- a/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
+++ b/tests/Dock.Avalonia.HeadlessTests/DelayedUniformTabPanelTests.cs
@@ -47,11 +47,10 @@ public class DelayedUniformTabPanelTests
         Layout(panel, 500, 32);
         AssertTabWidth(panel, 122d);
 
-        await Task.Delay(90);
-        Dispatcher.UIThread.RunJobs();
-
-        Layout(panel, 500, 32);
-        AssertTabWidth(panel, 164d);
+        var elapsedSinceClose = await WaitForTabWidthAsync(panel, 164d, 500d, TimeSpan.FromMilliseconds(800));
+        Assert.True(
+            elapsedSinceClose >= panel.ExpansionDelay - TimeSpan.FromMilliseconds(20),
+            $"Expansion happened too early. Elapsed={elapsedSinceClose.TotalMilliseconds:F0}ms Delay={panel.ExpansionDelay.TotalMilliseconds:F0}ms");
     }
 
     [AvaloniaFact]

--- a/tests/Dock.Avalonia.v11.HeadlessTests/Avalonia11CompatibilityTests.cs
+++ b/tests/Dock.Avalonia.v11.HeadlessTests/Avalonia11CompatibilityTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Chrome;
+using Avalonia.Headless.XUnit;
+using Avalonia.Styling;
+using Avalonia.Themes.Fluent;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Dock.Avalonia.Controls;
+using Dock.Avalonia.Diagnostics.Controls;
+using Dock.Avalonia.Themes.Browser;
+using Dock.Avalonia.Themes.Fluent;
+using Dock.Avalonia.Themes.Simple;
+using DockReactiveUISample.ViewModels;
+using DockReactiveUISample.Views;
+using Xunit;
+
+namespace Dock.Avalonia.v11.HeadlessTests;
+
+public sealed class Avalonia11CompatibilityTests
+{
+    [Fact]
+    public void ReferencesAvalonia11()
+    {
+        Assert.Equal(11, typeof(AvaloniaObject).Assembly.GetName().Version?.Major);
+    }
+
+    [AvaloniaFact]
+    public void V11ThemeResourcesLoad()
+    {
+        Assert.NotNull(new DockFluentTheme());
+        Assert.NotNull(new DockSimpleTheme());
+        Assert.NotNull(new BrowserTabTheme());
+        Assert.NotNull(new DockDebugView());
+    }
+
+    [AvaloniaFact]
+    public void HostWindowUsesAvalonia11TitleBarContract()
+    {
+        Application app = Application.Current ?? throw new InvalidOperationException("Application is not initialized.");
+        IStyle[] originalStyles = app.Styles.ToArray();
+        var window = new HostWindow();
+
+        try
+        {
+            app.Styles.Clear();
+            app.Styles.Add(new FluentTheme());
+            app.Styles.Add(new DockFluentTheme());
+
+            window.Show();
+            window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            HostWindowTitleBar? titleBar = window.GetVisualDescendants().OfType<HostWindowTitleBar>().FirstOrDefault();
+            Assert.NotNull(titleBar);
+            Assert.IsAssignableFrom<TitleBar>(titleBar);
+            Assert.Equal(SystemDecorations.Full, window.SystemDecorations);
+        }
+        finally
+        {
+            window.Close();
+            app.Styles.Clear();
+            foreach (IStyle style in originalStyles)
+            {
+                app.Styles.Add(style);
+            }
+        }
+    }
+
+    [AvaloniaFact]
+    public void ReactiveUISampleUsesAvalonia11XamlContract()
+    {
+        var viewModel = new MainWindowViewModel();
+
+        try
+        {
+            var view = new MainView
+            {
+                DataContext = viewModel
+            };
+
+            TextBox? id = view.FindControl<TextBox>("Id");
+            Assert.NotNull(id);
+            Assert.Equal("Dashboard", id.Watermark);
+            Assert.NotNull(viewModel.Layout);
+        }
+        finally
+        {
+            viewModel.CloseLayout();
+        }
+    }
+}

--- a/tests/Dock.Avalonia.v11.HeadlessTests/Dock.Avalonia.v11.HeadlessTests.csproj
+++ b/tests/Dock.Avalonia.v11.HeadlessTests/Dock.Avalonia.v11.HeadlessTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <IsPackable>False</IsPackable>
+    <IsTestProject>True</IsTestProject>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.XUnit" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="Avalonia.Themes.Fluent" VersionOverride="$(Avalonia11Version)" />
+    <PackageReference Include="xunit" VersionOverride="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\DockReactiveUISample.v11\DockReactiveUISample.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.v11\Dock.Avalonia.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Diagnostics.v11\Dock.Avalonia.Diagnostics.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Browser.v11\Dock.Avalonia.Themes.Browser.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Fluent.v11\Dock.Avalonia.Themes.Fluent.v11.csproj" />
+    <ProjectReference Include="..\..\src\Dock.Avalonia.Themes.Simple.v11\Dock.Avalonia.Themes.Simple.v11.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Dock.Avalonia.v11.HeadlessTests/TestAppBuilder.cs
+++ b/tests/Dock.Avalonia.v11.HeadlessTests/TestAppBuilder.cs
@@ -1,0 +1,19 @@
+using Avalonia;
+using Avalonia.Headless;
+using ReactiveUI.Avalonia;
+
+[assembly: AvaloniaTestApplication(typeof(Dock.Avalonia.v11.HeadlessTests.TestAppBuilder))]
+
+namespace Dock.Avalonia.v11.HeadlessTests;
+
+public sealed class TestApplication : Application
+{
+}
+
+public static class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<TestApplication>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions())
+            .UseReactiveUI(static _ => { });
+}


### PR DESCRIPTION
## Summary

- add source-linked `.v11` projects and packages for `Dock.Avalonia`, diagnostics, and all themes
- source-link the Avalonia-dependent package closure so the NuGet graph remains entirely on Avalonia 11.3.20
- preserve original assembly identities while publishing `.v11` package IDs
- isolate Avalonia 11 window chrome, title bar, visual-root, and XAML differences behind compatibility sources and conditionals
- add a source-linked `DockReactiveUISample.v11` using the compatible ReactiveUI 23 stack
- add Avalonia Headless coverage for runtime version, resources, window chrome, and the sample
- document the Avalonia 11 package lane

## Migration analysis

The compatibility surface was derived from the Avalonia 12 migrations in #1083 and #1124. The v11 lane restores the pre-v12 window decoration and title bar contracts while sharing the remaining current sources. `ReactiveUI.Avalonia` 11.4.13 is paired with ReactiveUI 23.2.28 because it is not binary-compatible with ReactiveUI 24.

## Validation

- `dotnet build Dock.slnx -c Release --no-restore` — 0 errors
- `dotnet test Dock.slnx -c Release --no-build --no-restore` — 1,684 passed, 0 failed
- current v12 and new v11 ReactiveUI samples build successfully
- `dotnet pack Dock.slnx -c Release --no-build --no-restore` succeeds
- generated package dependency audit contains Avalonia 11.3.20 and `.v11` Dock dependencies only
- temporary NuGet consumer restores the generated v11 package graph successfully
- `git diff --check` passes